### PR TITLE
Fix issue showing start and finish dates for runs

### DIFF
--- a/app/modules/projects/components/projectRun.tsx
+++ b/app/modules/projects/components/projectRun.tsx
@@ -138,8 +138,8 @@ export default function ProjectRun({
                               session.name
                             )}
                         </TableCell>
-                        <TableCell>{dayjs(session.startedAt).format('ddd, MMM D, YYYY - h:mm A')}</TableCell>
-                        <TableCell>{dayjs(session.finishedAt).format('ddd, MMM D, YYYY - h:mm A')}</TableCell>
+                        <TableCell>{session.status !== 'NOT_STARTED' ? dayjs(session.startedAt).format('ddd, MMM D, YYYY - h:mm A') : '--'}</TableCell>
+                        <TableCell>{session.finishedAt ? dayjs(session.finishedAt).format('ddd, MMM D, YYYY - h:mm A') : '--'}</TableCell>
                         <TableCell>{session.fileType}</TableCell>
                         <TableCell>{session.status}</TableCell>
                       </TableRow>


### PR DESCRIPTION
When finishedAt is undefined dayjs would use the current Date

Additionally if the status is NOT_STARTED we shouldn't show the start date

Fixes #969