### PR TITLE
Fix PROJECT_ROOT resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,6 @@ GITHUB_CLIENT_ID='' # Github OAuth App Client ID
 GITHUB_CLIENT_SECRET=''# Github OAuth App Client Secret
 SUPER_ADMIN_GITHUB_ID='' # Github ID to configure for super admin rights on application setup
 AUTH_CALLBACK_URL='http://localhost:5173/auth/callback'
+PROJECT_ROOT='' # Path to the project root directory, e.g. /home/user/pipeline
 # REDIS_LOCAL='true' # Use local Redis (localhost:6379) running with `yarn redis`. Overrides REDIS_URL
 # REDIS_URL='' # External Redis URL

--- a/app/helpers/projectRoot.ts
+++ b/app/helpers/projectRoot.ts
@@ -1,5 +1,25 @@
+import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
 
-const modulePath = path.dirname(fileURLToPath(import.meta.url));
-export const PROJECT_ROOT = path.resolve(modulePath, '../../..');
+function findRepoRoot(startDir: string, marker: string): string | null {
+  let dir = startDir;
+  while (true) {
+    if (fs.existsSync(path.join(dir, marker))) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return null;
+}
+
+export const PROJECT_ROOT: string = (() => {
+  if (process.env.PROJECT_ROOT) {
+    return path.resolve(process.env.PROJECT_ROOT);
+  }
+  const repoRoot = findRepoRoot(process.cwd(), 'yarn.lock');
+  const resolved = repoRoot || process.cwd();
+  console.warn('PROJECT_ROOT env var not set, using:', resolved);
+  return resolved;
+})();


### PR DESCRIPTION
There was a bug in the way the project root was resolved, causing issues for localmode in production. We now require a new env var PROJECT_ROOT with a fallback to the location of the yarn.lock file