### PR TITLE
Fix build jobs not receiving version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
   build-web:
     name: Build Web Image
-    needs: preflight-production
+    needs:
+      - resolve
+      - preflight-production
     uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_build_image.yml@main
     with:
       environment: production
@@ -58,7 +60,9 @@ jobs:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
   build-worker:
     name: Build Worker Image
-    needs: preflight-production
+    needs:
+      - resolve
+      - preflight-production
     uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_build_image.yml@main
     with:
       environment: production

--- a/documentation/workflows.md
+++ b/documentation/workflows.md
@@ -199,10 +199,12 @@ The resolve, preflight, and build stages are active. The deploy stages are disab
 
 ```
 resolve ──▶ preflight
-            ├──▶ build-web ──┐
-            └──▶ build-worker ──┤
-                                └──▶ production-summary
+│           ├──▶ build-web ──┐
+└───────────┤                └──▶ production-summary
+            └──▶ build-worker ──┘
 ```
+
+Both build jobs depend on `resolve` (for the version tag) and `preflight` (for the stability gate).
 
 ### Target Job Graph
 
@@ -210,9 +212,9 @@ Once the deploy jobs are re-enabled, the full pipeline will mirror staging with 
 
 ```
 resolve ──▶ preflight
-            ├──▶ build-web ──▶ deploy-web ──┐
-            └──▶ build-worker ──▶ deploy-worker ──┤
-                                                   └──▶ production-summary
+│           ├──▶ build-web ──▶ deploy-web ──┐
+└───────────┤                               └──▶ production-summary
+            └──▶ build-worker ──▶ deploy-worker ──┘
 ```
 
 The `resolve_release.yml` reusable workflow validates that the semantic version tag is well-formed and that the tagged commit originates from the `main` branch. This acts as a policy enforcement point to prevent deploying unreviewed code.


### PR DESCRIPTION
Added resolve to the needs list of both build-web and build-worker so the version input is accessible.

Updated documentation to reflect the corrected dependency graph.

Build jobs could only access needs.resolve.outputs.version. Without it the the tag input was empty and ecs_build_image fell back to the short commit SHA.

Part of the work towards:
- https://github.com/National-Tutoring-Observatory/infrastructure/issues/86

##### References:

- #1407 