### PR TITLE
Implement authorization for teams

### DIFF
--- a/app/modules/authorization/helpers/superAdmin.ts
+++ b/app/modules/authorization/helpers/superAdmin.ts
@@ -1,0 +1,8 @@
+import type { User } from '~/modules/users/users.types';
+
+export function userIsSuperAdmin(user: User | null): boolean {
+  if (!user) {
+    return false;
+  }
+  return user.role === 'SUPER_ADMIN';
+}

--- a/app/modules/authorization/helpers/teamMembership.ts
+++ b/app/modules/authorization/helpers/teamMembership.ts
@@ -1,0 +1,15 @@
+import type { User } from '~/modules/users/users.types';
+
+export function userIsTeamMember(user: User | null, teamId: string): boolean {
+  if (!user) {
+    return false;
+  }
+  return user.teams.some(t => t.team === teamId);
+}
+
+export function userIsTeamAdmin(user: User | null, teamId: string): boolean {
+  if (!user) {
+    return false;
+  }
+  return user.teams.some(t => t.team === teamId && t.role === 'ADMIN');
+}

--- a/app/modules/teams/__tests__/authorization.test.ts
+++ b/app/modules/teams/__tests__/authorization.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '../../users/users.types';
+import TeamAuthorization from '../authorization';
+
+describe('TeamAuthorization', () => {
+  const superAdminUser = {
+    _id: 'super-admin-1',
+    username: 'super_admin',
+    role: 'SUPER_ADMIN',
+    teams: ([] as any)
+  } as User;
+
+  const teamAdminUser = {
+    _id: 'team-admin-1',
+    username: 'team_admin',
+    role: 'USER',
+    teams: [{ team: 'team-1', role: 'ADMIN' }]
+  } as User;
+
+  const teamMemberUser = {
+    _id: 'team-member-1',
+    username: 'team_member',
+    role: 'USER',
+    teams: [{ team: 'team-1', role: 'MEMBER' }],
+  } as User;
+
+  const nonTeamUser = {
+    _id: 'non-team-1',
+    username: 'non_team',
+    role: 'USER',
+    teams: ([] as any)
+  } as User;
+
+  describe('canCreate', () => {
+    it('allows super admins to create teams', () => {
+      expect(TeamAuthorization.canCreate(superAdminUser)).toBe(true);
+    });
+
+    it('denies regular users from creating teams', () => {
+      expect(TeamAuthorization.canCreate(teamAdminUser)).toBe(false);
+      expect(TeamAuthorization.canCreate(teamMemberUser)).toBe(false);
+      expect(TeamAuthorization.canCreate(nonTeamUser)).toBe(false);
+    });
+
+    it('denies null users from creating teams', () => {
+      expect(TeamAuthorization.canCreate(null)).toBe(false);
+    });
+  });
+
+  describe('canView', () => {
+    it('allows super admins to view any team', () => {
+      expect(TeamAuthorization.canView(superAdminUser, 'team-1')).toBe(true);
+      expect(TeamAuthorization.canView(superAdminUser, 'team-999')).toBe(true);
+    });
+
+    it('allows team members to view their team', () => {
+      expect(TeamAuthorization.canView(teamAdminUser, 'team-1')).toBe(true);
+      expect(TeamAuthorization.canView(teamMemberUser, 'team-1')).toBe(true);
+    });
+
+    it('denies non-members from viewing a team', () => {
+      expect(TeamAuthorization.canView(nonTeamUser, 'team-1')).toBe(false);
+      expect(TeamAuthorization.canView(teamAdminUser, 'team-999')).toBe(false);
+    });
+
+    it('denies null users from viewing teams', () => {
+      expect(TeamAuthorization.canView(null, 'team-1')).toBe(false);
+    });
+  });
+
+  describe('canUpdate', () => {
+    it('allows team admins to update their team', () => {
+      expect(TeamAuthorization.canUpdate(teamAdminUser, 'team-1')).toBe(true);
+    });
+
+    it('denies super admins to update any team', () => {
+      expect(TeamAuthorization.canUpdate(superAdminUser, 'team-1')).toBe(false);
+      expect(TeamAuthorization.canUpdate(superAdminUser, 'team-999')).toBe(false);
+    });
+
+    it('denies team members from updating team', () => {
+      expect(TeamAuthorization.canUpdate(teamMemberUser, 'team-1')).toBe(false);
+    });
+
+    it('denies non-members from updating a team', () => {
+      expect(TeamAuthorization.canUpdate(nonTeamUser, 'team-1')).toBe(false);
+      expect(TeamAuthorization.canUpdate(teamAdminUser, 'team-999')).toBe(false);
+    });
+
+    it('denies null users from updating teams', () => {
+      expect(TeamAuthorization.canUpdate(null, 'team-1')).toBe(false);
+    });
+  });
+
+  describe('canDelete', () => {
+    it('allows team admins to delete their team', () => {
+      expect(TeamAuthorization.canDelete(teamAdminUser, 'team-1')).toBe(true);
+    });
+
+    it('denies super admins to delete any team', () => {
+      expect(TeamAuthorization.canDelete(superAdminUser, 'team-1')).toBe(false);
+      expect(TeamAuthorization.canDelete(superAdminUser, 'team-999')).toBe(false);
+    });
+
+    it('denies team admins from deleting other teams', () => {
+      expect(TeamAuthorization.canDelete(teamAdminUser, 'team-999')).toBe(false);
+    });
+
+    it('denies team members from deleting teams', () => {
+      expect(TeamAuthorization.canDelete(teamMemberUser, 'team-1')).toBe(false);
+    });
+
+    it('denies non-members from deleting teams', () => {
+      expect(TeamAuthorization.canDelete(nonTeamUser, 'team-1')).toBe(false);
+    });
+
+    it('denies null users from deleting teams', () => {
+      expect(TeamAuthorization.canDelete(null, 'team-1')).toBe(false);
+    });
+  });
+
+  describe('cross-team scenarios', () => {
+    it('handles users with multiple team memberships correctly', () => {
+      const multiTeamUser: User = {
+        ...teamAdminUser,
+        teams: [
+          { team: 'team-1', role: 'ADMIN' },
+          { team: 'team-2', role: 'MEMBER' },
+        ],
+      };
+
+      // Can admin team-1
+      expect(TeamAuthorization.canUpdate(multiTeamUser, 'team-1')).toBe(true);
+      // Can only view team-2 (not admin)
+      expect(TeamAuthorization.canView(multiTeamUser, 'team-2')).toBe(true);
+      expect(TeamAuthorization.canUpdate(multiTeamUser, 'team-2')).toBe(false);
+      // Cannot access team-3
+      expect(TeamAuthorization.canView(multiTeamUser, 'team-3')).toBe(false);
+    });
+  });
+
+  describe('Users', () => {
+    describe('canView', () => {
+      it('allows super admins to view team users', () => {
+        expect(TeamAuthorization.Users.canView(superAdminUser, 'team-1')).toBe(true);
+      });
+
+      it('allows team admins to view team users', () => {
+        expect(TeamAuthorization.Users.canView(teamAdminUser, 'team-1')).toBe(true);
+      });
+
+      it('denies team members from viewing team users', () => {
+        expect(TeamAuthorization.Users.canView(teamMemberUser, 'team-1')).toBe(false);
+      });
+
+      it('denies non-members from viewing team users', () => {
+        expect(TeamAuthorization.Users.canView(nonTeamUser, 'team-1')).toBe(false);
+      });
+
+      it('denies null users from viewing team users', () => {
+        expect(TeamAuthorization.Users.canView(null, 'team-1')).toBe(false);
+      });
+    });
+
+    describe('canUpdate', () => {
+      it('allows team admins to update team users', () => {
+        expect(TeamAuthorization.Users.canUpdate(teamAdminUser, 'team-1')).toBe(true);
+      });
+
+      it('denies super admins from updating team users', () => {
+        expect(TeamAuthorization.Users.canUpdate(superAdminUser, 'team-1')).toBe(false);
+      });
+
+      it('denies team members from updating team users', () => {
+        expect(TeamAuthorization.Users.canUpdate(teamMemberUser, 'team-1')).toBe(false);
+      });
+
+      it('denies non-members from updating team users', () => {
+        expect(TeamAuthorization.Users.canUpdate(nonTeamUser, 'team-1')).toBe(false);
+      });
+
+      it('denies null users from updating team users', () => {
+        expect(TeamAuthorization.Users.canUpdate(null, 'team-1')).toBe(false);
+      });
+    });
+
+    describe('canInvite', () => {
+      it('allows team admins to invite users to their team', () => {
+        expect(TeamAuthorization.Users.canInvite(teamAdminUser, 'team-1')).toBe(true);
+      });
+
+      it('denies super admins from inviting users to teams', () => {
+        expect(TeamAuthorization.Users.canInvite(superAdminUser, 'team-1')).toBe(false);
+      });
+
+      it('denies team members from inviting users', () => {
+        expect(TeamAuthorization.Users.canInvite(teamMemberUser, 'team-1')).toBe(false);
+      });
+
+      it('denies non-members from inviting users', () => {
+        expect(TeamAuthorization.Users.canInvite(nonTeamUser, 'team-1')).toBe(false);
+      });
+
+      it('denies null users from inviting users', () => {
+        expect(TeamAuthorization.Users.canInvite(null, 'team-1')).toBe(false);
+      });
+    });
+
+    describe('canRequestAccessToTeam', () => {
+      it('allows super admins not in the team to request access', () => {
+        expect(TeamAuthorization.Users.canRequestAccess(superAdminUser, 'team-999')).toBe(true);
+      });
+
+      it('denies super admins already in the team from requesting access', () => {
+        const superAdminInTeam: User = {
+          ...superAdminUser,
+          teams: [{ team: 'team-1', role: 'ADMIN' }]
+        };
+        expect(TeamAuthorization.Users.canRequestAccess(superAdminInTeam, 'team-1')).toBe(false);
+      });
+
+      it('denies team admins from requesting access', () => {
+        expect(TeamAuthorization.Users.canRequestAccess(teamAdminUser, 'team-1')).toBe(false);
+      });
+
+      it('denies team members from requesting access', () => {
+        expect(TeamAuthorization.Users.canRequestAccess(teamMemberUser, 'team-1')).toBe(false);
+      });
+
+      it('denies non members users from requesting access', () => {
+        expect(TeamAuthorization.Users.canRequestAccess(nonTeamUser, 'team-1')).toBe(false);
+      });
+
+      it('denies null users from requesting access', () => {
+        expect(TeamAuthorization.Users.canRequestAccess(null, 'team-1')).toBe(false);
+      });
+    });
+  });
+});

