### PR TITLE
Simplified toogle group border logic

### DIFF
--- a/app/modules/queues/components/queueStateTabs.tsx
+++ b/app/modules/queues/components/queueStateTabs.tsx
@@ -1,5 +1,6 @@
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { ToggleGroup } from "@/components/ui/toggle-group";
 import { useLocation, useNavigate } from "react-router";
+import { QueueTab } from "./queueTab";
 
 interface QueueState {
   key: string;
@@ -7,19 +8,19 @@ interface QueueState {
   count: number;
 }
 
+
 interface QueueStateTabsProps {
   queueType: string;
   states: QueueState[];
-  currentState?: string;
 }
 
-export default function QueueStateTabs({ queueType, states, currentState }: QueueStateTabsProps) {
+
+export default function QueueStateTabs({ queueType, states }: QueueStateTabsProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const currentPath = location.pathname;
 
-  // Determine current value from either prop or URL
-  const currentValue = currentState || states.find(state =>
+  const currentValue = states.find(state =>
     currentPath.includes(`/${state.key}`)
   )?.key || states[0]?.key;
 
@@ -33,33 +34,20 @@ export default function QueueStateTabs({ queueType, states, currentState }: Queu
     <div>
       <ToggleGroup
         type="single"
+        variant="outline"
         value={currentValue}
         onValueChange={handleValueChange}
-        className="justify-start"
         aria-label="Queue state filter"
       >
-        {states.map((state, index) => {
-          const isFirst = index === 0;
-          const isLast = index === states.length - 1;
-          const borderRadius = isFirst ? 'rounded-l-lg' : isLast ? 'rounded-r-lg' : '';
-          const borderRight = isLast ? 'border-r' : 'border-r-0';
-          const hoverBorderRight = !isLast ? 'hover:border-r' : '';
-          const selectedBorderRight = !isLast ? 'data-[state=on]:border-r' : '';
-
-          return (
-            <ToggleGroupItem
-              key={state.key}
-              value={state.key}
-              className={`flex items-center justify-between min-w-[120px] px-4 py-3 h-auto border border-border ${borderRadius} ${borderRight} ${hoverBorderRight} ${selectedBorderRight} transition-all cursor-pointer hover:shadow-sm hover:border-accent-foreground/50 data-[state=on]:bg-accent/10 data-[state=on]:border-accent-foreground`}
-              aria-label={`${state.label} jobs (${state.count} items)`}
-            >
-              <span className="font-medium">{state.label}</span>
-              <span className="px-2 py-1 rounded-full text-xs font-bold bg-muted text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground" aria-hidden="true">
-                {state.count}
-              </span>
-            </ToggleGroupItem>
-          );
-        })}
+        {states.map((state, idx) => (
+          <QueueTab
+            key={state.key}
+            value={state.key}
+            label={state.label}
+            count={state.count}
+            ariaLabel={`${state.label} jobs (${state.count} items)`}
+          />
+        ))}
       </ToggleGroup>
     </div>
   );

--- a/app/modules/queues/components/queueTab.tsx
+++ b/app/modules/queues/components/queueTab.tsx
@@ -1,0 +1,24 @@
+import { ToggleGroupItem } from "@/components/ui/toggle-group";
+
+interface QueueTabProps {
+  value: string;
+  label: string;
+  count: number;
+  ariaLabel: string;
+}
+
+export function QueueTab({ value, label, count, ariaLabel }: QueueTabProps) {
+  return (
+    <ToggleGroupItem
+      value={value}
+      variant="outline"
+      aria-label={ariaLabel}
+      className="data-[state=on]:bg-accent/50 hover:bg-accent/50"
+    >
+      <span className="font-medium">{label}</span>
+      <span className="px-2 py-1 rounded-full text-xs bg-muted" aria-hidden="true">
+        {count}
+      </span>
+    </ToggleGroupItem>
+  );
+}

--- a/app/modules/queues/components/queueTypeTabs.tsx
+++ b/app/modules/queues/components/queueTypeTabs.tsx
@@ -1,5 +1,6 @@
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { ToggleGroup } from "@/components/ui/toggle-group";
 import { useLocation, useNavigate } from "react-router";
+import { QueueTab } from "./queueTab";
 
 interface QueueTypeTabsProps {
   taskCount: number;
@@ -10,6 +11,11 @@ export default function QueueTypeTabs({ taskCount, cronCount }: QueueTypeTabsPro
   const location = useLocation();
   const navigate = useNavigate();
   const currentPath = location.pathname;
+
+  const types = [
+    { key: "tasks", label: "Tasks", count: taskCount },
+    { key: "cron", label: "Cron", count: cronCount }
+  ];
 
   const currentValue = currentPath.includes('/tasks') ? 'tasks' : 'cron';
 
@@ -23,31 +29,20 @@ export default function QueueTypeTabs({ taskCount, cronCount }: QueueTypeTabsPro
     <div className="mb-6">
       <ToggleGroup
         type="single"
+        variant="outline"
         value={currentValue}
         onValueChange={handleValueChange}
-        className="justify-start"
         aria-label="Queue type selection"
       >
-        <ToggleGroupItem
-          value="tasks"
-          className="flex items-center justify-between min-w-[160px] px-4 py-3 h-auto border border-border rounded-l-lg border-r-0 transition-all cursor-pointer hover:shadow-sm hover:border-accent-foreground/50 hover:border-r data-[state=on]:bg-accent/10 data-[state=on]:border-accent-foreground data-[state=on]:border-r"
-          aria-label={`Tasks queue (${taskCount} jobs)`}
-        >
-          <span className="font-medium">Tasks</span>
-          <span className="px-2 py-1 rounded-full text-xs font-bold bg-muted text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground" aria-hidden="true">
-            {taskCount}
-          </span>
-        </ToggleGroupItem>
-        <ToggleGroupItem
-          value="cron"
-          className="flex items-center justify-between min-w-[160px] px-4 py-3 h-auto border border-border rounded-r-lg transition-all cursor-pointer hover:shadow-sm hover:border-accent-foreground/50 data-[state=on]:bg-accent/10 data-[state=on]:border-accent-foreground"
-          aria-label={`Cron queue (${cronCount} jobs)`}
-        >
-          <span className="font-medium">Cron</span>
-          <span className="px-2 py-1 rounded-full text-xs font-bold bg-muted text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground" aria-hidden="true">
-            {cronCount}
-          </span>
-        </ToggleGroupItem>
+        {types.map((type, idx) => (
+          <QueueTab
+            key={type.key}
+            value={type.key}
+            label={type.label}
+            count={type.count}
+            ariaLabel={`${type.label} queue (${type.count} jobs)`}
+          />
+        ))}
       </ToggleGroup>
     </div>
   );


### PR DESCRIPTION
We can't use border around items to avoid double border issues Use toggle group variant outline
Extracted QueueTab component

Fixes #861