### PR TITLE
Fix all react-refresh/only-export-components warnings

### DIFF
--- a/app/modules/dialogs/addDialog.tsx
+++ b/app/modules/dialogs/addDialog.tsx
@@ -9,6 +9,6 @@ export const setDispatch = (dispatch: Dispatch<ModalAction>) => {
   addModalDispatch = dispatch;
 };
 
-export default (component: ReactNode) => {
+export default function addDialog(component: ReactNode) {
   addModalDispatch?.({ type: "ADD", modal: { component } });
-};
+}

--- a/app/modules/projects/components/projects.tsx
+++ b/app/modules/projects/components/projects.tsx
@@ -2,6 +2,7 @@ import { Collection } from "@/components/ui/collection";
 import { PageHeader, PageHeaderLeft } from "@/components/ui/pageHeader";
 import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
+import type { User } from "~/modules/users/users.types";
 import getProjectsEmptyAttributes from "../helpers/getProjectsEmptyAttributes";
 import getProjectsItemActions from "../helpers/getProjectsItemActions";
 import getProjectsItemAttributes from "../helpers/getProjectsItemAttributes";
@@ -12,6 +13,7 @@ import type { Project } from "../projects.types";
 
 interface ProjectsProps {
   projects: Project[];
+  user: User;
   searchValue: string;
   currentPage: number;
   totalPages: number;
@@ -29,6 +31,7 @@ interface ProjectsProps {
 
 export default function Projects({
   projects,
+  user,
   searchValue,
   currentPage,
   totalPages,
@@ -66,7 +69,7 @@ export default function Projects({
         isSyncing={isSyncing}
         emptyAttributes={getProjectsEmptyAttributes()}
         getItemAttributes={getProjectsItemAttributes}
-        getItemActions={getProjectsItemActions}
+        getItemActions={(item) => getProjectsItemActions(item, user)}
         onActionClicked={onActionClicked}
         onItemActionClicked={onItemActionClicked}
         onSearchValueChanged={onSearchValueChanged}

--- a/app/modules/projects/containers/projects.route.tsx
+++ b/app/modules/projects/containers/projects.route.tsx
@@ -1,12 +1,14 @@
 import escapeRegExp from "lodash/escapeRegExp";
 import find from "lodash/find";
 import map from "lodash/map";
+import { useContext } from "react";
 import { data, redirect, useNavigate, useRevalidator } from "react-router";
 import { toast } from "sonner";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
+import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
 import addDialog from "~/modules/dialogs/addDialog";
@@ -177,6 +179,7 @@ export function HydrateFallback() {
 
 export default function ProjectsRoute({ loaderData }: Route.ComponentProps) {
   const { projects } = loaderData;
+  const user = useContext(AuthenticationContext) as User;
   const navigate = useNavigate();
   const { revalidate } = useRevalidator();
 
@@ -266,6 +269,7 @@ export default function ProjectsRoute({ loaderData }: Route.ComponentProps) {
   return (
     <Projects
       projects={projects?.data}
+      user={user}
       searchValue={searchValue}
       currentPage={currentPage}
       totalPages={projects.totalPages}

--- a/app/modules/projects/helpers/getProjectsEmptyAttributes.tsx
+++ b/app/modules/projects/helpers/getProjectsEmptyAttributes.tsx
@@ -1,6 +1,6 @@
 import { Folder } from "lucide-react";
 
-export default () => {
+export default function getProjectsEmptyAttributes() {
   return {
     icon: <Folder />,
     title: "No Projects yet",
@@ -13,4 +13,4 @@ export default () => {
       },
     ],
   };
-};
+}

--- a/app/modules/projects/helpers/getProjectsItemActions.tsx
+++ b/app/modules/projects/helpers/getProjectsItemActions.tsx
@@ -1,13 +1,13 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 import { Edit, Trash2 } from "lucide-react";
-import { useContext } from "react";
-import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import type { User } from "~/modules/users/users.types";
 import ProjectAuthorization from "../authorization";
 import type { Project } from "../projects.types";
 
-export default (item: Project): CollectionItemAction[] => {
-  const user = useContext(AuthenticationContext) as User;
+export default function getProjectsItemActions(
+  item: Project,
+  user: User,
+): CollectionItemAction[] {
   const canUpdate = ProjectAuthorization.canUpdate(user, item);
   const canDelete = ProjectAuthorization.canDelete(user, item);
 
@@ -31,4 +31,4 @@ export default (item: Project): CollectionItemAction[] => {
   }
 
   return actions;
-};
+}

--- a/app/modules/projects/helpers/getProjectsItemAttributes.tsx
+++ b/app/modules/projects/helpers/getProjectsItemAttributes.tsx
@@ -3,7 +3,7 @@ import { Users } from "lucide-react";
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { Project } from "../projects.types";
 
-export default (item: Project) => {
+export default function getProjectsItemAttributes(item: Project) {
   const teamName = get(item, "team.name", "");
 
   return {
@@ -20,4 +20,4 @@ export default (item: Project) => {
       },
     ],
   };
-};
+}

--- a/app/modules/prompts/components/prompts.tsx
+++ b/app/modules/prompts/components/prompts.tsx
@@ -2,6 +2,7 @@ import { Collection } from "@/components/ui/collection";
 import { PageHeader, PageHeaderLeft } from "@/components/ui/pageHeader";
 import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
+import type { User } from "~/modules/users/users.types";
 import getPromptsEmptyAttributes from "../helpers/getPromptsEmptyAttributes";
 import getPromptsItemActions from "../helpers/getPromptsItemActions";
 import getPromptsItemAttributes from "../helpers/getPromptsItemAttributes";
@@ -12,6 +13,7 @@ import type { Prompt } from "../prompts.types";
 
 interface PromptsProps {
   prompts: Prompt[];
+  user: User;
   breadcrumbs: Breadcrumb[];
   searchValue: string;
   currentPage: number;
@@ -29,6 +31,7 @@ interface PromptsProps {
 
 export default function Prompts({
   prompts,
+  user,
   breadcrumbs,
   filtersValues,
   sortValue,
@@ -66,7 +69,7 @@ export default function Prompts({
         isSyncing={isSyncing}
         emptyAttributes={getPromptsEmptyAttributes()}
         getItemAttributes={getPromptsItemAttributes}
-        getItemActions={getPromptsItemActions}
+        getItemActions={(item) => getPromptsItemActions(item, user)}
         onActionClicked={onActionClicked}
         onItemActionClicked={onItemActionClicked}
         onSearchValueChanged={onSearchValueChanged}

--- a/app/modules/prompts/containers/prompts.route.tsx
+++ b/app/modules/prompts/containers/prompts.route.tsx
@@ -1,12 +1,13 @@
 import find from "lodash/find";
 import map from "lodash/map";
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { data, redirect, useFetcher, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
+import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
 import addDialog from "~/modules/dialogs/addDialog";
@@ -209,6 +210,7 @@ export function HydrateFallback() {
 
 export default function PromptsRoute({ loaderData }: Route.ComponentProps) {
   const { prompts } = loaderData;
+  const user = useContext(AuthenticationContext) as User;
   const fetcher = useFetcher();
   const navigate = useNavigate();
 
@@ -368,6 +370,7 @@ export default function PromptsRoute({ loaderData }: Route.ComponentProps) {
   return (
     <Prompts
       prompts={prompts?.data}
+      user={user}
       breadcrumbs={breadcrumbs}
       searchValue={searchValue}
       currentPage={currentPage}

--- a/app/modules/prompts/helpers/getPromptsEmptyAttributes.tsx
+++ b/app/modules/prompts/helpers/getPromptsEmptyAttributes.tsx
@@ -1,6 +1,6 @@
 import { ClipboardList } from "lucide-react";
 
-export default () => {
+export default function getPromptsEmptyAttributes() {
   return {
     icon: <ClipboardList />,
     title: "No Prompts yet",
@@ -13,4 +13,4 @@ export default () => {
       },
     ],
   };
-};
+}

--- a/app/modules/prompts/helpers/getPromptsItemActions.tsx
+++ b/app/modules/prompts/helpers/getPromptsItemActions.tsx
@@ -1,13 +1,13 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 import { Edit, Trash2 } from "lucide-react";
-import { useContext } from "react";
-import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import type { User } from "~/modules/users/users.types";
 import PromptAuthorization from "../authorization";
 import type { Prompt } from "../prompts.types";
 
-export default (item: Prompt): CollectionItemAction[] => {
-  const user = useContext(AuthenticationContext) as User;
+export default function getPromptsItemActions(
+  item: Prompt,
+  user: User,
+): CollectionItemAction[] {
   const canUpdate = PromptAuthorization.canUpdate(user, item);
   const canDelete = PromptAuthorization.canDelete(user, item);
 
@@ -31,4 +31,4 @@ export default (item: Prompt): CollectionItemAction[] => {
   }
 
   return actions;
-};
+}

--- a/app/modules/prompts/helpers/getPromptsItemAttributes.tsx
+++ b/app/modules/prompts/helpers/getPromptsItemAttributes.tsx
@@ -4,7 +4,7 @@ import { getAnnotationLabel } from "~/modules/annotations/helpers/annotationType
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { Prompt } from "../prompts.types";
 
-export default (item: Prompt) => {
+export default function getPromptsItemAttributes(item: Prompt) {
   const teamName = get(item, "team.name", "");
 
   return {
@@ -24,4 +24,4 @@ export default (item: Prompt) => {
       },
     ],
   };
-};
+}

--- a/app/modules/runSets/helpers/getEvaluationsEmptyAttributes.tsx
+++ b/app/modules/runSets/helpers/getEvaluationsEmptyAttributes.tsx
@@ -1,6 +1,6 @@
 import { ClipboardList } from "lucide-react";
 
-export default () => {
+export default function getEvaluationsEmptyAttributes() {
   return {
     icon: <ClipboardList />,
     title: "No evaluations found",
@@ -12,4 +12,4 @@ export default () => {
       },
     ],
   };
-};
+}

--- a/app/modules/runSets/helpers/getEvaluationsItemAttributes.tsx
+++ b/app/modules/runSets/helpers/getEvaluationsItemAttributes.tsx
@@ -2,7 +2,7 @@ import { Play } from "lucide-react";
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { Evaluation } from "~/modules/evaluations/evaluations.types";
 
-export default (item: Evaluation) => {
+export default function getEvaluationsItemAttributes(item: Evaluation) {
   const runCount = item.runs?.length || 0;
 
   return {
@@ -19,4 +19,4 @@ export default (item: Evaluation) => {
       },
     ],
   };
-};
+}

--- a/app/modules/runSets/helpers/getRunSetsEmptyAttributes.tsx
+++ b/app/modules/runSets/helpers/getRunSetsEmptyAttributes.tsx
@@ -1,6 +1,6 @@
 import { FolderOpen } from "lucide-react";
 
-export default () => {
+export default function getRunSetsEmptyAttributes() {
   return {
     icon: <FolderOpen />,
     title: "No run sets yet",
@@ -13,4 +13,4 @@ export default () => {
       },
     ],
   };
-};
+}

--- a/app/modules/runSets/helpers/getRunSetsItemActions.tsx
+++ b/app/modules/runSets/helpers/getRunSetsItemActions.tsx
@@ -2,7 +2,9 @@ import type { CollectionItemAction } from "@/components/ui/collectionContentItem
 import { Copy, Edit, FileInput, Trash2 } from "lucide-react";
 import type { RunSet } from "../runSets.types";
 
-export default (_item: RunSet): CollectionItemAction[] => {
+export default function getRunSetsItemActions(
+  _item: RunSet,
+): CollectionItemAction[] {
   return [
     {
       action: "EDIT",
@@ -25,4 +27,4 @@ export default (_item: RunSet): CollectionItemAction[] => {
       text: "Delete",
     },
   ];
-};
+}

--- a/app/modules/runSets/helpers/getRunSetsItemAttributes.tsx
+++ b/app/modules/runSets/helpers/getRunSetsItemAttributes.tsx
@@ -2,7 +2,7 @@ import { Zap } from "lucide-react";
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { RunSet } from "../runSets.types";
 
-export default (item: RunSet) => {
+export default function getRunSetsItemAttributes(item: RunSet) {
   const runCount = item.runs?.length || 0;
 
   return {
@@ -19,4 +19,4 @@ export default (item: RunSet) => {
       },
     ],
   };
-};
+}

--- a/app/modules/runs/helpers/getRunsEmptyAttributes.tsx
+++ b/app/modules/runs/helpers/getRunsEmptyAttributes.tsx
@@ -1,6 +1,6 @@
 import { Play } from "lucide-react";
 
-export default () => {
+export default function getRunsEmptyAttributes() {
   return {
     icon: <Play />,
     title: "No Runs yet",
@@ -13,4 +13,4 @@ export default () => {
       },
     ],
   };
-};
+}

--- a/app/modules/runs/helpers/getRunsItemAttributes.tsx
+++ b/app/modules/runs/helpers/getRunsItemAttributes.tsx
@@ -34,7 +34,7 @@ function getStatusMeta(item: Run) {
   };
 }
 
-export default (item: Run, options?: Options) => {
+export default function getRunsItemAttributes(item: Run, options?: Options) {
   const promptName = get(item, "snapshot.prompt.name", "");
 
   const meta = [
@@ -68,4 +68,4 @@ export default (item: Run, options?: Options) => {
     to,
     meta: meta,
   };
-};
+}

--- a/app/modules/sessions/helpers/getSessionsActions.tsx
+++ b/app/modules/sessions/helpers/getSessionsActions.tsx
@@ -1,6 +1,6 @@
 import type { Project } from "~/modules/projects/projects.types";
 
-export default (project: Project) => {
+export default function getSessionsActions(project: Project) {
   const actions = [];
 
   if (project.hasErrored && !project.isConvertingFiles) {
@@ -11,4 +11,4 @@ export default (project: Project) => {
   }
 
   return actions;
-};
+}

--- a/app/modules/sessions/helpers/getSessionsEmptyAttributes.tsx
+++ b/app/modules/sessions/helpers/getSessionsEmptyAttributes.tsx
@@ -1,10 +1,10 @@
 import { FileText } from "lucide-react";
 
-export default () => {
+export default function getSessionsEmptyAttributes() {
   return {
     icon: <FileText />,
     title: "No Sessions yet",
     description: "No sessions have been created for this project.",
     actions: [],
   };
-};
+}

--- a/app/modules/sessions/helpers/getSessionsItemActions.tsx
+++ b/app/modules/sessions/helpers/getSessionsItemActions.tsx
@@ -1,5 +1,5 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 
-export default (): CollectionItemAction[] => {
+export default function getSessionsItemActions(): CollectionItemAction[] {
   return [];
-};
+}

--- a/app/modules/sessions/helpers/getSessionsItemAttributes.tsx
+++ b/app/modules/sessions/helpers/getSessionsItemAttributes.tsx
@@ -1,7 +1,7 @@
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { Session } from "~/modules/sessions/sessions.types";
 
-export default (item: Session) => {
+export default function getSessionsItemAttributes(item: Session) {
   const status =
     item.hasConverted === true
       ? "Converted"
@@ -26,4 +26,4 @@ export default (item: Session) => {
       },
     ],
   };
-};
+}

--- a/app/modules/teams/components/teamProjects.tsx
+++ b/app/modules/teams/components/teamProjects.tsx
@@ -1,5 +1,6 @@
 import { Collection } from "@/components/ui/collection";
 import type { Project } from "~/modules/projects/projects.types";
+import type { User } from "~/modules/users/users.types";
 import getTeamProjectsActions from "../helpers/getTeamProjectsActions";
 import getTeamProjectsEmptyAttributes from "../helpers/getTeamProjectsEmptyAttributes";
 import getTeamProjectsItemActions from "../helpers/getTeamProjectsItemActions";
@@ -11,6 +12,7 @@ import type { Team } from "../teams.types";
 interface TeamProjectsProps {
   projects: Project[];
   team: Team;
+  user: User;
   searchValue: string;
   currentPage: number;
   totalPages: number;
@@ -28,6 +30,7 @@ interface TeamProjectsProps {
 export default function TeamProjects({
   projects,
   team,
+  user,
   filtersValues,
   sortValue,
   searchValue,
@@ -46,7 +49,7 @@ export default function TeamProjects({
       <Collection
         items={projects}
         itemsLayout="list"
-        actions={getTeamProjectsActions(team._id)}
+        actions={getTeamProjectsActions(user, team._id)}
         filters={teamProjectsFilters}
         sortOptions={teamProjectsSortOptions}
         hasSearch
@@ -59,7 +62,7 @@ export default function TeamProjects({
         isSyncing={isSyncing}
         emptyAttributes={getTeamProjectsEmptyAttributes()}
         getItemAttributes={(item) =>
-          getTeamProjectsItemAttributes(item, team._id)
+          getTeamProjectsItemAttributes(item, team._id, user)
         }
         getItemActions={getTeamProjectsItemActions}
         onActionClicked={onActionClicked}

--- a/app/modules/teams/components/teamUsers.tsx
+++ b/app/modules/teams/components/teamUsers.tsx
@@ -11,6 +11,7 @@ import type { Team } from "../teams.types";
 interface TeamUsersProps {
   users: User[];
   team: Team;
+  user: User;
   searchValue: string;
   currentPage: number;
   totalPages: number;
@@ -28,6 +29,7 @@ interface TeamUsersProps {
 export default function TeamUsers({
   users,
   team,
+  user,
   filtersValues,
   sortValue,
   searchValue,
@@ -46,7 +48,7 @@ export default function TeamUsers({
       <Collection
         items={users}
         itemsLayout="list"
-        actions={getTeamUsersActions(team._id)}
+        actions={getTeamUsersActions(user, team._id)}
         filters={teamUsersFilters}
         sortOptions={teamUsersSortOptions}
         hasSearch
@@ -59,7 +61,7 @@ export default function TeamUsers({
         emptyAttributes={getTeamUsersEmptyAttributes()}
         isSyncing={isSyncing}
         getItemAttributes={(item) => getTeamUsersItemAttributes(item, team)}
-        getItemActions={(item) => getTeamUsersItemActions(item, team._id)}
+        getItemActions={(item) => getTeamUsersItemActions(item, user, team._id)}
         onActionClicked={onActionClicked}
         onItemActionClicked={onItemActionClicked}
         onSearchValueChanged={onSearchValueChanged}

--- a/app/modules/teams/components/teams.tsx
+++ b/app/modules/teams/components/teams.tsx
@@ -2,6 +2,7 @@ import { Collection } from "@/components/ui/collection";
 import { PageHeader, PageHeaderLeft } from "@/components/ui/pageHeader";
 import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
+import type { User } from "~/modules/users/users.types";
 import getTeamsActions from "../helpers/getTeamsActions";
 import getTeamsEmptyAttributes from "../helpers/getTeamsEmptyAttributes";
 import getTeamsItemActions from "../helpers/getTeamsItemActions";
@@ -12,6 +13,7 @@ import type { Team } from "../teams.types";
 
 interface TeamsProps {
   teams: Team[];
+  user: User;
   breadcrumbs: Breadcrumb[];
   searchValue: string;
   currentPage: number;
@@ -29,6 +31,7 @@ interface TeamsProps {
 
 export default function Teams({
   teams,
+  user,
   breadcrumbs,
   filtersValues,
   sortValue,
@@ -66,7 +69,7 @@ export default function Teams({
         emptyAttributes={getTeamsEmptyAttributes()}
         isSyncing={isSyncing}
         getItemAttributes={getTeamsItemAttributes}
-        getItemActions={getTeamsItemActions}
+        getItemActions={(item) => getTeamsItemActions(item, user)}
         onActionClicked={onActionClicked}
         onItemActionClicked={onItemActionClicked}
         onSearchValueChanged={onSearchValueChanged}

--- a/app/modules/teams/containers/teamProjects.route.tsx
+++ b/app/modules/teams/containers/teamProjects.route.tsx
@@ -1,4 +1,5 @@
 import find from "lodash/find";
+import { useContext } from "react";
 import {
   redirect,
   useLoaderData,
@@ -10,11 +11,13 @@ import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
+import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import addDialog from "~/modules/dialogs/addDialog";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import CreateProjectDialog from "~/modules/projects/components/createProjectDialog";
 import { ProjectService } from "~/modules/projects/project";
+import type { User } from "~/modules/users/users.types";
 import TeamAuthorization from "../authorization";
 import TeamProjects from "../components/teamProjects";
 import type { Route } from "./+types/teamProjects.route";
@@ -97,6 +100,7 @@ export default function TeamProjectsRoute() {
   const params = useParams();
   const ctx = useOutletContext<any>();
   const navigate = useNavigate();
+  const user = useContext(AuthenticationContext) as User;
   const teamId = params.id;
 
   const {
@@ -167,6 +171,7 @@ export default function TeamProjectsRoute() {
     <TeamProjects
       projects={projects}
       team={ctx.team}
+      user={user}
       searchValue={searchValue}
       currentPage={currentPage}
       totalPages={data.projects.totalPages}

--- a/app/modules/teams/containers/teamUsers.route.tsx
+++ b/app/modules/teams/containers/teamUsers.route.tsx
@@ -1,4 +1,5 @@
 import find from "lodash/find";
+import { useContext } from "react";
 import {
   redirect,
   useLoaderData,
@@ -8,6 +9,7 @@ import {
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
+import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import addDialog from "~/modules/dialogs/addDialog";
 import { UserService } from "~/modules/users/user";
@@ -105,6 +107,7 @@ export default function TeamUsersRoute() {
   const data = useLoaderData<typeof loader>();
   const ctx = useOutletContext<any>();
   const submit = useSubmit();
+  const user = useContext(AuthenticationContext) as User;
 
   const {
     searchValue,
@@ -232,6 +235,7 @@ export default function TeamUsersRoute() {
     <TeamUsers
       users={users}
       team={ctx.team}
+      user={user}
       searchValue={searchValue}
       currentPage={currentPage}
       totalPages={data.users.totalPages}

--- a/app/modules/teams/containers/teams.route.tsx
+++ b/app/modules/teams/containers/teams.route.tsx
@@ -1,11 +1,12 @@
 import find from "lodash/find";
 import map from "lodash/map";
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { data, redirect, useFetcher, useNavigate } from "react-router";
 import { toast } from "sonner";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
+import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import addDialog from "~/modules/dialogs/addDialog";
 import type { User } from "~/modules/users/users.types";
@@ -125,6 +126,7 @@ export function HydrateFallback() {
 
 export default function TeamsRoute({ loaderData }: Route.ComponentProps) {
   const { teams } = loaderData;
+  const user = useContext(AuthenticationContext) as User;
   const fetcher = useFetcher();
   const navigate = useNavigate();
 
@@ -236,6 +238,7 @@ export default function TeamsRoute({ loaderData }: Route.ComponentProps) {
   return (
     <Teams
       teams={teams?.data}
+      user={user}
       breadcrumbs={breadcrumbs}
       searchValue={searchValue}
       currentPage={currentPage}

--- a/app/modules/teams/helpers/getAddUserToTeamDialogEmptyAttributes.tsx
+++ b/app/modules/teams/helpers/getAddUserToTeamDialogEmptyAttributes.tsx
@@ -1,10 +1,10 @@
 import { Users } from "lucide-react";
 
-export default () => {
+export default function getAddUserToTeamDialogEmptyAttributes() {
   return {
     icon: <Users />,
     title: "No users available",
     description: "No users available to add to this team",
     actions: [],
   };
-};
+}

--- a/app/modules/teams/helpers/getAddUserToTeamDialogItemActions.tsx
+++ b/app/modules/teams/helpers/getAddUserToTeamDialogItemActions.tsx
@@ -1,6 +1,8 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 import type { User } from "~/modules/users/users.types";
 
-export default (_user: User): CollectionItemAction[] => {
+export default function getAddUserToTeamDialogItemActions(
+  _user: User,
+): CollectionItemAction[] {
   return [];
-};
+}

--- a/app/modules/teams/helpers/getAddUserToTeamDialogItemAttributes.tsx
+++ b/app/modules/teams/helpers/getAddUserToTeamDialogItemAttributes.tsx
@@ -1,8 +1,8 @@
 import type { User } from "~/modules/users/users.types";
 
-export default (user: User) => {
+export default function getAddUserToTeamDialogItemAttributes(user: User) {
   return {
     id: user._id,
     title: user.username,
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamProjectsActions.tsx
+++ b/app/modules/teams/helpers/getTeamProjectsActions.tsx
@@ -1,11 +1,7 @@
-import { useContext } from "react";
-import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import type { User } from "~/modules/users/users.types";
 
-export default (teamId: string) => {
-  const user = useContext(AuthenticationContext) as User;
-
+export default function getTeamProjectsActions(user: User, teamId: string) {
   if (ProjectAuthorization.canCreate(user, teamId)) {
     return [
       {
@@ -16,4 +12,4 @@ export default (teamId: string) => {
   } else {
     return [];
   }
-};
+}

--- a/app/modules/teams/helpers/getTeamProjectsEmptyAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamProjectsEmptyAttributes.tsx
@@ -1,10 +1,10 @@
 import { FolderOpen } from "lucide-react";
 
-export default () => {
+export default function getTeamProjectsEmptyAttributes() {
   return {
     icon: <FolderOpen />,
     title: "No Projects yet",
     description: "No projects are associated with this team",
     actions: [],
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamProjectsItemActions.tsx
+++ b/app/modules/teams/helpers/getTeamProjectsItemActions.tsx
@@ -1,5 +1,5 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 
-export default (): CollectionItemAction[] => {
+export default function getTeamProjectsItemActions(): CollectionItemAction[] {
   return [];
-};
+}

--- a/app/modules/teams/helpers/getTeamProjectsItemAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamProjectsItemAttributes.tsx
@@ -1,12 +1,13 @@
-import { useContext } from "react";
 import getDateString from "~/modules/app/helpers/getDateString";
-import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import type { Project } from "~/modules/projects/projects.types";
 import type { User } from "~/modules/users/users.types";
 
-export default (item: Project, teamId: string) => {
-  const user = useContext(AuthenticationContext) as User;
+export default function getTeamProjectsItemAttributes(
+  item: Project,
+  teamId: string,
+  user: User,
+) {
   const canCreate = ProjectAuthorization.canCreate(user, teamId);
 
   return {
@@ -19,4 +20,4 @@ export default (item: Project, teamId: string) => {
       },
     ],
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamPromptsActions.tsx
+++ b/app/modules/teams/helpers/getTeamPromptsActions.tsx
@@ -1,7 +1,10 @@
 import PromptAuthorization from "~/modules/prompts/authorization";
 import type { User } from "~/modules/users/users.types";
 
-export default (teamId: string, user: User | null) => {
+export default function getTeamPromptsActions(
+  teamId: string,
+  user: User | null,
+) {
   if (PromptAuthorization.canCreate(user, teamId)) {
     return [
       {
@@ -12,4 +15,4 @@ export default (teamId: string, user: User | null) => {
   } else {
     return [];
   }
-};
+}

--- a/app/modules/teams/helpers/getTeamPromptsEmptyAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamPromptsEmptyAttributes.tsx
@@ -1,10 +1,10 @@
 import { ClipboardList } from "lucide-react";
 
-export default () => {
+export default function getTeamPromptsEmptyAttributes() {
   return {
     icon: <ClipboardList />,
     title: "No Prompts yet",
     description: "No prompts are associated with this team",
     actions: [],
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamPromptsItemActions.tsx
+++ b/app/modules/teams/helpers/getTeamPromptsItemActions.tsx
@@ -1,5 +1,5 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 
-export default (): CollectionItemAction[] => {
+export default function getTeamPromptsItemActions(): CollectionItemAction[] {
   return [];
-};
+}

--- a/app/modules/teams/helpers/getTeamPromptsItemAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamPromptsItemAttributes.tsx
@@ -4,7 +4,11 @@ import PromptAuthorization from "~/modules/prompts/authorization";
 import type { Prompt } from "~/modules/prompts/prompts.types";
 import type { User } from "~/modules/users/users.types";
 
-export default (item: Prompt, teamId: string, user: User | null) => {
+export default function getTeamPromptsItemAttributes(
+  item: Prompt,
+  teamId: string,
+  user: User | null,
+) {
   const canCreate = PromptAuthorization.canCreate(user, teamId);
 
   return {
@@ -22,4 +26,4 @@ export default (item: Prompt, teamId: string, user: User | null) => {
       },
     ],
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamUsersActions.tsx
+++ b/app/modules/teams/helpers/getTeamUsersActions.tsx
@@ -1,25 +1,24 @@
-import useTeamAuthorization from "../hooks/useTeamAuthorization";
+import type { User } from "~/modules/users/users.types";
+import TeamAuthorization from "../authorization";
 
-export default (teamId: string) => {
-  const { users: usersAuthorization } = useTeamAuthorization(teamId);
-
+export default function getTeamUsersActions(user: User, teamId: string) {
   const actions = [];
 
-  if (usersAuthorization.canRequestAccess) {
+  if (TeamAuthorization.Users.canRequestAccess(user, teamId)) {
     actions.push({
       action: "REQUEST_ACCESS",
       text: "Request Access to Team",
     });
   }
 
-  if (usersAuthorization.canUpdate) {
+  if (TeamAuthorization.Users.canUpdate(user, teamId)) {
     actions.push({
       action: "ADD_USER",
       text: "Add existing user",
     });
   }
 
-  if (usersAuthorization.canInvite) {
+  if (TeamAuthorization.Users.canInvite(user, teamId)) {
     actions.push({
       action: "INVITE_USER",
       text: "Invite new user",
@@ -27,4 +26,4 @@ export default (teamId: string) => {
   }
 
   return actions;
-};
+}

--- a/app/modules/teams/helpers/getTeamUsersEmptyAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamUsersEmptyAttributes.tsx
@@ -1,10 +1,10 @@
 import { Users } from "lucide-react";
 
-export default () => {
+export default function getTeamUsersEmptyAttributes() {
   return {
     icon: <Users />,
     title: "No Users yet",
     description: "No users are associated with this team",
     actions: [],
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamUsersItemActions.tsx
+++ b/app/modules/teams/helpers/getTeamUsersItemActions.tsx
@@ -1,14 +1,16 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 import { Trash2 } from "lucide-react";
 import type { User } from "~/modules/users/users.types";
-import useTeamAuthorization from "../hooks/useTeamAuthorization";
+import TeamAuthorization from "../authorization";
 
-export default (item: User, teamId: string): CollectionItemAction[] => {
-  const { users: usersAuthorization } = useTeamAuthorization(teamId);
-
+export default function getTeamUsersItemActions(
+  item: User,
+  user: User,
+  teamId: string,
+): CollectionItemAction[] {
   const actions: CollectionItemAction[] = [];
 
-  if (usersAuthorization.canUpdate) {
+  if (TeamAuthorization.Users.canUpdate(user, teamId)) {
     actions.push({
       action: "REMOVE",
       icon: <Trash2 />,
@@ -18,4 +20,4 @@ export default (item: User, teamId: string): CollectionItemAction[] => {
   }
 
   return actions;
-};
+}

--- a/app/modules/teams/helpers/getTeamUsersItemAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamUsersItemAttributes.tsx
@@ -3,7 +3,7 @@ import type { User } from "~/modules/users/users.types";
 import type { Team } from "../teams.types";
 import getUserRoleInTeam from "./getUserRoleInTeam";
 
-export default (item: User, team: Team) => {
+export default function getTeamUsersItemAttributes(item: User, team: Team) {
   const { name: roleName } = getUserRoleInTeam({ user: item, team });
 
   let username = item.username;
@@ -31,4 +31,4 @@ export default (item: User, team: Team) => {
       },
     ],
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamsEmptyAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamsEmptyAttributes.tsx
@@ -1,6 +1,6 @@
 import { Users } from "lucide-react";
 
-export default () => {
+export default function getTeamsEmptyAttributes() {
   return {
     icon: <Users />,
     title: "No Teams yet",
@@ -13,4 +13,4 @@ export default () => {
       },
     ],
   };
-};
+}

--- a/app/modules/teams/helpers/getTeamsItemActions.tsx
+++ b/app/modules/teams/helpers/getTeamsItemActions.tsx
@@ -1,14 +1,16 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 import { Edit } from "lucide-react";
-import useTeamAuthorization from "../hooks/useTeamAuthorization";
+import type { User } from "~/modules/users/users.types";
+import TeamAuthorization from "../authorization";
 import type { Team } from "../teams.types";
 
-export default (item: Team): CollectionItemAction[] => {
-  const { canUpdate } = useTeamAuthorization(item._id);
-
+export default function getTeamsItemActions(
+  item: Team,
+  user: User,
+): CollectionItemAction[] {
   const actions: CollectionItemAction[] = [];
 
-  if (canUpdate) {
+  if (TeamAuthorization.canUpdate(user, item._id)) {
     actions.push({
       action: "EDIT",
       icon: <Edit />,
@@ -17,4 +19,4 @@ export default (item: Team): CollectionItemAction[] => {
   }
 
   return actions;
-};
+}

--- a/app/modules/teams/helpers/getTeamsItemAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamsItemAttributes.tsx
@@ -1,7 +1,7 @@
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { Team } from "../teams.types";
 
-export default (item: Team) => {
+export default function getTeamsItemAttributes(item: Team) {
   return {
     id: item._id,
     title: item.name,
@@ -12,4 +12,4 @@ export default (item: Team) => {
       },
     ],
   };
-};
+}

--- a/app/modules/teams/helpers/renderAddUserToTeamDialogItem.tsx
+++ b/app/modules/teams/helpers/renderAddUserToTeamDialogItem.tsx
@@ -3,7 +3,10 @@ import { Label } from "@/components/ui/label";
 import includes from "lodash/includes";
 import type { User } from "~/modules/users/users.types";
 
-export default (user: User, selectedUsers: string[]) => {
+export default function renderAddUserToTeamDialogItem(
+  user: User,
+  selectedUsers: string[],
+) {
   const isChecked = !!includes(selectedUsers, user._id);
   return (
     <div className="flex items-center gap-3 p-3">
@@ -13,4 +16,4 @@ export default (user: User, selectedUsers: string[]) => {
       </Label>
     </div>
   );
-};
+}

--- a/app/modules/users/helpers/getAuditLogItemAttributes.tsx
+++ b/app/modules/users/helpers/getAuditLogItemAttributes.tsx
@@ -11,7 +11,9 @@ const getActionLabel = (action: string): string => {
   return labels[action] || "Role updated";
 };
 
-export default (audit: AuditRecord): CollectionItemAttributes => {
+export default function getAuditLogItemAttributes(
+  audit: AuditRecord,
+): CollectionItemAttributes {
   const icon =
     audit.action === "ADD_SUPERADMIN" ? (
       <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
@@ -38,4 +40,4 @@ export default (audit: AuditRecord): CollectionItemAttributes => {
       },
     ],
   };
-};
+}

--- a/app/modules/users/helpers/getEmptyStateAttributes.tsx
+++ b/app/modules/users/helpers/getEmptyStateAttributes.tsx
@@ -1,6 +1,6 @@
-export default () => {
+export default function getEmptyStateAttributes() {
   return {
     title: "No users found",
     description: "All system users will appear here",
   };
-};
+}

--- a/app/modules/users/helpers/getUserManagementItemActions.tsx
+++ b/app/modules/users/helpers/getUserManagementItemActions.tsx
@@ -2,7 +2,10 @@ import type { CollectionItemAction } from "@/components/ui/collectionContentItem
 import UserManagementAuthorization from "../authorization";
 import type { User } from "../users.types";
 
-export default (item: User, currentUser: User): CollectionItemAction[] => {
+export default function getUserManagementItemActions(
+  item: User,
+  currentUser: User,
+): CollectionItemAction[] {
   const actions: CollectionItemAction[] = [];
 
   if (
@@ -30,4 +33,4 @@ export default (item: User, currentUser: User): CollectionItemAction[] => {
   }
 
   return actions;
-};
+}

--- a/app/modules/users/helpers/getUserManagementItemAttributes.tsx
+++ b/app/modules/users/helpers/getUserManagementItemAttributes.tsx
@@ -1,7 +1,7 @@
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { User } from "../users.types";
 
-export default (item: User) => {
+export default function getUserManagementItemAttributes(item: User) {
   return {
     id: item._id,
     title: item.username || "Unknown User",
@@ -15,4 +15,4 @@ export default (item: User) => {
       },
     ],
   };
-};
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,7 @@ export default defineConfig([
     extends: [reactHooks.configs.flat.recommended, reactRefresh.configs.vite],
     rules: {
       "react-refresh/only-export-components": [
-        "warn",
+        "error",
         {
           allowExportNames: [
             "meta",
@@ -42,9 +42,16 @@ export default defineConfig([
             "action",
             "shouldRevalidate",
           ],
+          allowConstantExport: true,
         },
       ],
       "react-hooks/exhaustive-deps": "off",
+    },
+  },
+  {
+    files: ["app/uikit/**/*.{ts,tsx}"],
+    rules: {
+      "react-refresh/only-export-components": "off",
     },
   },
 ]);


### PR DESCRIPTION
- Name 41 anonymous default exports for fast refresh compatibility
- Remove hook calls from 7 helper functions, pass user/teamId as params
- Routes get user from context and pass as props to components
- Exclude uikit (vendored shadcn) from rule since they co-export variants