--- a/app/modules/teams/authorization.ts
+++ b/app/modules/teams/authorization.ts
@@ -1,0 +1,52 @@
+import type { User } from '~/modules/users/users.types';
+import { userIsSuperAdmin } from '../authorization/helpers/superAdmin';
+import { userIsTeamAdmin, userIsTeamMember } from '../authorization/helpers/teamMembership';
+
+const TeamAuthorization = {
+  canCreate(user: User | null): boolean {
+    return userIsSuperAdmin(user);
+  },
+
+  canView(user: User | null, teamId: string): boolean {
+    return userIsSuperAdmin(user) || userIsTeamMember(user, teamId);
+  },
+
+  canUpdate(user: User | null, teamId: string): boolean {
+    return userIsTeamAdmin(user, teamId);
+  },
+
+  canDelete(user: User | null, teamId: string): boolean {
+    return userIsTeamAdmin(user, teamId);
+  },
+
+  Users: {
+    canView(user: User | null, teamId: string): boolean {
+      return userIsSuperAdmin(user) || userIsTeamAdmin(user, teamId);
+    },
+
+    canUpdate(user: User | null, teamId: string): boolean {
+      return userIsTeamAdmin(user, teamId);
+    },
+
+    canInvite(user: User | null, teamId: string): boolean {
+      return userIsTeamAdmin(user, teamId);
+    },
+
+    canRequestAccess(user: User | null, teamId: string): boolean {
+      return userIsSuperAdmin(user) && !userIsTeamMember(user, teamId);
+    },
+  },
+};
+
+type UsersAuthorizationShape = {
+  [K in keyof typeof TeamAuthorization.Users]: boolean;
+};
+
+type TeamAuthorizationShape = {
+  [K in Exclude<keyof typeof TeamAuthorization, 'Users'>]: boolean;
+} & {
+  users: UsersAuthorizationShape;
+};
+
+export default TeamAuthorization;
+export type { TeamAuthorizationShape, UsersAuthorizationShape };

