### PR TITLE
Fix all no-unused-vars errors and wire up missing UI feedback

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -27,6 +27,7 @@ export default function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   routerContext: EntryContext,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadContext: AppLoadContext,
   // If you have middleware enabled:
   // loadContext: unstable_RouterContextProvider

--- a/app/functions/annotateRunSessions.tsx
+++ b/app/functions/annotateRunSessions.tsx
@@ -8,10 +8,11 @@ import { SessionService } from "~/modules/sessions/session";
 import { handler as annotatePerSession } from "./annotatePerSession/app";
 import { handler as annotatePerUtterance } from "./annotatePerUtterance/app";
 
-export default async function annotateRunSessions(
-  { runId }: { runId: string },
-  context: { request: Request },
-) {
+export default async function annotateRunSessions({
+  runId,
+}: {
+  runId: string;
+}) {
   const run = await RunService.findById(runId);
   if (!run) throw new Error(`Run not found: ${runId}`);
   const project = await ProjectService.findById(run.project as string);

--- a/app/modules/app/containers/api.route.tsx
+++ b/app/modules/app/containers/api.route.tsx
@@ -1,4 +1,3 @@
-import type { Route } from ".react-router/types/app/+types/root";
 import mongoose from "mongoose";
 import { redis } from "~/modules/queues/helpers/createQueue";
 
@@ -12,7 +11,7 @@ const checkParamsExist = (paramKeys: string[]) => {
   return missingParams;
 };
 
-export async function loader({ request }: Route.LoaderArgs) {
+export async function loader() {
   let missingParameters: any[] = [];
 
   const { LLM_PROVIDER, STORAGE_ADAPTER, DOCUMENTS_ADAPTER } = process.env;

--- a/app/modules/authentication/components/login.tsx
+++ b/app/modules/authentication/components/login.tsx
@@ -13,13 +13,11 @@ export default function Login({
   errorTitle,
   errorDescription,
   hasError,
-  onLoginWithOrcidClicked,
   onLoginWithGithubClicked,
 }: {
   errorTitle: string | undefined;
   errorDescription: string | undefined;
   hasError: boolean;
-  onLoginWithOrcidClicked: () => void;
   onLoginWithGithubClicked: () => void;
 }) {
   return (
@@ -57,26 +55,6 @@ export default function Login({
           </CardDescription>
         </CardHeader>
         <CardFooter className="flex-row gap-2">
-          {/* <Button variant="outline" className="w-full" onClick={onLoginWithOrcidClicked}>
-            <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" width="72px" height="72px" viewBox="0 0 72 72" version="1.1">
-              <title>Orcid logo</title>
-              <g id="Symbols" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                <g id="hero" transform="translate(-924.000000, -72.000000)" fillRule="nonzero">
-                  <g id="Group-4">
-                    <g id="vector_iD_icon" transform="translate(924.000000, 72.000000)">
-                      <path d="M72,36 C72,55.884375 55.884375,72 36,72 C16.115625,72 0,55.884375 0,36 C0,16.115625 16.115625,0 36,0 C55.884375,0 72,16.115625 72,36 Z" id="Path" fill="#A6CE39" />
-                      <g id="Group" transform="translate(18.868966, 12.910345)" fill="#FFFFFF">
-                        <polygon id="Path" points="5.03734929 39.1250878 0.695429861 39.1250878 0.695429861 9.14431787 5.03734929 9.14431787 5.03734929 22.6930505 5.03734929 39.1250878" />
-                        <path d="M11.409257,9.14431787 L23.1380784,9.14431787 C34.303014,9.14431787 39.2088191,17.0664074 39.2088191,24.1486995 C39.2088191,31.846843 33.1470485,39.1530811 23.1944669,39.1530811 L11.409257,39.1530811 L11.409257,9.14431787 Z M15.7511765,35.2620194 L22.6587756,35.2620194 C32.49858,35.2620194 34.7541226,27.8438084 34.7541226,24.1486995 C34.7541226,18.1301509 30.8915059,13.0353795 22.4332213,13.0353795 L15.7511765,13.0353795 L15.7511765,35.2620194 Z" id="Shape" />
-                        <path d="M5.71401206,2.90182329 C5.71401206,4.441452 4.44526937,5.72914146 2.86638958,5.72914146 C1.28750978,5.72914146 0.0187670918,4.441452 0.0187670918,2.90182329 C0.0187670918,1.33420133 1.28750978,0.0745051096 2.86638958,0.0745051096 C4.44526937,0.0745051096 5.71401206,1.36219458 5.71401206,2.90182329 Z" id="Path" />
-                      </g>
-                    </g>
-                  </g>
-                </g>
-              </g>
-            </svg>
-            Login with ORCID
-          </Button> */}
           {!hasError && (
             <Button
               variant="outline"

--- a/app/modules/authentication/containers/login.container.tsx
+++ b/app/modules/authentication/containers/login.container.tsx
@@ -23,17 +23,6 @@ export default function LoginContainer() {
   const hasError = searchParams.has("error");
   const errorType = searchParams.get("error");
 
-  const onLoginWithOrcidClicked = () => {
-    fetcher.submit(
-      { provider: "orcid" },
-      {
-        action: `/api/authentication`,
-        method: "post",
-        encType: "application/json",
-      },
-    );
-  };
-
   const onLoginWithGithubClicked = () => {
     fetcher.submit(
       { provider: "github" },
@@ -62,7 +51,6 @@ export default function LoginContainer() {
       errorTitle={errorTitle}
       errorDescription={errorDescription}
       hasError={hasError}
-      onLoginWithOrcidClicked={onLoginWithOrcidClicked}
       onLoginWithGithubClicked={onLoginWithGithubClicked}
     />
   );

--- a/app/modules/featureFlags/components/addUsersToFeatureFlagDialog.tsx
+++ b/app/modules/featureFlags/components/addUsersToFeatureFlagDialog.tsx
@@ -73,12 +73,12 @@ export default function AddUsersToFeatureFlagDialog({
         <DialogClose asChild>
           <Button
             type="button"
-            disabled={isSubmitButtonDisabled}
+            disabled={isSubmitButtonDisabled || isSubmitting}
             onClick={() => {
               onAddUsersClicked();
             }}
           >
-            Add users
+            {isSubmitting ? "Adding..." : "Add users"}
           </Button>
         </DialogClose>
       </DialogFooter>

--- a/app/modules/featureFlags/containers/featureFlags.route.tsx
+++ b/app/modules/featureFlags/containers/featureFlags.route.tsx
@@ -12,7 +12,7 @@ import { FeatureFlagService } from "../featureFlag";
 import type { FeatureFlag } from "../featureFlags.types";
 import type { Route } from "./+types/featureFlags.route";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   const user = (await getSessionUser({ request })) as User;
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
     return redirect("/");

--- a/app/modules/llm/providers/openAI.ts
+++ b/app/modules/llm/providers/openAI.ts
@@ -13,7 +13,6 @@ registerLLM("OPEN_AI", {
   },
   createChat: async ({
     llm,
-    options,
     messages,
     schema,
   }: {

--- a/app/modules/projects/__tests__/projects.route.test.ts
+++ b/app/modules/projects/__tests__/projects.route.test.ts
@@ -1,4 +1,3 @@
-import { Types } from "mongoose";
 import { beforeEach, describe, expect, it } from "vitest";
 import "~/modules/teams/team";
 import { TeamService } from "~/modules/teams/team";
@@ -7,8 +6,6 @@ import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/projects.route";
 import { ProjectService } from "../project";
-
-const createValidId = () => new Types.ObjectId().toString();
 
 describe("projects.route loader", () => {
   beforeEach(async () => {
@@ -58,7 +55,7 @@ describe("projects.route loader", () => {
       createdBy: user._id,
     });
 
-    const project2 = await ProjectService.create({
+    await ProjectService.create({
       name: "Project in Team 2",
       team: team2._id,
       createdBy: user._id,

--- a/app/modules/projects/containers/projects.route.tsx
+++ b/app/modules/projects/containers/projects.route.tsx
@@ -19,11 +19,7 @@ import { ProjectService } from "../project";
 import deleteProject from "../services/deleteProject.server";
 import type { Route } from "./+types/projects.route";
 
-export async function loader({
-  request,
-  params,
-  context,
-}: Route.LoaderArgs & { context: any }) {
+export async function loader({ request }: Route.LoaderArgs) {
   const authenticationTeams = await getSessionUserTeams({ request });
   const teamIds = map(authenticationTeams, "team");
 

--- a/app/modules/prompts/__tests__/prompt.route.test.ts
+++ b/app/modules/prompts/__tests__/prompt.route.test.ts
@@ -28,7 +28,7 @@ describe("prompt.route action", () => {
         createdBy: user._id,
       });
 
-      const promptVersion = await PromptVersionService.create({
+      await PromptVersionService.create({
         name: "Version 1",
         prompt: prompt._id,
         version: 1,

--- a/app/modules/prompts/components/promptEditor.tsx
+++ b/app/modules/prompts/components/promptEditor.tsx
@@ -32,7 +32,6 @@ export default function PromptEditor({
   const [name, setName] = useState("");
   const [userPrompt, setUserPrompt] = useState("");
   const [annotationSchema, setAnnotationSchema] = useState<any[]>([]);
-  const [isSaving, setIsSaving] = useState(false);
 
   const onNameChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     setHasChanges(true);
@@ -52,7 +51,6 @@ export default function PromptEditor({
   };
 
   const onSavePromptVersionClicked = () => {
-    setIsSaving(true);
     onSavePromptVersion({ name, userPrompt, annotationSchema });
   };
 

--- a/app/modules/prompts/components/promptSelector.tsx
+++ b/app/modules/prompts/components/promptSelector.tsx
@@ -102,7 +102,7 @@ export default function PromptSelector({
                   <CommandItem
                     key={prompt._id}
                     value={prompt._id}
-                    onSelect={(currentValue) => {
+                    onSelect={() => {
                       onSelectedPromptChange(prompt._id);
                       onTogglePromptPopover(false);
                     }}
@@ -174,7 +174,7 @@ export default function PromptSelector({
                       <CommandItem
                         key={promptVersion._id}
                         value={`${promptVersion.version}`}
-                        onSelect={(currentValue) => {
+                        onSelect={() => {
                           onSelectedPromptVersionChange(promptVersion.version);
                           onTogglePromptVersionsPopover(false);
                         }}

--- a/app/modules/prompts/containers/promptVersionsList.route.tsx
+++ b/app/modules/prompts/containers/promptVersionsList.route.tsx
@@ -6,7 +6,7 @@ import type { User } from "~/modules/users/users.types";
 import PromptAuthorization from "../authorization";
 import type { Route } from "./+types/promptVersionsList.route";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   const user = (await getSessionUser({ request })) as User;
   if (!user) {
     return redirect("/");

--- a/app/modules/prompts/containers/promptsList.route.tsx
+++ b/app/modules/prompts/containers/promptsList.route.tsx
@@ -7,7 +7,7 @@ import annotationTypes from "../annotationTypes";
 import { PromptService } from "../prompt";
 import type { Route } from "./+types/promptsList.route";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   const user = (await getSessionUser({ request })) as User;
   if (!user) {
     return redirect("/");

--- a/app/modules/queues/components/jobsList.tsx
+++ b/app/modules/queues/components/jobsList.tsx
@@ -54,7 +54,7 @@ export default function JobsList({
     };
   };
 
-  const getItemActions = (job: Job) => {
+  const getItemActions = () => {
     const actions = [
       { action: "VIEW", text: "View Details" },
       ...(state === "failed" ? [{ action: "RETRY", text: "Retry Job" }] : []),

--- a/app/modules/queues/components/queueControls.tsx
+++ b/app/modules/queues/components/queueControls.tsx
@@ -2,13 +2,11 @@ import { Button } from "@/components/ui/button";
 import { Pause, Play } from "lucide-react";
 
 interface QueueControlsProps {
-  queueType?: string;
   onPauseResume?: () => void;
   isPaused?: boolean;
 }
 
 export default function QueueControls({
-  queueType,
   onPauseResume,
   isPaused = false,
 }: QueueControlsProps) {

--- a/app/modules/queues/components/queueStateTabs.tsx
+++ b/app/modules/queues/components/queueStateTabs.tsx
@@ -40,7 +40,7 @@ export default function QueueStateTabs({
         onValueChange={handleValueChange}
         aria-label="Queue state filter"
       >
-        {states.map((state, idx) => (
+        {states.map((state) => (
           <QueueTab
             key={state.key}
             value={state.key}

--- a/app/modules/queues/components/queueTypeTabs.tsx
+++ b/app/modules/queues/components/queueTypeTabs.tsx
@@ -37,7 +37,7 @@ export default function QueueTypeTabs({ queues }: QueueTypeTabsProps) {
         onValueChange={handleValueChange}
         aria-label="Queue type selection"
       >
-        {queues.map((queue, idx) => (
+        {queues.map((queue) => (
           <QueueTab
             key={queue.key}
             value={queue.key}

--- a/app/modules/queues/containers/queue.route.tsx
+++ b/app/modules/queues/containers/queue.route.tsx
@@ -98,7 +98,6 @@ export default function QueueRoute() {
           <QueueStateTabs queueType={queueType} states={states} />
 
           <QueueControls
-            queueType={queueType}
             onPauseResume={handlePauseResume}
             isPaused={data.isPaused}
           />

--- a/app/modules/runSets/containers/runSetCreate.route.tsx
+++ b/app/modules/runSets/containers/runSetCreate.route.tsx
@@ -184,7 +184,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return { project, prefillData };
 }
 
-export async function action({ request, params, context }: Route.ActionArgs) {
+export async function action({ request, params }: Route.ActionArgs) {
   const user = (await getSessionUser({ request })) as User;
   if (!user) {
     return redirect("/");

--- a/app/modules/runSets/helpers/getRunSetsItemActions.tsx
+++ b/app/modules/runSets/helpers/getRunSetsItemActions.tsx
@@ -2,7 +2,7 @@ import type { CollectionItemAction } from "@/components/ui/collectionContentItem
 import { Copy, Edit, FileInput, Trash2 } from "lucide-react";
 import type { RunSet } from "../runSets.types";
 
-export default (item: RunSet): CollectionItemAction[] => {
+export default (_item: RunSet): CollectionItemAction[] => {
   return [
     {
       action: "EDIT",

--- a/app/modules/runs/__tests__/createRunAnnotations.test.ts
+++ b/app/modules/runs/__tests__/createRunAnnotations.test.ts
@@ -120,7 +120,7 @@ describe("createRunAnnotations", () => {
       team: team._id,
     });
 
-    const promptVersion = await PromptVersionService.create({
+    await PromptVersionService.create({
       name: "Version 1",
       prompt: prompt._id,
       version: 1,

--- a/app/modules/runs/__tests__/run.route.test.ts
+++ b/app/modules/runs/__tests__/run.route.test.ts
@@ -23,7 +23,7 @@ vi.mock("~/modules/runs/helpers/buildRunSessions.server", () => ({
 }));
 
 vi.mock("~/modules/runs/services/buildRunSnapshot.server", () => ({
-  default: vi.fn(async ({ promptId, promptVersionNumber, modelCode }: any) => ({
+  default: vi.fn(async ({ promptVersionNumber, modelCode }: any) => ({
     prompt: {
       name: "Mock Prompt",
       userPrompt: "Mock",

--- a/app/modules/runs/containers/createRun.route.tsx
+++ b/app/modules/runs/containers/createRun.route.tsx
@@ -37,7 +37,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return { project, initialRun, duplicateWarnings };
 }
 
-export async function action({ request, params, context }: Route.ActionArgs) {
+export async function action({ request, params }: Route.ActionArgs) {
   const { intent, payload = {} } = await request.json();
 
   const { name, annotationType, prompt, promptVersion, model, sessions } =

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -120,7 +120,7 @@ export default function ProjectRunRoute() {
   const submit = useSubmit();
   const fetcher = useFetcher();
   const navigate = useNavigate();
-  const { revalidate, state } = useRevalidator();
+  const { revalidate } = useRevalidator();
 
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data) {

--- a/app/modules/runs/containers/runs.route.tsx
+++ b/app/modules/runs/containers/runs.route.tsx
@@ -209,7 +209,7 @@ export default function ProjectRunsRoute() {
         status: "FINISHED",
       },
     ],
-    callback: (payload) => {
+    callback: () => {
       revalidate();
     },
   });

--- a/app/modules/runs/containers/runsList.route.tsx
+++ b/app/modules/runs/containers/runsList.route.tsx
@@ -5,7 +5,7 @@ import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "../run";
 import type { Route } from "./+types/runsList.route";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const projectId = url.searchParams.get("project");
 

--- a/app/modules/sessions/__tests__/sessionsList.route.test.ts
+++ b/app/modules/sessions/__tests__/sessionsList.route.test.ts
@@ -140,7 +140,7 @@ describe("sessionsList.route loader", () => {
 
   it("redirects when not project owner", async () => {
     const team = await TeamService.create({ name: "team 1" });
-    const project = await ProjectService.create({
+    await ProjectService.create({
       name: "project 1",
       team: team._id,
     });

--- a/app/modules/sessions/containers/sessions.route.tsx
+++ b/app/modules/sessions/containers/sessions.route.tsx
@@ -50,7 +50,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return { sessions, project };
 }
 
-export async function action({ request, params, context }: Route.ActionArgs) {
+export async function action({ request, params }: Route.ActionArgs) {
   const { intent } = await request.json();
 
   switch (intent) {

--- a/app/modules/support/components/supportArticleDetail.tsx
+++ b/app/modules/support/components/supportArticleDetail.tsx
@@ -2,10 +2,8 @@ import type { SupportArticle } from "../support.types";
 
 export default function SupportArticleDetail({
   article,
-  onBackToSupportArticlesClicked,
 }: {
   article: SupportArticle;
-  onBackToSupportArticlesClicked: () => void;
 }) {
   return (
     <div className="px-4">

--- a/app/modules/support/components/supportArticleList.tsx
+++ b/app/modules/support/components/supportArticleList.tsx
@@ -5,11 +5,9 @@ import type { SupportArticle } from "../support.types";
 export default function SupportArticleList({
   supportArticles,
   onSupportArticleClicked,
-  onSearchClicked,
 }: {
   supportArticles: SupportArticle[];
   onSupportArticleClicked: (selectedDocumentId: string) => void;
-  onSearchClicked: () => void;
 }) {
   return (
     <div className="px-4">

--- a/app/modules/support/components/supportArticles.tsx
+++ b/app/modules/support/components/supportArticles.tsx
@@ -36,15 +36,11 @@ export default function SupportArticles({
           </div>
         )}
         {selectedDocumentId ? (
-          <SupportArticleDetail
-            article={selectedSupportArticle!}
-            onBackToSupportArticlesClicked={onBackToSupportArticlesClicked}
-          />
+          <SupportArticleDetail article={selectedSupportArticle!} />
         ) : (
           <SupportArticleList
             supportArticles={supportArticles}
             onSupportArticleClicked={onSupportArticleClicked}
-            onSearchClicked={onSearchClicked}
           />
         )}
       </div>

--- a/app/modules/teams/__tests__/teamUsers.route.test.ts
+++ b/app/modules/teams/__tests__/teamUsers.route.test.ts
@@ -57,13 +57,13 @@ describe("teamUsers.route", () => {
         githubId: 1,
       });
 
-      const user1 = await UserService.create({
+      await UserService.create({
         username: "user1",
         githubId: 2,
         teams: [{ team: team._id, role: "ADMIN" }],
       });
 
-      const user2 = await UserService.create({
+      await UserService.create({
         username: "user2",
         githubId: 3,
         teams: [{ team: team._id, role: "ADMIN" }],

--- a/app/modules/teams/__tests__/teams.route.test.ts
+++ b/app/modules/teams/__tests__/teams.route.test.ts
@@ -46,8 +46,8 @@ describe("teams.route", () => {
 
     it("returns only user's teams for regular user", async () => {
       const team1 = await TeamService.create({ name: "team 1" });
-      const team2 = await TeamService.create({ name: "team 2" });
-      const team3 = await TeamService.create({ name: "team 3" });
+      await TeamService.create({ name: "team 2" });
+      await TeamService.create({ name: "team 3" });
 
       const user = await UserService.create({
         username: "user1",

--- a/app/modules/teams/components/teamProjects.tsx
+++ b/app/modules/teams/components/teamProjects.tsx
@@ -23,7 +23,6 @@ interface TeamProjectsProps {
   onPaginationChanged: (currentPage: number) => void;
   onFiltersValueChanged: (filterValue: any) => void;
   onSortValueChanged: (sortValue: any) => void;
-  onCreateProjectButtonClicked: () => void;
 }
 
 export default function TeamProjects({
@@ -35,7 +34,6 @@ export default function TeamProjects({
   currentPage,
   totalPages,
   isSyncing,
-  onCreateProjectButtonClicked,
   onActionClicked,
   onItemActionClicked,
   onSearchValueChanged,
@@ -58,6 +56,7 @@ export default function TeamProjects({
         searchValue={searchValue}
         currentPage={currentPage}
         totalPages={totalPages}
+        isSyncing={isSyncing}
         emptyAttributes={getTeamProjectsEmptyAttributes()}
         getItemAttributes={(item) =>
           getTeamProjectsItemAttributes(item, team._id)

--- a/app/modules/teams/containers/availableTeams.route.tsx
+++ b/app/modules/teams/containers/availableTeams.route.tsx
@@ -4,7 +4,7 @@ import type { User } from "~/modules/users/users.types";
 import { TeamService } from "../team";
 import type { Route } from "./+types/availableTeams.route";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   const userSession = (await getSessionUser({ request })) as User;
 
   if (!userSession) {

--- a/app/modules/teams/containers/generateInviteToTeam.route.tsx
+++ b/app/modules/teams/containers/generateInviteToTeam.route.tsx
@@ -5,8 +5,8 @@ import type { User } from "~/modules/users/users.types";
 import TeamAuthorization from "../authorization";
 import type { Route } from "./+types/generateInviteToTeam.route";
 
-export async function action({ request, params }: Route.ActionArgs) {
-  const { intent, entityId, payload = {} } = await request.json();
+export async function action({ request }: Route.ActionArgs) {
+  const { intent, payload = {} } = await request.json();
 
   const { teamId, role, username } = payload;
 

--- a/app/modules/teams/containers/teamProjects.route.tsx
+++ b/app/modules/teams/containers/teamProjects.route.tsx
@@ -136,7 +136,7 @@ export default function TeamProjectsRoute() {
 
   const onItemActionClicked = ({
     id,
-    action,
+    action: _action,
   }: {
     id: string;
     action: string;
@@ -179,7 +179,6 @@ export default function TeamProjectsRoute() {
       onPaginationChanged={onPaginationChanged}
       onFiltersValueChanged={onFiltersValueChanged}
       onSortValueChanged={onSortValueChanged}
-      onCreateProjectButtonClicked={onCreateProjectButtonClicked}
     />
   );
 }

--- a/app/modules/teams/containers/teamPrompts.route.tsx
+++ b/app/modules/teams/containers/teamPrompts.route.tsx
@@ -6,7 +6,6 @@ import {
   useLoaderData,
   useNavigate,
   useOutletContext,
-  useParams,
   useSubmit,
 } from "react-router";
 import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
@@ -121,7 +120,6 @@ export async function action({ request, params }: Route.ActionArgs) {
 
 export default function TeamPromptsRoute() {
   const data = useLoaderData<typeof loader>();
-  const params = useParams();
   const ctx = useOutletContext<any>();
   const actionData = useActionData();
   const submit = useSubmit();
@@ -185,7 +183,7 @@ export default function TeamPromptsRoute() {
 
   const onItemActionClicked = ({
     id,
-    action,
+    action: _action,
   }: {
     id: string;
     action: string;

--- a/app/modules/teams/containers/teamUsers.route.tsx
+++ b/app/modules/teams/containers/teamUsers.route.tsx
@@ -3,7 +3,6 @@ import {
   redirect,
   useLoaderData,
   useOutletContext,
-  useParams,
   useSubmit,
 } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
@@ -104,7 +103,6 @@ export async function action({ request, params }: Route.ActionArgs) {
 
 export default function TeamUsersRoute() {
   const data = useLoaderData<typeof loader>();
-  const params = useParams();
   const ctx = useOutletContext<any>();
   const submit = useSubmit();
 

--- a/app/modules/teams/helpers/getAddUserToTeamDialogItemActions.tsx
+++ b/app/modules/teams/helpers/getAddUserToTeamDialogItemActions.tsx
@@ -1,6 +1,6 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 import type { User } from "~/modules/users/users.types";
 
-export default (user: User): CollectionItemAction[] => {
+export default (_user: User): CollectionItemAction[] => {
   return [];
 };

--- a/app/modules/uploads/services/convertFilesToSessions.tsx
+++ b/app/modules/uploads/services/convertFilesToSessions.tsx
@@ -55,7 +55,7 @@ export default async function convertFilesToSessions({
       });
       hasErrored = false;
       hasConverted = true;
-    } catch (error) {
+    } catch {
       hasErrored = true;
       hasConverted = false;
     }

--- a/app/modules/users/__tests__/availableFeatureFlagUsers.route.test.ts
+++ b/app/modules/users/__tests__/availableFeatureFlagUsers.route.test.ts
@@ -100,7 +100,7 @@ describe("availableFeatureFlagUsers.route loader", () => {
     });
 
     // Create a user with the feature flag
-    const userWithFlag = await UserService.create({
+    await UserService.create({
       username: "with_flag",
       isRegistered: true,
       featureFlags: ["beta_feature"],

--- a/app/modules/users/__tests__/availableTeamUsers.route.test.ts
+++ b/app/modules/users/__tests__/availableTeamUsers.route.test.ts
@@ -68,7 +68,7 @@ describe("availableTeamUsers.route loader", () => {
     });
 
     // Create users: some in team, some not
-    const userInTeam = await UserService.create({
+    await UserService.create({
       username: "in_team",
       role: "USER",
       githubId: 100001,
@@ -120,7 +120,7 @@ describe("availableTeamUsers.route loader", () => {
     });
 
     // Create an unregistered user
-    const unregisteredUser = await UserService.create({
+    await UserService.create({
       username: "unregistered",
       role: "USER",
       githubId: 100002,

--- a/app/modules/users/components/adminUsers.tsx
+++ b/app/modules/users/components/adminUsers.tsx
@@ -24,6 +24,7 @@ interface AdminUsersProps {
   sortValue: string;
   filtersValues: Record<string, any>;
   isSyncing?: boolean;
+  isAuditSyncing?: boolean;
   onItemActionClicked: ({ id, action }: { id: string; action: string }) => void;
   onSearchValueChanged: (searchValue: string) => void;
   onPaginationChanged: (currentPage: number) => void;
@@ -49,6 +50,7 @@ export default function AdminUsers({
   sortValue,
   filtersValues,
   isSyncing,
+  isAuditSyncing,
   onItemActionClicked,
   onSearchValueChanged,
   onPaginationChanged,
@@ -58,10 +60,6 @@ export default function AdminUsers({
   onAuditPageChanged,
   onAuditSortChanged,
 }: AdminUsersProps) {
-  const onActionClicked = (action: string) => {
-    // No collection-level actions
-  };
-
   return (
     <div className="max-w-6xl p-8">
       <PageHeader>
@@ -93,7 +91,7 @@ export default function AdminUsers({
             getItemActions={(item) =>
               getUserManagementItemActions(item, currentUser)
             }
-            onActionClicked={onActionClicked}
+            onActionClicked={() => {}}
             onItemActionClicked={onItemActionClicked}
             onSearchValueChanged={onSearchValueChanged}
             onPaginationChanged={onPaginationChanged}
@@ -112,6 +110,7 @@ export default function AdminUsers({
             sortValue={auditSortValue}
             currentPage={auditCurrentPage}
             totalPages={auditTotalPages}
+            isSyncing={isAuditSyncing}
             onSearchValueChanged={onAuditSearchChanged}
             onPaginationChanged={onAuditPageChanged}
             onSortValueChanged={onAuditSortChanged}

--- a/app/modules/users/components/auditLog.tsx
+++ b/app/modules/users/components/auditLog.tsx
@@ -8,6 +8,7 @@ interface AuditLogProps {
   sortValue: string;
   currentPage: number;
   totalPages: number;
+  isSyncing?: boolean;
   onSearchValueChanged: (searchValue: string) => void;
   onPaginationChanged: (page: number) => void;
   onSortValueChanged: (sortValue: string) => void;
@@ -19,6 +20,7 @@ export default function AuditLog({
   sortValue,
   currentPage,
   totalPages,
+  isSyncing,
   onSearchValueChanged,
   onPaginationChanged,
   onSortValueChanged,
@@ -37,6 +39,7 @@ export default function AuditLog({
       hasPagination
       currentPage={currentPage}
       totalPages={totalPages}
+      isSyncing={isSyncing}
       emptyAttributes={{
         title: "No audit records",
         description: searchValue

--- a/app/modules/users/containers/adminUsers.route.tsx
+++ b/app/modules/users/containers/adminUsers.route.tsx
@@ -326,6 +326,7 @@ export default function UserManagementRoute({
       sortValue={sortValue}
       filtersValues={filtersValues}
       isSyncing={isSyncing}
+      isAuditSyncing={isAuditSyncing}
       onItemActionClicked={onItemActionClicked}
       onSearchValueChanged={setSearchValue}
       onPaginationChanged={setCurrentPage}

--- a/app/storageAdapters/awsS3/index.ts
+++ b/app/storageAdapters/awsS3/index.ts
@@ -86,7 +86,7 @@ registerStorageAdapter({
     }
   },
   upload: async ({ file, uploadPath }: UploadParams): Promise<void> => {
-    const { buffer, contentType, size } = file;
+    const { buffer, contentType } = file;
 
     const s3Client = getS3Client();
 

--- a/app/storageAdapters/local/index.ts
+++ b/app/storageAdapters/local/index.ts
@@ -45,7 +45,7 @@ registerStorageAdapter({
     const absolutePath = path.resolve(PROJECT_ROOT, sourcePath);
     await fse.remove(absolutePath);
   },
-  request: ({ url, options }: RequestParams): Promise<unknown> => {
+  request: ({ url }: RequestParams): Promise<unknown> => {
     return new Promise((resolve) => {
       resolve(`/${url}`);
     });

--- a/app/uikit/components/ui/filters.tsx
+++ b/app/uikit/components/ui/filters.tsx
@@ -51,7 +51,7 @@ const Filters = ({
             </p>
           </div>
           <div className="grid gap-8">
-            {map(filters, (filter, index) => {
+            {map(filters, (filter) => {
               return (
                 <FiltersItem
                   key={filter.category}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,14 @@ export default defineConfig([
     rules: {
       // TODO: enable these incrementally as violations are fixed
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
     },
   },
   {

--- a/sockets.ts
+++ b/sockets.ts
@@ -44,7 +44,7 @@ export function setupSockets({ server, app }: { server: any; app: any }) {
       }
       (socket as AuthenticatedSocket).user = user;
       next();
-    } catch (error) {
+    } catch {
       return next(
         new Error("Authentication error: Session could not be parsed"),
       );

--- a/test/vitest.globalSetup.ts
+++ b/test/vitest.globalSetup.ts
@@ -2,7 +2,7 @@ import * as dotenv from "dotenv";
 import fse from "fs-extra";
 import type { TestProject } from "vitest/node";
 
-export default async function setup(project: TestProject) {
+export default async function setup(_project: TestProject) {
   dotenv.config({ path: [".env.test", ".env.ci"] });
   if (process.env.DATA_PATH) fse.mkdirpSync(process.env.DATA_PATH);
 }

--- a/workers/general/__tests__/runMigration.test.ts
+++ b/workers/general/__tests__/runMigration.test.ts
@@ -47,8 +47,6 @@ describe("runMigration worker", () => {
   });
 
   it("creates and updates migration run records", async () => {
-    const { default: emitFromJob } = await import("../../helpers/emitFromJob");
-
     const user = await UserService.create({
       username: "test_user",
       role: "SUPER_ADMIN",

--- a/workers/tasks/annotatePerSession.ts
+++ b/workers/tasks/annotatePerSession.ts
@@ -12,16 +12,8 @@ import updateRunSession from "../helpers/updateRunSession";
 import annotationPerSessionPrompts from "../prompts/annotatePerSession.prompts.json";
 
 export default async function annotatePerSession(job: any) {
-  const {
-    projectId,
-    runId,
-    sessionId,
-    inputFile,
-    outputFolder,
-    prompt,
-    model,
-    team,
-  } = job.data;
+  const { runId, sessionId, inputFile, outputFolder, prompt, model, team } =
+    job.data;
 
   try {
     await updateRunSession({

--- a/workers/tasks/convertFileToSession.ts
+++ b/workers/tasks/convertFileToSession.ts
@@ -8,14 +8,8 @@ import emitFromJob from "../helpers/emitFromJob";
 dotenv.config({ path: ".env" });
 
 export default async function convertFileToSession(job: any) {
-  const {
-    projectId,
-    sessionId,
-    inputFile,
-    outputFolder,
-    team,
-    attributesMapping,
-  } = job.data;
+  const { projectId, sessionId, inputFile, outputFolder, attributesMapping } =
+    job.data;
 
   try {
     await emitFromJob(


### PR DESCRIPTION
Enable @typescript-eslint/no-unused-vars rule and resolve 61 errors:
- Remove unused variables, imports, and destructured params
- Wire up isSyncing to Collection components for loading feedback
- Wire up isSubmitting to addUsersToFeatureFlagDialog button
- Wire up isAuditSyncing through adminUsers → auditLog chain
- Remove dead ORCID login feature (unused)
- Remove unused queueType and supportArticle callback props
- Prefix callback signature params with _ where interface consistency needed
- Add eslint-disable for framework-imposed signatures (entry.server, route stubs)