### PR TITLE
Add run status filter to run set overview

### DIFF
--- a/app/modules/app/__tests__/buildQueryFromParams.test.ts
+++ b/app/modules/app/__tests__/buildQueryFromParams.test.ts
@@ -96,6 +96,81 @@ describe("buildQueryFromParams", () => {
     expect(query.match).toEqual({});
   });
 
+  it("applies a filter function to produce custom match conditions", () => {
+    const query = buildQueryFromParams({
+      match: {},
+      queryParams: { filters: { status: "COMPLETE" } },
+      searchableFields: [],
+      sortableFields: ["name"],
+      filterableFields: [{ status: () => ({ isComplete: true }) }],
+    });
+
+    expect(query.match).toEqual({ isComplete: true });
+  });
+
+  it("passes the filter value to the filter function", () => {
+    const query = buildQueryFromParams({
+      match: {},
+      queryParams: { filters: { status: "QUEUED" } },
+      searchableFields: [],
+      sortableFields: ["name"],
+      filterableFields: [
+        {
+          status: (value: string) => {
+            if (value === "QUEUED")
+              return { isRunning: { $ne: true }, isComplete: { $ne: true } };
+            return { isComplete: true };
+          },
+        },
+      ],
+    });
+
+    expect(query.match).toEqual({
+      isRunning: { $ne: true },
+      isComplete: { $ne: true },
+    });
+  });
+
+  it("skips filter function when it returns null", () => {
+    const query = buildQueryFromParams({
+      match: {},
+      queryParams: { filters: { status: "INVALID" } },
+      searchableFields: [],
+      sortableFields: ["name"],
+      filterableFields: [{ status: () => null }],
+    });
+
+    expect(query.match).toEqual({});
+  });
+
+  it("mixes string and function filterableFields", () => {
+    const query = buildQueryFromParams({
+      match: {},
+      queryParams: { filters: { team: "team1", status: "COMPLETE" } },
+      searchableFields: [],
+      sortableFields: ["name"],
+      filterableFields: ["team", { status: () => ({ isComplete: true }) }],
+    });
+
+    expect(query.match).toEqual({
+      $and: [{ isComplete: true }, { team: "team1" }],
+    });
+  });
+
+  it("combines filter function with existing match using $and", () => {
+    const query = buildQueryFromParams({
+      match: { _id: { $in: ["a", "b"] } },
+      queryParams: { filters: { status: "COMPLETE" } },
+      searchableFields: [],
+      sortableFields: ["name"],
+      filterableFields: [{ status: () => ({ isComplete: true }) }],
+    });
+
+    expect(query.match).toEqual({
+      $and: [{ _id: { $in: ["a", "b"] } }, { isComplete: true }],
+    });
+  });
+
   it("throws when filters provided but no filterableFields configured", () => {
     expect(() =>
       buildQueryFromParams({

--- a/app/modules/app/helpers/buildQueryFromParams.ts
+++ b/app/modules/app/helpers/buildQueryFromParams.ts
@@ -7,12 +7,14 @@ export type QueryParams = {
   filters?: Record<string, string>;
   sort?: string;
 };
+type FilterMatchBuilder = (value: string) => Record<string, any> | null;
+type FilterableField = string | Record<string, FilterMatchBuilder>;
 type BuildQueryProps = {
   match: any;
   queryParams: QueryParams;
   searchableFields: string[];
   sortableFields: string[];
-  filterableFields?: string[];
+  filterableFields?: FilterableField[];
 };
 export type Query = { match: any; sort?: any; page?: number };
 
@@ -65,9 +67,19 @@ export function buildQueryFromParams({
     }
 
     const filterConditions: any = {};
-    for (const field of filterableFields) {
-      if (has(filters, field)) {
-        filterConditions[field] = filters[field];
+    for (const entry of filterableFields) {
+      if (typeof entry === "string") {
+        if (has(filters, entry)) {
+          filterConditions[entry] = filters[entry];
+        }
+      } else {
+        const [field, buildMatch] = Object.entries(entry)[0];
+        if (has(filters, field)) {
+          const customMatch = buildMatch(filters[field]);
+          if (customMatch) {
+            query.match = addConditionToMatch(query.match, customMatch);
+          }
+        }
       }
     }
 

--- a/app/modules/runSets/__tests__/runSetOverview.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetOverview.route.test.ts
@@ -195,6 +195,95 @@ describe("runSetOverview.route loader", () => {
     expect(data.sessions).toHaveProperty("totalPages");
   });
 
+  it("filters runs by COMPLETE status", async () => {
+    const completeRun = await createTestRun({
+      name: "Complete Run",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      isRunning: false,
+      isComplete: true,
+    });
+    const multiRunSet = await RunSetService.create({
+      name: "Multi RunSet",
+      project: project._id,
+      sessions: [],
+      runs: [run._id, completeRun._id],
+      annotationType: "PER_UTTERANCE",
+    });
+
+    const res = await loader({
+      request: new Request("http://localhost/?runsFilter_status=COMPLETE", {
+        headers: { cookie: cookieHeader },
+      }),
+      params: { projectId: project._id, runSetId: multiRunSet._id },
+      unstable_pattern: "",
+      context: {},
+    } as any);
+
+    const data = res as LoaderResult;
+    expect(data.runs.data).toHaveLength(1);
+    expect(data.runs.data[0].name).toBe("Complete Run");
+  });
+
+  it("filters runs by QUEUED status", async () => {
+    const completeRun = await createTestRun({
+      name: "Complete Run",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      isRunning: false,
+      isComplete: true,
+    });
+    const multiRunSet = await RunSetService.create({
+      name: "Multi RunSet",
+      project: project._id,
+      sessions: [],
+      runs: [run._id, completeRun._id],
+      annotationType: "PER_UTTERANCE",
+    });
+
+    const res = await loader({
+      request: new Request("http://localhost/?runsFilter_status=QUEUED", {
+        headers: { cookie: cookieHeader },
+      }),
+      params: { projectId: project._id, runSetId: multiRunSet._id },
+      unstable_pattern: "",
+      context: {},
+    } as any);
+
+    const data = res as LoaderResult;
+    expect(data.runs.data).toHaveLength(1);
+    expect(data.runs.data[0].name).toBe("Test Run");
+  });
+
+  it("returns all runs when no status filter is applied", async () => {
+    const completeRun = await createTestRun({
+      name: "Complete Run",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      isRunning: false,
+      isComplete: true,
+    });
+    const multiRunSet = await RunSetService.create({
+      name: "Multi RunSet",
+      project: project._id,
+      sessions: [],
+      runs: [run._id, completeRun._id],
+      annotationType: "PER_UTTERANCE",
+    });
+
+    const res = await loader({
+      request: new Request("http://localhost/", {
+        headers: { cookie: cookieHeader },
+      }),
+      params: { projectId: project._id, runSetId: multiRunSet._id },
+      unstable_pattern: "",
+      context: {},
+    } as any);
+
+    const data = res as LoaderResult;
+    expect(data.runs.data).toHaveLength(2);
+  });
+
   it("paginates sessions correctly", async () => {
     const res = await loader({
       request: new Request(

--- a/app/modules/runSets/components/runSetOverview.tsx
+++ b/app/modules/runSets/components/runSetOverview.tsx
@@ -4,6 +4,7 @@ import { Play, Trash2 } from "lucide-react";
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { RunSet } from "~/modules/runSets/runSets.types";
 import getRunsItemAttributes from "~/modules/runs/helpers/getRunsItemAttributes";
+import runStatusFilters from "~/modules/runs/helpers/runStatusFilters";
 import type { Run } from "~/modules/runs/runs.types";
 import getSessionsItemAttributes from "~/modules/sessions/helpers/getSessionsItemAttributes";
 import type { Session } from "~/modules/sessions/sessions.types";
@@ -27,6 +28,8 @@ export default function RunSetOverview({
   onSessionItemClicked,
   onRunsSearchValueChanged,
   onRunsCurrentPageChanged,
+  runsFiltersValues,
+  onRunsFiltersValueChanged,
   onRunsSortValueChanged,
   onSessionsSearchValueChanged,
   onSessionsCurrentPageChanged,
@@ -51,6 +54,10 @@ export default function RunSetOverview({
   onSessionItemClicked: (id: string) => void;
   onRunsSearchValueChanged: (value: string) => void;
   onRunsCurrentPageChanged: (page: number) => void;
+  runsFiltersValues: Record<string, string | null>;
+  onRunsFiltersValueChanged: (
+    filterValue: Record<string, string | null>,
+  ) => void;
   onRunsSortValueChanged: (sort: string) => void;
   onSessionsSearchValueChanged: (value: string) => void;
   onSessionsCurrentPageChanged: (page: number) => void;
@@ -151,8 +158,9 @@ export default function RunSetOverview({
               ]}
               onSortValueChanged={onRunsSortValueChanged}
               isSyncing={isRunsSyncing}
-              filters={[]}
-              filtersValues={{}}
+              filters={runStatusFilters}
+              filtersValues={runsFiltersValues}
+              onFiltersValueChanged={onRunsFiltersValueChanged}
             />
           </div>
         </div>

--- a/app/modules/runSets/containers/runSetOverview.route.tsx
+++ b/app/modules/runSets/containers/runSetOverview.route.tsx
@@ -15,6 +15,7 @@ import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import addDialog from "~/modules/dialogs/addDialog";
+import buildRunStatusMatch from "~/modules/runs/helpers/buildRunStatusMatch";
 import { RunService } from "~/modules/runs/run";
 import type { Run } from "~/modules/runs/runs.types";
 import RemoveRunFromRunSetDialog from "~/modules/runSets/components/removeRunFromRunSetDialog";
@@ -53,6 +54,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     queryParams: runsQueryParams,
     searchableFields: ["name"],
     sortableFields: ["name", "createdAt"],
+    filterableFields: [{ status: buildRunStatusMatch }],
   });
 
   const runs = await RunService.paginate({
@@ -123,6 +125,8 @@ export default function RunSetOverviewRoute() {
     setCurrentPage: setRunsCurrentPage,
     sortValue: runsSortValue,
     setSortValue: setRunsSortValue,
+    filtersValues: runsFiltersValues,
+    setFiltersValues: setRunsFiltersValues,
     isSyncing: isRunsSyncing,
   } = useSearchQueryParams(
     {
@@ -263,6 +267,10 @@ export default function RunSetOverviewRoute() {
       onSessionItemClicked={onSessionItemClicked}
       onRunsSearchValueChanged={setRunsSearchValue}
       onRunsCurrentPageChanged={setRunsCurrentPage}
+      runsFiltersValues={runsFiltersValues}
+      onRunsFiltersValueChanged={(filterValue: Record<string, string | null>) =>
+        setRunsFiltersValues({ ...runsFiltersValues, ...filterValue })
+      }
       onRunsSortValueChanged={setRunsSortValue}
       onSessionsSearchValueChanged={setSessionsSearchValue}
       onSessionsCurrentPageChanged={setSessionsCurrentPage}

--- a/app/modules/runs/__tests__/buildRunStatusMatch.test.ts
+++ b/app/modules/runs/__tests__/buildRunStatusMatch.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import buildRunStatusMatch from "../helpers/buildRunStatusMatch";
+
+describe("buildRunStatusMatch", () => {
+  it("returns { isRunning: true } for RUNNING", () => {
+    expect(buildRunStatusMatch("RUNNING")).toEqual({ isRunning: true });
+  });
+
+  it("returns stoppedAt exists for STOPPED", () => {
+    expect(buildRunStatusMatch("STOPPED")).toEqual({
+      stoppedAt: { $exists: true },
+    });
+  });
+
+  it("returns { hasErrored: true } for FAILED", () => {
+    expect(buildRunStatusMatch("FAILED")).toEqual({ hasErrored: true });
+  });
+
+  it("returns { isComplete: true, hasErrored: false } for COMPLETE", () => {
+    expect(buildRunStatusMatch("COMPLETE")).toEqual({
+      isComplete: true,
+      hasErrored: false,
+    });
+  });
+
+  it("returns negated conditions for QUEUED", () => {
+    expect(buildRunStatusMatch("QUEUED")).toEqual({
+      isRunning: false,
+      isComplete: false,
+      hasErrored: false,
+      stoppedAt: { $exists: false },
+    });
+  });
+
+  it("returns null for invalid status", () => {
+    expect(buildRunStatusMatch("INVALID")).toBeNull();
+  });
+});

--- a/app/modules/runs/helpers/buildRunStatusMatch.ts
+++ b/app/modules/runs/helpers/buildRunStatusMatch.ts
@@ -1,0 +1,23 @@
+import type { StatusKey } from "~/modules/runs/helpers/statusMeta";
+
+const STATUS_MATCH: Record<StatusKey, Record<string, any>> = {
+  RUNNING: { isRunning: true },
+  STOPPED: { stoppedAt: { $exists: true } },
+  FAILED: { hasErrored: true },
+  COMPLETE: { isComplete: true, hasErrored: false },
+  QUEUED: {
+    isRunning: false,
+    stoppedAt: { $exists: false },
+    hasErrored: false,
+    isComplete: false,
+  },
+};
+
+export default function buildRunStatusMatch(
+  statusKey: string,
+): Record<string, any> | null {
+  if (statusKey in STATUS_MATCH) {
+    return STATUS_MATCH[statusKey as StatusKey];
+  }
+  return null;
+}

--- a/app/modules/runs/helpers/runStatusFilters.ts
+++ b/app/modules/runs/helpers/runStatusFilters.ts
@@ -1,0 +1,13 @@
+export default [
+  {
+    category: "status",
+    text: "Status",
+    options: [
+      { value: "RUNNING", text: "Running" },
+      { value: "FAILED", text: "Failed" },
+      { value: "COMPLETE", text: "Complete" },
+      { value: "QUEUED", text: "Queued" },
+      { value: "STOPPED", text: "Stopped" },
+    ],
+  },
+];


### PR DESCRIPTION
Support function-based filterableFields in buildQueryFromParams for derived fields that don't map to a single DB column.

Fixes #1465