--- a/app/modules/teams/components/team.tsx
+++ b/app/modules/teams/components/team.tsx
@@ -1,8 +1,9 @@
+import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Pencil } from "lucide-react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import type { Team } from "../teams.types";
-import { Button } from "@/components/ui/button";
-import { Pencil } from "lucide-react";
+import useTeamAuthorization from "../hooks/useTeamAuthorization";
 
 
 interface TeamProps {
@@ -16,6 +17,7 @@ export default function Team({
 }: TeamProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const { canUpdate } = useTeamAuthorization(team._id);
 
   const parts = location.pathname.split('/').filter(Boolean);
   // Expect path like /teams/:id(/projects|prompts|users)
@@ -32,10 +34,12 @@ export default function Team({
         <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight text-balance">
           {team.name}
         </h1>
-        <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={() => onEditTeamButtonClicked(team)}>
-          <Pencil />
-          Edit
-        </Button>
+        {canUpdate && (
+          <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={() => onEditTeamButtonClicked(team)}>
+            <Pencil />
+            Edit
+          </Button>
+        )}
       </div>
       <Tabs value={active} onValueChange={handleTabChange} className="mb-2">
         <TabsList>

--- a/app/modules/teams/components/teamUsers.tsx
+++ b/app/modules/teams/components/teamUsers.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import type { User } from "~/modules/users/users.types";
 import getUserRoleInTeam from "../helpers/getUserRoleInTeam";
+import useTeamAuthorization from "../hooks/useTeamAuthorization";
 import type { Team } from "../teams.types";
 
 interface TeamUsersProps {
@@ -16,24 +17,27 @@ interface TeamUsersProps {
 }
 
 export default function TeamUsers({ users, team, isSuperAdminUser, isTeamMemberUser, onAddUserToTeamButtonClicked, onAddSuperAdminToTeamButtonClicked, onInviteUserToTeamButtonClicked, onRemoveUserFromTeamClicked }: TeamUsersProps) {
+  const { users: usersAuthorization } = useTeamAuthorization(team._id);
   return (
     <div>
       <div className="flex items-center justify-between">
         <div className="text-sm font-medium text-muted-foreground">Users</div>
         <div>
-          {isSuperAdminUser && !isTeamMemberUser && (
+          {usersAuthorization.canRequestAccess && (
             <Button variant="secondary" onClick={onAddSuperAdminToTeamButtonClicked} className="mr-2">
               Request Access to Team
             </Button>
           )}
-          {isSuperAdminUser && (
+          {usersAuthorization.canUpdate && (
             <Button variant="secondary" onClick={onAddUserToTeamButtonClicked} className="mr-2">
               Add existing user
             </Button>
           )}
-          <Button onClick={onInviteUserToTeamButtonClicked}>
-            Invite new user
-          </Button>
+          {usersAuthorization.canInvite && (
+            <Button onClick={onInviteUserToTeamButtonClicked}>
+              Invite new user
+            </Button>
+          )}
         </div>
       </div>
       <div>

--- a/app/modules/teams/components/teams.tsx
+++ b/app/modules/teams/components/teams.tsx
@@ -1,4 +1,5 @@
-import { Button } from "@/components/ui/button"
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -6,15 +7,14 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table"
+} from "@/components/ui/table";
+import dayjs from 'dayjs';
 import map from 'lodash/map';
-import { Link } from "react-router";
-
-import type { Team } from "../teams.types";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { EllipsisVertical } from "lucide-react";
-import dayjs from 'dayjs'
+import { Link } from "react-router";
 import type { User } from "~/modules/users/users.types";
+import type { Team } from "../teams.types";
+import useTeamAuthorization from "../hooks/useTeamAuthorization";
 
 interface TeamsProps {
   teams: Team[];
@@ -31,6 +31,8 @@ export default function Teams({
   onEditTeamButtonClicked,
   onDeleteTeamButtonClicked
 }: TeamsProps) {
+  const { canCreate } = useTeamAuthorization();
+
   return (
     <div className="max-w-6xl p-8">
       <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight text-balance mb-8">
@@ -40,7 +42,7 @@ export default function Teams({
         <div className="mt-4 mb-4 p-8 border border-black/10 rounded-md text-center">
           No teams created
           <div className="mt-3">
-            {(authentication?.role === 'SUPER_ADMIN') && (
+            {canCreate && (
               <Button onClick={onCreateTeamButtonClicked}>Create team</Button>
             )}
           </div>
@@ -49,7 +51,7 @@ export default function Teams({
       {(teams.length > 0) && (
         <div className="border rounded-md">
           <div className="flex justify-end border-b p-2">
-            {(authentication?.role === 'SUPER_ADMIN') && (
+            {canCreate && (
               <Button onClick={onCreateTeamButtonClicked}>Create team</Button>
             )}
           </div>
@@ -63,6 +65,7 @@ export default function Teams({
             </TableHeader>
             <TableBody>
               {map(teams, (team) => {
+                const { canUpdate, canDelete } = useTeamAuthorization(team._id);
                 return (
                   <TableRow key={team._id}>
                     <TableCell className="font-medium">
@@ -72,29 +75,37 @@ export default function Teams({
                     </TableCell>
                     <TableCell>{dayjs(team.createdAt).format('ddd, MMM D, YYYY - h:mm A')}</TableCell>
                     <TableCell className="text-right flex justify-end">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
-                            size="icon"
-                          >
-                            <EllipsisVertical />
-                            <span className="sr-only">Open menu</span>
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-32">
-                          <DropdownMenuItem onClick={() => onEditTeamButtonClicked(team)}>
-                            Edit
-                          </DropdownMenuItem>
-                          {/* <DropdownMenuItem>Make a copy</DropdownMenuItem>
-                          <DropdownMenuItem>Favorite</DropdownMenuItem> */}
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem variant="destructive" onClick={() => onDeleteTeamButtonClicked(team)}>
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                      {(canUpdate || canDelete) && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
+                              size="icon"
+                            >
+                              <EllipsisVertical />
+                              <span className="sr-only">Open menu</span>
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-32">
+                            {canUpdate && (
+                              <DropdownMenuItem onClick={() => onEditTeamButtonClicked(team)}>
+                                Edit
+                              </DropdownMenuItem>
+                            )}
+                            {/* <DropdownMenuItem>Make a copy</DropdownMenuItem>
+                            <DropdownMenuItem>Favorite</DropdownMenuItem> */}
+                            {canDelete && (
+                              <>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem variant="destructive" onClick={() => onDeleteTeamButtonClicked(team)}>
+                                  Delete
+                                </DropdownMenuItem>
+                              </>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
                     </TableCell>
                   </TableRow>
                 );

--- a/app/modules/teams/containers/generateInviteToTeam.route.tsx
+++ b/app/modules/teams/containers/generateInviteToTeam.route.tsx
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getDocumentsAdapter from "~/modules/documents/helpers/getDocumentsAdapter";
 import type { User } from "~/modules/users/users.types";
-import { validateTeamAdmin } from "../helpers/teamAdmin";
+import TeamAuthorization from "../authorization";
 import type { Route } from "./+types/generateInviteToTeam.route";
 
 export async function action({
@@ -22,7 +22,9 @@ export async function action({
       return {};
     }
 
-    await validateTeamAdmin({ user, teamId: payload.teamId });
+    if (!TeamAuthorization.Users.canInvite(user, payload.teamId)) {
+      throw new Error('You do not have permission to invite users to this team.');
+    }
 
     const documents = getDocumentsAdapter();
 

--- a/app/modules/teams/containers/team.route.tsx
+++ b/app/modules/teams/containers/team.route.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from "react";
 import { redirect, useFetcher } from "react-router";
+import { toast } from "sonner";
 import updateBreadcrumb from "~/modules/app/updateBreadcrumb";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import addDialog from "~/modules/dialogs/addDialog";
 import getDocumentsAdapter from "~/modules/documents/helpers/getDocumentsAdapter";
 import type { User } from "~/modules/users/users.types";
+import TeamAuthorization from "../authorization";
+import EditTeamDialog from "../components/editTeamDialog";
 import Team from '../components/team';
-import { isTeamAdmin } from "../helpers/teamAdmin";
 import type { Team as TeamType } from "../teams.types";
 import type { Route } from "./+types/team.route";
-import EditTeamDialog from "../components/editTeamDialog";
-import addDialog from "~/modules/dialogs/addDialog";
-import { toast } from "sonner";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const documents = getDocumentsAdapter();
@@ -21,7 +21,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     return redirect('/');
   }
 
-  if (!(await isTeamAdmin({ user: userSession, teamId: params.id }))) {
+  if (!TeamAuthorization.canView(userSession, params.id)) {
     return redirect('/');
   }
 

--- a/app/modules/teams/hooks/useTeamAuthorization.ts
+++ b/app/modules/teams/hooks/useTeamAuthorization.ts
@@ -1,0 +1,37 @@
+import { useContext } from 'react';
+import { AuthenticationContext } from '~/modules/authentication/containers/authentication.container';
+import type { User } from '~/modules/users/users.types';
+import TeamAuthorization, { type TeamAuthorizationShape } from '../authorization';
+
+export default function useTeamAuthorization(teamId: string | null = null): TeamAuthorizationShape {
+  const user = useContext(AuthenticationContext) as User | null;
+
+  const defaults: TeamAuthorizationShape = {
+    canCreate: false,
+    canView: false,
+    canUpdate: false,
+    canDelete: false,
+    users: {
+      canView: false,
+      canUpdate: false,
+      canInvite: false,
+      canRequestAccess: false,
+    },
+  };
+
+  if (!user || !teamId) return defaults;
+
+  return {
+    ...defaults,
+    canCreate: TeamAuthorization.canCreate(user),
+    canView: TeamAuthorization.canView(user, teamId),
+    canUpdate: TeamAuthorization.canUpdate(user, teamId),
+    canDelete: TeamAuthorization.canDelete(user, teamId),
+    users: {
+      canView: TeamAuthorization.Users.canView(user, teamId),
+      canUpdate: TeamAuthorization.Users.canUpdate(user, teamId),
+      canInvite: TeamAuthorization.Users.canInvite(user, teamId),
+      canRequestAccess: TeamAuthorization.Users.canRequestAccess(user, teamId),
+    },
+  };
+}


### PR DESCRIPTION
This showcases the pattern to implement authorization for the app.
We have an authorization object which becomes the source of truth for actions, which allows use to test it and make changes safely without modifying other parts of the app.
We have a hook/helper to use on our react components for showing/hiding UI elements.

Before this proposal I did research other libraries like Pundit and others but I feel those add extra overhead which we don't really need.
