### PR TITLE
Adds approximate time remaining for long runs

### DIFF
--- a/app/modules/runSets/components/runSetDetail.tsx
+++ b/app/modules/runSets/components/runSetDetail.tsx
@@ -26,6 +26,7 @@ import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import Flag from "~/modules/featureFlags/components/flag";
 import DownloadDropdown from "~/modules/runs/components/downloadDropdown";
+import formatTimeRemaining from "~/modules/runs/helpers/formatTimeRemaining";
 import type { RunSet } from "~/modules/runSets/runSets.types";
 
 export default function RunSetDetail({
@@ -45,7 +46,12 @@ export default function RunSetDetail({
   runSet: RunSet;
   project: { _id: string; name: string };
   breadcrumbs: Breadcrumb[];
-  runsProgress: { total: number; completed: number; running: number };
+  runsProgress: {
+    total: number;
+    completed: number;
+    running: number;
+    startedAt: string | null;
+  };
   onExportRunSetButtonClicked: ({ exportType }: { exportType: string }) => void;
   onAddRunsClicked: () => void;
   onMergeClicked: () => void;
@@ -110,6 +116,14 @@ export default function RunSetDetail({
         <div className="relative mb-4">
           <div className="absolute top-3 right-0 text-xs opacity-40">
             Annotating runs {runsProgress.completed}/{runsProgress.total}
+            {(() => {
+              const estimate = formatTimeRemaining(
+                runsProgress.startedAt,
+                runsProgress.completed,
+                runsProgress.total,
+              );
+              return estimate ? ` · ${estimate}` : null;
+            })()}
           </div>
           <Progress
             value={(runsProgress.completed / runsProgress.total) * 100}

--- a/app/modules/runSets/containers/runSetDetail.route.tsx
+++ b/app/modules/runSets/containers/runSetDetail.route.tsx
@@ -46,14 +46,32 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const runIds = runSet.runs ?? [];
   const totalRuns = runIds.length;
-  let runsProgress = { total: totalRuns, completed: 0, running: 0 };
+  let runsProgress = {
+    total: totalRuns,
+    completed: 0,
+    running: 0,
+    startedAt: null as string | null,
+  };
 
   if (totalRuns > 0) {
-    const [completed, running] = await Promise.all([
+    const [completed, running, [earliestRun]] = await Promise.all([
       RunService.count({ _id: { $in: runIds }, isComplete: true }),
       RunService.count({ _id: { $in: runIds }, isRunning: true }),
+      RunService.find({
+        match: {
+          _id: { $in: runIds },
+          startedAt: { $exists: true, $ne: null },
+        },
+        sort: { startedAt: 1 },
+        pagination: { skip: 0, limit: 1 },
+      }),
     ]);
-    runsProgress = { total: totalRuns, completed, running };
+    runsProgress = {
+      total: totalRuns,
+      completed,
+      running,
+      startedAt: earliestRun ? String(earliestRun.startedAt) : null,
+    };
   }
 
   return {

--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -29,6 +29,7 @@ import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import Flag from "~/modules/featureFlags/components/flag";
 import annotationTypes from "~/modules/prompts/annotationTypes";
+import formatTimeRemaining from "~/modules/runs/helpers/formatTimeRemaining";
 import getRunSessionsItemAttributes from "~/modules/runs/helpers/getRunSessionsItemAttributes";
 import { getRunModelDisplayName } from "~/modules/runs/helpers/runModel";
 import type { Run, RunSession } from "~/modules/runs/runs.types";
@@ -161,6 +162,17 @@ export default function RunDetail({
             <Progress value={runSessionsProgress} />
             <div className="mt-1 text-right text-xs opacity-40">
               Annotating {runSessionsStep}
+              {(() => {
+                const [completed, total] = runSessionsStep
+                  .split("/")
+                  .map(Number);
+                const estimate = formatTimeRemaining(
+                  run.startedAt,
+                  completed,
+                  total,
+                );
+                return estimate ? ` · ${estimate}` : null;
+              })()}
             </div>
           </div>
         )}

--- a/app/modules/runs/helpers/formatTimeRemaining.ts
+++ b/app/modules/runs/helpers/formatTimeRemaining.ts
@@ -1,0 +1,23 @@
+export default function formatTimeRemaining(
+  startedAt: Date | string | undefined | null,
+  completed: number,
+  total: number,
+): string | null {
+  if (!startedAt || completed === 0 || completed >= total) return null;
+
+  const elapsedMs = Date.now() - new Date(startedAt).getTime();
+  if (elapsedMs <= 0) return null;
+
+  const avgMsPerSession = elapsedMs / completed;
+  const remainingMs = avgMsPerSession * (total - completed);
+  const remainingSeconds = Math.round(remainingMs / 1000);
+
+  if (remainingSeconds < 60) return "< 1 min remaining";
+
+  const hours = Math.floor(remainingSeconds / 3600);
+  const minutes = Math.round((remainingSeconds % 3600) / 60);
+
+  if (hours === 0) return `~${minutes} min remaining`;
+  if (minutes === 0) return `~${hours} hr remaining`;
+  return `~${hours} hr ${minutes} min remaining`;
+}


### PR DESCRIPTION
Shows estimated time next to progress on both run detail and run set detail pages using live wall-clock calculation.

Fixes #1434