### PR TITLE
Preserve collection context in breadcrumbs via URL structure

### DIFF
--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -58,6 +58,7 @@ export default function RunDetail({
   onAddToExistingCollectionClicked,
   onAddToNewCollectionClicked,
   onUseAsTemplateClicked,
+  collectionId,
 }: {
   run: Run;
   promptInfo: { name: string; version: number };
@@ -72,6 +73,7 @@ export default function RunDetail({
   onAddToExistingCollectionClicked: (run: Run) => void;
   onAddToNewCollectionClicked: (run: Run) => void;
   onUseAsTemplateClicked: (run: Run) => void;
+  collectionId?: string;
 }) {
   const projectId =
     typeof run.project === "string" ? run.project : run.project._id;
@@ -193,7 +195,11 @@ export default function RunDetail({
                         <TableCell className="font-medium">
                           {(session.status === "DONE" && (
                             <Link
-                              to={`/projects/${projectId}/runs/${run._id}/sessions/${session.sessionId}`}
+                              to={
+                                collectionId
+                                  ? `/projects/${projectId}/collections/${collectionId}/runs/${run._id}/sessions/${session.sessionId}`
+                                  : `/projects/${projectId}/runs/${run._id}/sessions/${session.sessionId}`
+                              }
                             >
                               {session.name}
                             </Link>

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -52,12 +52,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     version: run.snapshot.prompt.version,
   };
 
-  const url = new URL(request.url);
-  const collectionId = url.searchParams.get("collectionId");
+  const collectionId = params.collectionId;
   const collection = collectionId
     ? await CollectionService.findById(collectionId)
     : null;
 
+  const url = new URL(request.url);
   const intent = url.searchParams.get("intent");
   if (intent === "GET_ALL_COLLECTIONS") {
     const runCollections = await CollectionService.paginate({
@@ -293,6 +293,7 @@ export default function ProjectRunRoute() {
       onAddToExistingCollectionClicked={onAddToExistingCollectionClicked}
       onAddToNewCollectionClicked={() => openCreateCollectionDialog(run._id)}
       onUseAsTemplateClicked={onUseAsTemplateClicked}
+      collectionId={collection?._id}
     />
   );
 }

--- a/app/modules/runs/helpers/getRunsItemAttributes.tsx
+++ b/app/modules/runs/helpers/getRunsItemAttributes.tsx
@@ -34,10 +34,9 @@ export default (item: Run, options?: Options) => {
     text: `Created at - ${getDateString(item.createdAt)}`,
   });
 
-  let to = `/projects/${item.project}/runs/${item._id}`;
-  if (options?.collectionId) {
-    to += `?collectionId=${options.collectionId}`;
-  }
+  const to = options?.collectionId
+    ? `/projects/${item.project}/collections/${options.collectionId}/runs/${item._id}`
+    : `/projects/${item.project}/runs/${item._id}`;
 
   return {
     id: item._id,

--- a/app/modules/runs/services/validateRunResources.server.ts
+++ b/app/modules/runs/services/validateRunResources.server.ts
@@ -11,8 +11,7 @@ export async function validateRunResources(run: Run): Promise<string[]> {
     warnings.push(`Model "${run.snapshot.model.name}" is no longer available`);
   }
 
-  const promptId =
-    typeof run.prompt === "string" ? run.prompt : run.prompt._id;
+  const promptId = typeof run.prompt === "string" ? run.prompt : run.prompt._id;
   const prompt = await PromptService.findById(promptId);
   if (!prompt) {
     warnings.push(

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -52,6 +52,16 @@ export default [
       "modules/runs/containers/runSessions.route.tsx",
     ),
     route(
+      ":projectId/collections/:collectionId/runs/:runId",
+      "modules/runs/containers/run.route.tsx",
+      { id: "collectionRun" },
+    ),
+    route(
+      ":projectId/collections/:collectionId/runs/:runId/sessions/:sessionId",
+      "modules/runs/containers/runSessions.route.tsx",
+      { id: "collectionRunSession" },
+    ),
+    route(
       ":projectId/collections/:collectionId",
       "modules/collections/containers/collectionDetail.route.tsx",
       [


### PR DESCRIPTION
Add collection-scoped routes for runs and sessions that reuse the existing route files. The collection context is now part of the URL path instead of being threaded through query parameters.

Fixes #1400