### PR TITLE
Preserve session_id and sequence_id on export

### DIFF
--- a/app/functions/outputRunDataToCSV/app.ts
+++ b/app/functions/outputRunDataToCSV/app.ts
@@ -19,11 +19,12 @@ export const handler = async (event: {
 
     let utteranceKeys = [
       "_id",
-      "sessionId",
+      "session_id",
+      "sequence_id",
       "role",
+      "content",
       "start_time",
       "end_time",
-      "content",
     ];
     let utteranceAnnotationKeysAsObject: { [key: string]: boolean } = {};
     let sessionAnnotationKeysAsObject: { [key: string]: boolean } = {};


### PR DESCRIPTION
Don;t export internal mongodb fields (_id, sessionId)

Fixes #1289