### PR TITLE
Add environment to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ env:
 
 jobs:
   deploy:
+    environment: production
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-${{ github.ref_name }}


### PR DESCRIPTION
- Added the environment field to the release workflow and set it to production.
- This value will then be checked as part of our AWS trust policy when performing updates

Part of the work towards:
- #600 