### PR TITLE
Set isRunning immediately when starting a run

### DIFF
--- a/app/modules/runs/run.ts
+++ b/app/modules/runs/run.ts
@@ -89,6 +89,7 @@ export class RunService {
   }
 
   static async start(run: Run): Promise<void> {
+    await this.updateById(run._id, { isRunning: true });
     await createRunAnnotations(run);
   }
 


### PR DESCRIPTION
Show the progress bar on page load instead of waiting for the background worker to pick up the START job.

Fixes #1468