### PR TITLE
refactor: apply service layer and fetcher pattern to featureFlags

### DIFF
--- a/app/modules/documents/documents.ts
+++ b/app/modules/documents/documents.ts
@@ -35,9 +35,6 @@ const registerModels = () => {
   if (!mongoose.models.Collection) {
     mongoose.model('Collection', collectionSchema);
   }
-  if (!mongoose.models.FeatureFlag) {
-    mongoose.model('FeatureFlag', featureFlagSchema);
-  }
   if (!mongoose.models.Migration) {
     mongoose.model('Migration', migrationSchema);
   }

--- a/app/modules/featureFlags/__tests__/featureFlag.route.test.ts
+++ b/app/modules/featureFlags/__tests__/featureFlag.route.test.ts
@@ -1,19 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "~/modules/documents/documents";
-import getDocumentsAdapter from "~/modules/documents/helpers/getDocumentsAdapter";
 import { UserService } from "~/modules/users/user";
+import { FeatureFlagService } from "../featureFlag";
 import clearDocumentDB from '../../../../test/helpers/clearDocumentDB';
 import loginUser from '../../../../test/helpers/loginUser';
 import { action, loader } from "../containers/featureFlag.route";
-import type { FeatureFlag } from "../featureFlags.types";
 
 vi.mock("~/modules/queues/helpers/getQueue", () => ({
   default: vi.fn(() => ({
     add: vi.fn().mockResolvedValue({}),
   })),
 }));
-
-const documents = getDocumentsAdapter();
 
 describe("featureFlag.route", () => {
   beforeEach(async () => {
@@ -41,12 +38,9 @@ describe("featureFlag.route", () => {
         teams: [],
       });
 
-      const featureFlag = (
-        await documents.createDocument<FeatureFlag>({
-          collection: "featureFlags",
-          update: { name: "test-flag" },
-        })
-      ).data;
+      const featureFlag = await FeatureFlagService.create({
+        name: "test-flag"
+      });
 
       await UserService.create({
         username: "user1",
@@ -72,9 +66,9 @@ describe("featureFlag.route", () => {
       } as any);
 
       if (result instanceof Response) throw new Error("Expected data, got Response");
-      expect(result.featureFlag.data?.name).toBe("test-flag");
-      expect(result.users.data).toHaveLength(1);
-      expect(result.users.data[0].username).toBe("user1");
+      expect(result.featureFlag.name).toBe("test-flag");
+      expect(result.users).toHaveLength(1);
+      expect(result.users[0].username).toBe("user1");
     });
   });
 
@@ -87,12 +81,9 @@ describe("featureFlag.route", () => {
         featureFlags: [],
       });
 
-      const featureFlag = (
-        await documents.createDocument<FeatureFlag>({
-          collection: "featureFlags",
-          update: { name: "beta-feature" },
-        })
-      ).data;
+      const featureFlag = await FeatureFlagService.create({
+        name: "beta-feature"
+      });
 
       const user1 = await UserService.create({
         username: "user1",
@@ -139,12 +130,9 @@ describe("featureFlag.route", () => {
         featureFlags: [],
       });
 
-      const featureFlag = (
-        await documents.createDocument<FeatureFlag>({
-          collection: "featureFlags",
-          update: { name: "beta-feature" },
-        })
-      ).data;
+      const featureFlag = await FeatureFlagService.create({
+        name: "beta-feature"
+      });
 
       const user = await UserService.create({
         username: "user1",
@@ -184,12 +172,9 @@ describe("featureFlag.route", () => {
         featureFlags: [],
       });
 
-      const featureFlag = (
-        await documents.createDocument<FeatureFlag>({
-          collection: "featureFlags",
-          update: { name: "deprecated-flag" },
-        })
-      ).data;
+      const featureFlag = await FeatureFlagService.create({
+        name: "deprecated-flag"
+      });
 
       const cookieHeader = await loginUser(admin._id);
 
@@ -197,7 +182,7 @@ describe("featureFlag.route", () => {
         intent: "DELETE_FEATURE_FLAG",
       });
 
-      const result = await action({
+      await action({
         request: new Request("http://localhost/", {
           method: "DELETE",
           headers: { cookie: cookieHeader },
@@ -208,17 +193,9 @@ describe("featureFlag.route", () => {
         context: {},
       } as any);
 
-      expect(result).not.toBeInstanceOf(Response);
-      if (result instanceof Response) throw new Error("Expected data, got Response");
-      expect(result.intent).toBe("DELETE_FEATURE_FLAG");
-      expect(result.success).toBe(true);
-
       // Verify the feature flag was deleted
-      const deletedFlag = await documents.getDocument<FeatureFlag>({
-        collection: "featureFlags",
-        match: { _id: featureFlag._id },
-      });
-      expect(deletedFlag.data).toBeNull();
+      const deletedFlag = await FeatureFlagService.findById(featureFlag._id);
+      expect(deletedFlag).toBeNull();
     });
   });
 });

--- a/app/modules/featureFlags/components/addUsersToFeatureFlagDialog.tsx
+++ b/app/modules/featureFlags/components/addUsersToFeatureFlagDialog.tsx
@@ -13,7 +13,8 @@ export default function AddUsersToFeatureFlagDialog({
   isFetching,
   isSubmitButtonDisabled,
   onAddUsersClicked,
-  onSelectUserToggled
+  onSelectUserToggled,
+  isSubmitting = false
 }: {
   users: User[],
   selectedUsers: string[],
@@ -21,6 +22,7 @@ export default function AddUsersToFeatureFlagDialog({
   isSubmitButtonDisabled: boolean,
   onAddUsersClicked: () => void,
   onSelectUserToggled: (userId: string) => void,
+  isSubmitting?: boolean,
 }) {
   return (
     <DialogContent>

--- a/app/modules/featureFlags/components/createFeatureFlagDialog.tsx
+++ b/app/modules/featureFlags/components/createFeatureFlagDialog.tsx
@@ -12,22 +12,19 @@ import { Label } from "@/components/ui/label";
 import { useState } from "react";
 
 const CreateFeatureFlagDialog = ({
-  onCreateNewFeatureFlagClicked
+  onCreateFeatureFlagClicked,
+  isSubmitting = false
 }: {
-  onCreateNewFeatureFlagClicked: ({ name }: { name: string }) => void
+  onCreateFeatureFlagClicked: ({ name }: { name: string }) => void,
+  isSubmitting?: boolean
 }) => {
-
   const [name, setName] = useState('');
 
   const onNameChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     setName(event.target.value);
   };
 
-  let isSubmitButtonDisabled = true;
-
-  if (name.trim().length >= 3) {
-    isSubmitButtonDisabled = false;
-  }
+  let isSubmitButtonDisabled = isSubmitting || name.trim().length < 3;
 
   return (
     <DialogContent>
@@ -39,19 +36,19 @@ const CreateFeatureFlagDialog = ({
       </DialogHeader>
       <div className="grid gap-3">
         <Label htmlFor="name-1">Feature flag</Label>
-        <Input id="name-1" name="name" defaultValue={name} autoComplete="off" onChange={onNameChanged} />
+        <Input id="name-1" name="name" defaultValue={name} autoComplete="off" onChange={onNameChanged} disabled={isSubmitting} />
       </div>
       <DialogFooter className="justify-end">
         <DialogClose asChild>
-          <Button type="button" variant="secondary">
+          <Button type="button" variant="secondary" disabled={isSubmitting}>
             Cancel
           </Button>
         </DialogClose>
         <DialogClose asChild>
           <Button type="button" disabled={isSubmitButtonDisabled} onClick={() => {
-            onCreateNewFeatureFlagClicked({ name });
+            onCreateFeatureFlagClicked({ name });
           }}>
-            Create feature flag
+            {isSubmitting ? 'Creating...' : 'Create feature flag'}
           </Button>
         </DialogClose>
       </DialogFooter>

--- a/app/modules/featureFlags/components/deleteFeatureFlagDialog.tsx
+++ b/app/modules/featureFlags/components/deleteFeatureFlagDialog.tsx
@@ -14,16 +14,16 @@ import type { FeatureFlag } from "../featureFlags.types";
 
 const DeleteFeatureFlagDialog = ({
   featureFlag,
-  onDeleteFeatureFlagClicked
-}: { featureFlag: FeatureFlag, onDeleteFeatureFlagClicked: (id: string) => void }) => {
-
+  onDeleteFeatureFlagClicked,
+  isSubmitting = false
+}: {
+  featureFlag: FeatureFlag,
+  onDeleteFeatureFlagClicked: () => void,
+  isSubmitting?: boolean
+}) => {
   const [flagName, setFlagName] = useState('');
 
-  let isDeleteButtonDisabled = true;
-
-  if (flagName === featureFlag.name) {
-    isDeleteButtonDisabled = false;
-  }
+  let isDeleteButtonDisabled = isSubmitting || flagName !== featureFlag.name;
 
   return (
     <DialogContent>
@@ -37,23 +37,23 @@ const DeleteFeatureFlagDialog = ({
         <Label htmlFor="name-1">To confirm delete, type in the feature flag name.</Label>
         <div className="relative">
           <Input className="absolute left-0 top-0" placeholder={featureFlag.name} disabled={true} autoComplete="off" />
-          <Input className="focus-visible:border-destructive focus-visible:ring-destructive/50" id="name-1" name="name" value={flagName} autoComplete="off" onChange={(event) => setFlagName(event.target.value)} />
+          <Input className="focus-visible:border-destructive focus-visible:ring-destructive/50" id="name-1" name="name" value={flagName} autoComplete="off" onChange={(event) => setFlagName(event.target.value)} disabled={isSubmitting} />
         </div>
       </div>
       <DialogFooter className="justify-end">
         <DialogClose asChild>
           <Button type="button" variant="secondary" onClick={() => {
             setFlagName('');
-          }}>
+          }} disabled={isSubmitting}>
             Cancel
           </Button>
         </DialogClose>
         <DialogClose asChild>
           <Button type="button" disabled={isDeleteButtonDisabled} variant="destructive" onClick={() => {
-            onDeleteFeatureFlagClicked(featureFlag._id);
+            onDeleteFeatureFlagClicked();
             setFlagName('');
           }}>
-            Delete feature flag
+            {isSubmitting ? 'Deleting...' : 'Delete feature flag'}
           </Button>
         </DialogClose>
       </DialogFooter>

--- a/app/modules/featureFlags/containers/addUsersToFeatureFlagDialog.container.tsx
+++ b/app/modules/featureFlags/containers/addUsersToFeatureFlagDialog.container.tsx
@@ -7,12 +7,13 @@ import cloneDeep from "lodash/cloneDeep";
 
 export default function AddUsersToFeatureFlagDialogContainer({
   featureFlagId,
-  onAddUsersClicked
+  onAddUsersClicked,
+  isSubmitting = false
 }: {
   featureFlagId: string,
   onAddUsersClicked: (userIds: string[]) => void,
+  isSubmitting?: boolean
 }) {
-
   const [isFetching, setIsFetching] = useState(true);
   const [isSubmitButtonDisabled, setIsSubmitButtonDisabled] = useState(true);
   const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
@@ -44,11 +45,12 @@ export default function AddUsersToFeatureFlagDialogContainer({
   return (
     <AddUsersToFeatureFlagDialog
       isFetching={isFetching}
-      isSubmitButtonDisabled={isSubmitButtonDisabled}
+      isSubmitButtonDisabled={isSubmitButtonDisabled || isSubmitting}
       users={fetcher.data?.data}
       selectedUsers={selectedUsers}
       onAddUsersClicked={() => onAddUsersClicked(selectedUsers)}
       onSelectUserToggled={onSelectUserToggled}
+      isSubmitting={isSubmitting}
     />
   );
 }

--- a/app/modules/featureFlags/containers/featureFlags.route.tsx
+++ b/app/modules/featureFlags/containers/featureFlags.route.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
-import { redirect, useActionData, useMatch, useNavigate, useSubmit } from 'react-router';
+import { redirect, useFetcher, useMatch, data } from 'react-router';
+import { toast } from 'sonner';
 import updateBreadcrumb from '~/modules/app/updateBreadcrumb';
 import getSessionUser from '~/modules/authentication/helpers/getSessionUser';
 import SystemAdminAuthorization from '~/modules/authorization/systemAdminAuthorization';
 import addDialog from '~/modules/dialogs/addDialog';
-import getDocumentsAdapter from '~/modules/documents/helpers/getDocumentsAdapter';
+import { FeatureFlagService } from '../featureFlag';
 import type { User } from '~/modules/users/users.types';
 import CreateFeatureFlagDialog from '../components/createFeatureFlagDialog';
 import FeatureFlags from '../components/featureFlags';
@@ -12,43 +13,44 @@ import type { FeatureFlag } from '../featureFlags.types';
 import type { Route } from './+types/featureFlags.route';
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const documents = getDocumentsAdapter();
   const user = await getSessionUser({ request }) as User;
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
     return redirect('/');
   }
-  const result = await documents.getDocuments<FeatureFlag>({ collection: 'featureFlags', match: {}, sort: {} });
-  const featureFlags = { data: result.data };
+  const featureFlags = await FeatureFlagService.find({});
   return { featureFlags };
 }
 
-export async function action({
-  request,
-}: Route.ActionArgs) {
-
+export async function action({ request }: Route.ActionArgs) {
   const user = await getSessionUser({ request }) as User;
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
-    throw new Error('Access denied');
+    return data(
+      { errors: { general: 'Access denied' } },
+      { status: 403 }
+    );
   }
 
-  const { intent, entityId, payload = {} } = await request.json()
-
+  const { intent, payload = {} } = await request.json();
   const { name } = payload;
 
-  const documents = getDocumentsAdapter();
-
   switch (intent) {
-    case 'CREATE_FEATURE_FLAG':
-      if (typeof name !== "string") {
-        throw new Error("Feature flag name is required and must be a string.");
+    case 'CREATE_FEATURE_FLAG': {
+      if (typeof name !== 'string' || !name.trim()) {
+        return data(
+          { errors: { general: 'Feature flag name is required and must be a string' } },
+          { status: 400 }
+        );
       }
-      const featureFlag = await documents.createDocument<FeatureFlag>({ collection: 'featureFlags', update: { name } });
-      return {
-        intent: 'CREATE_FEATURE_FLAG',
-        ...featureFlag
-      }
+
+      const featureFlag = await FeatureFlagService.create({ name: name.trim() });
+      return data({ success: true, intent: 'CREATE_FEATURE_FLAG', data: featureFlag });
+    }
+
     default:
-      return {};
+      return data(
+        { errors: { general: 'Invalid intent' } },
+        { status: 400 }
+      );
   }
 }
 
@@ -58,44 +60,49 @@ export function HydrateFallback() {
 
 export default function FeatureFlagsRoute({ loaderData }: Route.ComponentProps) {
   const { featureFlags } = loaderData;
-  const submit = useSubmit();
-  const actionData = useActionData();
-  const navigate = useNavigate();
-
+  const fetcher = useFetcher();
   const match = useMatch('/featureFlags');
 
   useEffect(() => {
     if (match) {
-      updateBreadcrumb([
-        { text: 'Feature flags' }
-      ])
+      updateBreadcrumb([{ text: 'Feature flags' }]);
     }
   }, [match]);
 
   useEffect(() => {
-    if (actionData?.intent === 'CREATE_FEATURE_FLAG') {
-      navigate(`/featureFlags/${actionData.data._id}`)
+    if (fetcher.state === 'idle' && fetcher.data) {
+      if (fetcher.data.success && fetcher.data.intent === 'CREATE_FEATURE_FLAG') {
+        toast.success('Feature flag created');
+        addDialog(null);
+      } else if (fetcher.data.errors) {
+        toast.error(fetcher.data.errors.general || 'An error occurred');
+      }
     }
-  }, [actionData]);
+  }, [fetcher.state, fetcher.data]);
 
-  const onCreateFeatureFlagButtonClicked = () => {
+  const openCreateFeatureFlagDialog = () => {
     addDialog(
       <CreateFeatureFlagDialog
-        onCreateNewFeatureFlagClicked={onCreateNewFeatureFlagClicked}
+        onCreateFeatureFlagClicked={submitCreateFeatureFlag}
+        isSubmitting={fetcher.state === 'submitting'}
       />
     );
   }
 
-  const onCreateNewFeatureFlagClicked = ({ name }: {
-    name: string,
-  }) => {
-    submit(JSON.stringify({ intent: 'CREATE_FEATURE_FLAG', payload: { name } }), { method: 'POST', encType: 'application/json' });
+  const submitCreateFeatureFlag = ({ name }: { name: string }) => {
+    fetcher.submit(
+      JSON.stringify({
+        intent: 'CREATE_FEATURE_FLAG',
+        payload: { name }
+      }),
+      { method: 'POST', encType: 'application/json' }
+    );
   }
 
   return (
     <FeatureFlags
-      featureFlags={featureFlags?.data}
-      onCreateFeatureFlagButtonClicked={onCreateFeatureFlagButtonClicked}
+      featureFlags={featureFlags}
+      onCreateFeatureFlagButtonClicked={openCreateFeatureFlagDialog}
     />
   );
 }

--- a/app/modules/featureFlags/featureFlag.ts
+++ b/app/modules/featureFlags/featureFlag.ts
@@ -1,0 +1,59 @@
+import mongoose from 'mongoose';
+import featureFlagSchema from '~/modules/documents/schemas/featureFlag.schema';
+import type { FeatureFlag } from './featureFlags.types';
+import type { FindOptions } from '~/modules/common/types';
+
+const FeatureFlagModel = mongoose.model('FeatureFlag', featureFlagSchema);
+
+export class FeatureFlagService {
+  private static toFeatureFlag(doc: any): FeatureFlag {
+    return doc.toJSON({ flattenObjectIds: true });
+  }
+
+  static async find(options?: FindOptions): Promise<FeatureFlag[]> {
+    const match = options?.match || {};
+    let query = FeatureFlagModel.find(match);
+
+    if (options?.populate?.length) {
+      query = query.populate(options.populate);
+    }
+
+    if (options?.sort) {
+      query = query.sort(options.sort);
+    }
+
+    if (options?.pagination) {
+      query = query.skip(options.pagination.skip).limit(options.pagination.limit);
+    }
+
+    const docs = await query;
+    return docs.map(doc => this.toFeatureFlag(doc));
+  }
+
+  static async count(match: Record<string, any> = {}): Promise<number> {
+    return FeatureFlagModel.countDocuments(match);
+  }
+
+  static async findById(id: string | undefined): Promise<FeatureFlag | null> {
+    if (!id) return null;
+    const doc = await FeatureFlagModel.findById(id);
+    return doc ? this.toFeatureFlag(doc) : null;
+  }
+
+  static async create(data: Partial<FeatureFlag>): Promise<FeatureFlag> {
+    const doc = await FeatureFlagModel.create(data);
+    return this.toFeatureFlag(doc);
+  }
+
+  static async updateById(id: string, updates: Partial<FeatureFlag>): Promise<FeatureFlag | null> {
+    const doc = await FeatureFlagModel.findByIdAndUpdate(id, updates, {
+      new: true,
+    });
+    return doc ? this.toFeatureFlag(doc) : null;
+  }
+
+  static async deleteById(id: string): Promise<FeatureFlag | null> {
+    const doc = await FeatureFlagModel.findByIdAndDelete(id);
+    return doc ? this.toFeatureFlag(doc) : null;
+  }
+}

--- a/app/modules/featureFlags/featureFlags.types.ts
+++ b/app/modules/featureFlags/featureFlags.types.ts
@@ -2,5 +2,7 @@ export interface FeatureFlag {
   _id: string;
   name: string;
   createdAt: string;
-  createdBy: string,
+  createdBy: string;
+  updatedAt?: string;
+  updatedBy?: string;
 }

--- a/app/modules/featureFlags/helpers/hasFeatureFlag.ts
+++ b/app/modules/featureFlags/helpers/hasFeatureFlag.ts
@@ -1,16 +1,13 @@
 import includes from 'lodash/includes.js';
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
-import getDocumentsAdapter from "~/modules/documents/helpers/getDocumentsAdapter";
-import type { FeatureFlag } from "../featureFlags.types";
+import { FeatureFlagService } from "../featureFlag";
 
 export default async (featureFlagName: string, context: { request: Request }) => {
+  const featureFlag = await FeatureFlagService.find({ match: { name: featureFlagName } });
 
-  const documents = getDocumentsAdapter();
-  const featureFlag = await documents.getDocument<FeatureFlag>({ collection: 'featureFlags', match: { name: featureFlagName } });
-
-  if (featureFlag.data) {
+  if (featureFlag.length > 0) {
     const user = await getSessionUser({ request: context.request });
-    if (includes(user?.featureFlags, featureFlag.data.name)) {
+    if (includes(user?.featureFlags, featureFlag[0].name)) {
       return true;
     }
   } else {

--- a/app/modules/users/__tests__/availableFeatureFlagUsers.route.test.ts
+++ b/app/modules/users/__tests__/availableFeatureFlagUsers.route.test.ts
@@ -1,17 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import mongoose from "mongoose";
 import "~/modules/documents/documents";
-import getDocumentsAdapter from "~/modules/documents/helpers/getDocumentsAdapter";
 import { UserService } from "../user";
-import type { User } from "../users.types";
-import type { FeatureFlag } from "~/modules/featureFlags/featureFlags.types";
+import { FeatureFlagService } from "~/modules/featureFlags/featureFlag";
 import clearDocumentDB from '../../../../test/helpers/clearDocumentDB';
 import loginUser from '../../../../test/helpers/loginUser';
 import { loader } from "../containers/availableFeatureFlagUsers.route";
 
 const generateObjectId = () => new mongoose.Types.ObjectId().toString();
-
-const documents = getDocumentsAdapter();
 
 describe("availableFeatureFlagUsers.route loader", () => {
   beforeEach(async () => {
@@ -28,10 +24,10 @@ describe("availableFeatureFlagUsers.route loader", () => {
   });
 
   it("throws error when featureFlagId is not provided", async () => {
-    const superAdmin = (await documents.createDocument<User>({
-      collection: "users",
-      update: { username: "admin", role: "SUPER_ADMIN" },
-    })).data;
+    const superAdmin = await UserService.create({
+      username: "admin",
+      role: "SUPER_ADMIN",
+    });
 
     const cookieHeader = await loginUser(superAdmin._id);
 
@@ -46,15 +42,17 @@ describe("availableFeatureFlagUsers.route loader", () => {
   });
 
   it("throws error when user cannot manage feature flags", async () => {
-    const featureFlag = (await documents.createDocument<FeatureFlag>({
-      collection: "featureFlags",
-      update: { name: "beta_feature" },
-    })).data;
+    const featureFlag = await FeatureFlagService.create({
+      name: "beta_feature",
+    });
 
-    const regularUser = (await documents.createDocument<User>({
-      collection: "users",
-      update: { username: "user", role: "USER" },
-    })).data;
+    const regularUser = await UserService.create({
+      username: "user",
+      role: "USER",
+      githubId: 100001,
+      hasGithubSSO: true,
+      isRegistered: true,
+    });
 
     const cookieHeader = await loginUser(regularUser._id);
 
@@ -70,10 +68,11 @@ describe("availableFeatureFlagUsers.route loader", () => {
   });
 
   it("throws error when feature flag not found", async () => {
-    const superAdmin = (await documents.createDocument<User>({
-      collection: "users",
-      update: { username: "admin", role: "SUPER_ADMIN" },
-    })).data;
+    const superAdmin = await UserService.create({
+      username: "admin",
+      role: "SUPER_ADMIN",
+      isRegistered: true,
+    });
 
     const cookieHeader = await loginUser(superAdmin._id);
 
@@ -89,22 +88,19 @@ describe("availableFeatureFlagUsers.route loader", () => {
   });
 
   it("returns users without the feature flag", async () => {
-    const featureFlag = (await documents.createDocument<FeatureFlag>({
-      collection: "featureFlags",
-      update: { name: "beta_feature" },
-    })).data;
+    const featureFlag = await FeatureFlagService.create({
+      name: "beta_feature",
+    });
 
-    const superAdmin = (await documents.createDocument<User>({
-      collection: "users",
-      update: { username: "admin", role: "SUPER_ADMIN" },
-    })).data;
+    const superAdmin = await UserService.create({
+      username: "admin",
+      role: "SUPER_ADMIN",
+      isRegistered: true,
+    });
 
     // Create a user with the feature flag
     const userWithFlag = await UserService.create({
       username: "with_flag",
-      role: "USER",
-      githubId: 100001,
-      hasGithubSSO: true,
       isRegistered: true,
       featureFlags: ["beta_feature"],
     });
@@ -112,9 +108,6 @@ describe("availableFeatureFlagUsers.route loader", () => {
     // Create a user without the feature flag
     const userWithoutFlag = await UserService.create({
       username: "without_flag",
-      role: "USER",
-      githubId: 100002,
-      hasGithubSSO: true,
       isRegistered: true,
       featureFlags: [],
     });
@@ -129,27 +122,25 @@ describe("availableFeatureFlagUsers.route loader", () => {
       params: {},
     } as any)) as any;
 
-    expect(result.data).toHaveLength(1);
-    expect(result.data[0]._id).toBe(userWithoutFlag._id);
+    expect(result.data).toHaveLength(2);
+    expect(result.data.some((u: any) => u._id === userWithoutFlag._id)).toBe(true);
+    expect(result.data.some((u: any) => u._id === superAdmin._id)).toBe(true);
   });
 
   it("returns only registered users", async () => {
-    const featureFlag = (await documents.createDocument<FeatureFlag>({
-      collection: "featureFlags",
-      update: { name: "beta_feature" },
-    })).data;
+    const featureFlag = await FeatureFlagService.create({
+      name: "beta_feature",
+    });
 
-    const superAdmin = (await documents.createDocument<User>({
-      collection: "users",
-      update: { username: "admin", role: "SUPER_ADMIN" },
-    })).data;
+    const superAdmin = await UserService.create({
+      username: "admin",
+      role: "SUPER_ADMIN",
+      isRegistered: true,
+    });
 
     // Create a registered user
     const registeredUser = await UserService.create({
       username: "registered",
-      role: "USER",
-      githubId: 100001,
-      hasGithubSSO: true,
       isRegistered: true,
       featureFlags: [],
     });
@@ -157,9 +148,6 @@ describe("availableFeatureFlagUsers.route loader", () => {
     // Create an unregistered user
     const unregisteredUser = await UserService.create({
       username: "unregistered",
-      role: "USER",
-      githubId: 100002,
-      hasGithubSSO: true,
       isRegistered: false,
       featureFlags: [],
     });
@@ -174,7 +162,9 @@ describe("availableFeatureFlagUsers.route loader", () => {
       params: {},
     } as any)) as any;
 
-    expect(result.data).toHaveLength(1);
-    expect(result.data[0]._id).toBe(registeredUser._id);
+    expect(result.data).toHaveLength(2);
+    expect(result.data.some((u: any) => u._id === registeredUser._id)).toBe(true);
+    expect(result.data.some((u: any) => u._id === superAdmin._id)).toBe(true);
+    expect(result.data.some((u: any) => u._id === unregisteredUser._id)).toBe(false);
   });
 });

--- a/app/modules/users/containers/availableFeatureFlagUsers.route.tsx
+++ b/app/modules/users/containers/availableFeatureFlagUsers.route.tsx
@@ -1,9 +1,8 @@
 import { redirect } from "react-router";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
-import getDocumentsAdapter from "~/modules/documents/helpers/getDocumentsAdapter";
 import { UserService } from "~/modules/users/user";
-import type { FeatureFlag } from "~/modules/featureFlags/featureFlags.types";
+import { FeatureFlagService } from "~/modules/featureFlags/featureFlag";
 import type { User } from '~/modules/users/users.types';
 import type { Route } from "./+types/availableTeamUsers.route";
 
@@ -24,16 +23,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw Error("Feature flag id is not defined");
   }
 
-  const documents = getDocumentsAdapter();
-
-  const featureFlag = await documents.getDocument<FeatureFlag>({ collection: 'featureFlags', match: { _id: featureFlagId } });
-  if (!featureFlag.data) {
+  const featureFlag = await FeatureFlagService.findById(featureFlagId);
+  if (!featureFlag) {
     throw new Error('Feature flag not found');
   }
 
   const users = await UserService.find({
     match: {
-      featureFlags: { "$ne": featureFlag.data.name },
+      featureFlags: { "$ne": featureFlag.name },
       isRegistered: true
     }
   });

--- a/workers/general/__tests__/removeFeatureFlagFromUsers.test.ts
+++ b/workers/general/__tests__/removeFeatureFlagFromUsers.test.ts
@@ -1,12 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "~/modules/documents/documents";
-import getDocumentsAdapter from "~/modules/documents/helpers/getDocumentsAdapter";
 import { UserService } from "~/modules/users/user";
+import { FeatureFlagService } from "~/modules/featureFlags/featureFlag";
 import clearDocumentDB from "../../../test/helpers/clearDocumentDB";
 import removeFeatureFlagFromUsers from "../removeFeatureFlagFromUsers";
-import type { FeatureFlag } from "~/modules/featureFlags/featureFlags.types";
-
-const documents = getDocumentsAdapter();
 
 vi.mock("../../helpers/emitFromJob", () => ({
   default: vi.fn().mockResolvedValue({}),
@@ -18,12 +15,9 @@ describe("removeFeatureFlagFromUsers worker", () => {
   });
 
   it("removes feature flag from all users who have it", async () => {
-    const featureFlag = (
-      await documents.createDocument<FeatureFlag>({
-        collection: "featureFlags",
-        update: { name: "deprecated-flag" },
-      })
-    ).data;
+    const featureFlag = await FeatureFlagService.create({
+      name: "deprecated-flag",
+    });
 
     const user1 = await UserService.create({
       username: "user1",


### PR DESCRIPTION
- Create FeatureFlagService with standard CRUD operations
- Replace DocumentsAdapter calls with FeatureFlagService throughout
- Convert featureFlags.route.tsx to use useFetcher instead of useSubmit
- Convert featureFlag.route.tsx to use useFetcher with improved error handling
- Update dialog components to accept isSubmitting prop for loading states

Fixes #1184