### PR TITLE
Consolidate run edit/delete actions

### DIFF
--- a/app/modules/runs/__tests__/run.route.test.ts
+++ b/app/modules/runs/__tests__/run.route.test.ts
@@ -252,4 +252,92 @@ describe("run.route action", () => {
     expect(data.runSets).toHaveLength(1);
     expect(data.runSets[0]._id).toBe(runSet._id);
   });
+
+  it("UPDATE_RUN updates run name", async () => {
+    const user = await UserService.create({ username: "test_user", teams: [] });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+
+    const run = await RunService.create({
+      project: project._id,
+      name: "Old Name",
+      sessions: [],
+      annotationType: "PER_UTTERANCE",
+      prompt: new Types.ObjectId().toString(),
+      promptVersion: 1,
+      modelCode: "gpt-4",
+    });
+
+    const res = await action({
+      request: new Request(
+        "http://localhost/projects/" + project._id + "/runs/" + run._id,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            intent: "UPDATE_RUN",
+            payload: { name: "New Name" },
+          }),
+        },
+      ),
+      params: { projectId: project._id, runId: run._id },
+    } as any);
+
+    const data = res as any;
+    expect(data.success).toBe(true);
+    expect(data.intent).toBe("UPDATE_RUN");
+    const updatedRun = await RunService.findById(run._id);
+    expect(updatedRun?.name).toBe("New Name");
+  });
+
+  it("DELETE_RUN deletes the run", async () => {
+    const user = await UserService.create({ username: "test_user", teams: [] });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+
+    const run = await RunService.create({
+      project: project._id,
+      name: "Delete Run",
+      sessions: [],
+      annotationType: "PER_UTTERANCE",
+      prompt: new Types.ObjectId().toString(),
+      promptVersion: 1,
+      modelCode: "gpt-4",
+    });
+
+    const res = await action({
+      request: new Request(
+        "http://localhost/projects/" + project._id + "/runs/" + run._id,
+        {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ intent: "DELETE_RUN", payload: {} }),
+        },
+      ),
+      params: { projectId: project._id, runId: run._id },
+    } as any);
+
+    const data = res as any;
+    expect(data.success).toBe(true);
+    expect(data.intent).toBe("DELETE_RUN");
+
+    const deletedRun = await RunService.findById(run._id);
+    expect(deletedRun).toBeNull();
+  });
 });

--- a/app/modules/runs/__tests__/runs.route.test.ts
+++ b/app/modules/runs/__tests__/runs.route.test.ts
@@ -1,14 +1,12 @@
-import { Types } from "mongoose";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ProjectService } from "~/modules/projects/project";
-import { RunService } from "~/modules/runs/run";
 import "~/modules/teams/team";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
 import loginUser from "../../../../test/helpers/loginUser";
-import { action, loader } from "../containers/runs.route";
+import { loader } from "../containers/runs.route";
 
 describe("runs.route loader", () => {
   beforeEach(async () => {
@@ -79,77 +77,5 @@ describe("runs.route loader", () => {
     expect((res as any).runs.data[0].name).toBe("Test Run");
     // Ensure no .data property on returned run
     expect((res as any).runs.data[0].data).toBeUndefined();
-  });
-});
-
-describe("runs.route action - UPDATE_RUN", () => {
-  beforeEach(async () => {
-    await clearDocumentDB();
-  });
-
-  it("returns 400 when project not found", async () => {
-    const user = await UserService.create({ username: "test_user" });
-    const cookieHeader = await loginUser(user._id);
-    const fakeProjectId = new Types.ObjectId().toString();
-    const fakeRunId = new Types.ObjectId().toString();
-
-    const req = new Request("http://localhost/projects/" + fakeProjectId, {
-      method: "PUT",
-      headers: { cookie: cookieHeader, "content-type": "application/json" },
-      body: JSON.stringify({
-        intent: "UPDATE_RUN",
-        entityId: fakeRunId,
-        payload: { name: "New Name" },
-      }),
-    });
-
-    const resp = (await action({
-      request: req,
-      params: { id: fakeProjectId },
-    } as any)) as any;
-    expect(resp.init?.status).toBe(400);
-    expect(resp.data?.errors?.project).toBe("Project not found");
-  });
-
-  it("updates run name successfully", async () => {
-    const user = await UserService.create({ username: "test_user", teams: [] });
-    const team = await TeamService.create({ name: "Test Team" });
-    await UserService.updateById(user._id, {
-      teams: [{ team: team._id, role: "ADMIN" }],
-    });
-
-    const project = await ProjectService.create({
-      name: "Test Project",
-      createdBy: user._id,
-      team: team._id,
-    });
-
-    const run = await createTestRun({
-      name: "Old Name",
-      project: project._id,
-      isRunning: false,
-      isComplete: false,
-    });
-
-    const cookieHeader = await loginUser(user._id);
-
-    const req = new Request("http://localhost/projects/" + project._id, {
-      method: "PUT",
-      headers: { cookie: cookieHeader, "content-type": "application/json" },
-      body: JSON.stringify({
-        intent: "UPDATE_RUN",
-        entityId: run._id,
-        payload: { name: "New Name" },
-      }),
-    });
-
-    const resp = await action({
-      request: req,
-      params: { id: project._id },
-    } as any);
-
-    expect(resp).not.toBeInstanceOf(Response);
-    const updatedRun = await RunService.findById(run._id);
-    expect(updatedRun?.name).toBe("New Name");
   });
 });

--- a/app/modules/runs/components/deleteRunDialog.tsx
+++ b/app/modules/runs/components/deleteRunDialog.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@/components/ui/button";
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useState } from "react";
+import type { Run } from "~/modules/runs/runs.types";
+
+const DeleteRunDialog = ({
+  run,
+  onDeleteRunClicked,
+  isSubmitting = false,
+}: {
+  run: Run;
+  onDeleteRunClicked: (runId: string) => void;
+  isSubmitting?: boolean;
+}) => {
+  const [runName, setRunName] = useState("");
+
+  const isDeleteButtonDisabled = runName !== run.name;
+
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Delete run - {run.name}</DialogTitle>
+        <DialogDescription>
+          This will only remove the run. Sessions in the project will remain.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="grid gap-3">
+        <Label htmlFor="name">To confirm delete, type in the run name.</Label>
+        <div className="relative">
+          <Input
+            className="absolute top-0 left-0"
+            placeholder={run.name}
+            disabled={true}
+            autoComplete="off"
+          />
+          <Input
+            className="focus-visible:border-destructive focus-visible:ring-destructive/50"
+            id="name"
+            name="name"
+            value={runName}
+            autoComplete="off"
+            onChange={(event) => setRunName(event.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+      </div>
+      <DialogFooter className="justify-end">
+        <DialogClose asChild>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              setRunName("");
+            }}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+        </DialogClose>
+        <DialogClose asChild>
+          <Button
+            type="button"
+            disabled={isDeleteButtonDisabled || isSubmitting}
+            variant="destructive"
+            onClick={() => {
+              onDeleteRunClicked(run._id);
+              setRunName("");
+            }}
+          >
+            Delete run
+          </Button>
+        </DialogClose>
+      </DialogFooter>
+    </DialogContent>
+  );
+};
+
+export default DeleteRunDialog;

--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -24,6 +24,7 @@ import {
   OctagonX,
   Pencil,
   Stamp,
+  Trash2,
 } from "lucide-react";
 import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
@@ -50,6 +51,7 @@ export default function RunDetail({
   onStopRunClicked,
   onReRunClicked,
   onEditRunButtonClicked,
+  onDeleteRunButtonClicked,
   onAddToExistingRunSetClicked,
   onAddToNewRunSetClicked,
   onUseAsTemplateClicked,
@@ -77,6 +79,7 @@ export default function RunDetail({
   onStopRunClicked: () => void;
   onReRunClicked: () => void;
   onEditRunButtonClicked: (run: Run) => void;
+  onDeleteRunButtonClicked: (run: Run) => void;
   onAddToExistingRunSetClicked: (run: Run) => void;
   onAddToNewRunSetClicked: (run: Run) => void;
   onUseAsTemplateClicked: (run: Run) => void;
@@ -141,6 +144,13 @@ export default function RunDetail({
               <DropdownMenuItem onClick={() => onEditRunButtonClicked(run)}>
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onDeleteRunButtonClicked(run)}
+                className="text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -4,13 +4,11 @@ import throttle from "lodash/throttle";
 import { useEffect, useState } from "react";
 import {
   redirect,
-  useFetcher,
   useLoaderData,
   useNavigate,
   useRevalidator,
   useSubmit,
 } from "react-router";
-import { toast } from "sonner";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import triggerDownload from "~/modules/app/helpers/triggerDownload";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
@@ -20,10 +18,10 @@ import addDialog from "~/modules/dialogs/addDialog";
 import { ProjectService } from "~/modules/projects/project";
 import exportRun from "~/modules/runs/helpers/exportRun";
 import { useCreateRunSetForRun } from "~/modules/runs/hooks/useCreateRunSetForRun";
+import { useRunActions } from "~/modules/runs/hooks/useRunActions";
 import { RunService } from "~/modules/runs/run";
 import type { Run } from "~/modules/runs/runs.types";
 import { RunSetService } from "~/modules/runSets/runSet";
-import EditRunDialog from "../components/editRunDialog";
 import RunDetail from "../components/run";
 import StopRunDialog from "../components/stopRunDialog";
 import type { Route } from "./+types/run.route";
@@ -130,6 +128,21 @@ export async function action({ request, params }: Route.ActionArgs) {
       });
       return { runSets: allRunSets.data };
     }
+    case "UPDATE_RUN": {
+      const run = await RunService.findById(params.runId);
+      if (!run) throw new Error("Run not found");
+      if (typeof payload.name !== "string") {
+        throw new Error("Run name is required and must be a string.");
+      }
+      await RunService.updateById(run._id, { name: payload.name });
+      return { success: true, intent: "UPDATE_RUN" };
+    }
+    case "DELETE_RUN": {
+      const run = await RunService.findById(params.runId);
+      if (!run) throw new Error("Run not found");
+      await RunService.deleteById(run._id);
+      return { success: true, intent: "DELETE_RUN" };
+    }
     default:
       return {};
   }
@@ -172,15 +185,18 @@ export default function ProjectRunRoute() {
     { paramPrefix: "sessions" },
   );
   const submit = useSubmit();
-  const fetcher = useFetcher();
   const navigate = useNavigate();
   const { revalidate } = useRevalidator();
-
-  useEffect(() => {
-    if (fetcher.state === "idle" && fetcher.data) {
-      toast.success("Updated run");
-    }
-  }, [fetcher.state, fetcher.data]);
+  const { openEditRunDialog, openDeleteRunDialog } = useRunActions({
+    projectId: project._id,
+    onDeleteSuccess: () => {
+      if (runSet?._id) {
+        navigate(`/projects/${project._id}/run-sets/${runSet._id}`);
+      } else {
+        navigate(`/projects/${project._id}`);
+      }
+    },
+  });
 
   const onExportRunButtonClicked = ({ exportType }: { exportType: string }) => {
     submit(
@@ -214,28 +230,6 @@ export default function ProjectRunRoute() {
         payload: {},
       }),
       { method: "POST", encType: "application/json" },
-    );
-  };
-
-  const onEditRunButtonClicked = (run: Run) => {
-    addDialog(
-      <EditRunDialog
-        run={run}
-        onEditRunClicked={(r: Run) => {
-          fetcher.submit(
-            JSON.stringify({
-              intent: "UPDATE_RUN",
-              entityId: r._id,
-              payload: { name: r.name },
-            }),
-            {
-              method: "PUT",
-              encType: "application/json",
-              action: `/projects/${project._id}?index`,
-            },
-          );
-        }}
-      />,
     );
   };
 
@@ -359,7 +353,8 @@ export default function ProjectRunRoute() {
       onExportRunButtonClicked={onExportRunButtonClicked}
       onStopRunClicked={openStopRunDialog}
       onReRunClicked={onReRunClicked}
-      onEditRunButtonClicked={onEditRunButtonClicked}
+      onEditRunButtonClicked={openEditRunDialog}
+      onDeleteRunButtonClicked={openDeleteRunDialog}
       onAddToExistingRunSetClicked={onAddToExistingRunSetClicked}
       onAddToNewRunSetClicked={() => openCreateRunSetDialog(run._id)}
       onUseAsTemplateClicked={onUseAsTemplateClicked}

--- a/app/modules/runs/containers/runs.route.tsx
+++ b/app/modules/runs/containers/runs.route.tsx
@@ -1,27 +1,19 @@
 import find from "lodash/find";
 import {
-  data,
-  redirect,
   useLoaderData,
   useNavigate,
   useParams,
   useRevalidator,
-  useSubmit,
 } from "react-router";
-import { toast } from "sonner";
 import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
-import addDialog from "~/modules/dialogs/addDialog";
-import ProjectAuthorization from "~/modules/projects/authorization";
-import { ProjectService } from "~/modules/projects/project";
 import { useCreateRunSetForRun } from "~/modules/runs/hooks/useCreateRunSetForRun";
+import { useRunActions } from "~/modules/runs/hooks/useRunActions";
 import { RunService } from "~/modules/runs/run";
 import type { Run } from "~/modules/runs/runs.types";
-import EditRunDialog from "../components/editRunDialog";
 import Runs from "../components/runs";
 import type { Route } from "./+types/runs.route";
 
@@ -55,53 +47,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return { runs: { data: runs, totalPages: getTotalPages(total) } };
 }
 
-export async function action({ request, params }: Route.ActionArgs) {
-  const { intent, entityId, payload = {} } = await request.json();
-
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
-
-  const { name } = payload;
-
-  const project = await ProjectService.findById(params.id);
-  if (!project) {
-    return data({ errors: { project: "Project not found" } }, { status: 400 });
-  }
-  switch (intent) {
-    case "UPDATE_RUN": {
-      if (typeof name !== "string") {
-        throw new Error("Run name is required and must be a string.");
-      }
-
-      if (!ProjectAuthorization.Runs.canManage(user, project)) {
-        throw new Error(
-          "You do not have permission to update runs in this project.",
-        );
-      }
-
-      const existingRun = await RunService.findById(entityId);
-      if (!existingRun) {
-        throw new Error("Run not found.");
-      }
-
-      await RunService.updateById(entityId, { name });
-      return {};
-    }
-    default: {
-      return {};
-    }
-  }
-}
-
 export default function ProjectRunsRoute() {
   const { runs } = useLoaderData();
   const { id: projectId } = useParams();
-  const submit = useSubmit();
   const navigate = useNavigate();
   const { revalidate } = useRevalidator();
   const { openCreateRunSetDialog } = useCreateRunSetForRun({
+    projectId: projectId!,
+  });
+  const { openEditRunDialog, openDeleteRunDialog } = useRunActions({
     projectId: projectId!,
   });
 
@@ -121,23 +75,6 @@ export default function ProjectRunsRoute() {
     sortValue: "name",
     filters: {},
   });
-
-  const onEditRunClicked = (run: Run) => {
-    submit(
-      JSON.stringify({
-        intent: "UPDATE_RUN",
-        entityId: run._id,
-        payload: { name: run.name },
-      }),
-      { method: "PUT", encType: "application/json" },
-    ).then(() => {
-      toast.success("Updated run");
-    });
-  };
-
-  const onEditRunButtonClicked = (run: Run) => {
-    addDialog(<EditRunDialog run={run} onEditRunClicked={onEditRunClicked} />);
-  };
 
   const onCreateRunButtonClicked = () => {
     navigate(`/projects/${projectId}/create-run`);
@@ -164,10 +101,13 @@ export default function ProjectRunsRoute() {
     if (!run) return null;
     switch (action) {
       case "EDIT":
-        onEditRunButtonClicked(run);
+        openEditRunDialog(run);
         break;
       case "DUPLICATE":
         onDuplicateRunButtonClicked(run);
+        break;
+      case "DELETE":
+        openDeleteRunDialog(run);
         break;
       case "ADD_TO_EXISTING_RUN_SET":
         navigate(`/projects/${projectId}/runs/${id}/add-to-run-set`);

--- a/app/modules/runs/helpers/getRunsItemActions.tsx
+++ b/app/modules/runs/helpers/getRunsItemActions.tsx
@@ -1,6 +1,6 @@
 import type { CollectionItemAction } from "@/components/ui/collectionContentItem";
 import includes from "lodash/includes";
-import { Copy, Edit, FolderPlus, ListPlus, Stamp } from "lucide-react";
+import { Copy, Edit, FolderPlus, ListPlus, Stamp, Trash2 } from "lucide-react";
 import { useContext } from "react";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import type { User } from "~/modules/users/users.types";
@@ -23,6 +23,12 @@ export default function useRunsItemActions(): () => CollectionItemAction[] {
         action: "DUPLICATE",
         icon: <Copy />,
         text: "Duplicate",
+      },
+      {
+        action: "DELETE",
+        icon: <Trash2 />,
+        text: "Delete",
+        variant: "destructive",
       },
     ];
 

--- a/app/modules/runs/hooks/useRunActions.tsx
+++ b/app/modules/runs/hooks/useRunActions.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+import { useFetcher } from "react-router";
+import { toast } from "sonner";
+import addDialog from "~/modules/dialogs/addDialog";
+import DeleteRunDialog from "~/modules/runs/components/deleteRunDialog";
+import EditRunDialog from "~/modules/runs/components/editRunDialog";
+import type { Run } from "~/modules/runs/runs.types";
+
+interface UseRunActionsOptions {
+  projectId: string;
+  onUpdateSuccess?: () => void;
+  onDeleteSuccess?: () => void;
+}
+
+export function useRunActions({
+  projectId,
+  onUpdateSuccess,
+  onDeleteSuccess,
+}: UseRunActionsOptions) {
+  const fetcher = useFetcher();
+
+  useEffect(() => {
+    if (fetcher.state === "idle" && fetcher.data) {
+      if (fetcher.data.success && fetcher.data.intent === "UPDATE_RUN") {
+        toast.success("Updated run");
+        addDialog(null);
+        onUpdateSuccess?.();
+      } else if (fetcher.data.success && fetcher.data.intent === "DELETE_RUN") {
+        toast.success("Deleted run");
+        addDialog(null);
+        onDeleteSuccess?.();
+      } else if (fetcher.data.errors) {
+        toast.error(fetcher.data.errors.general || "An error occurred");
+      }
+    }
+  }, [fetcher.state, fetcher.data, onDeleteSuccess, onUpdateSuccess]);
+
+  const submitEditRun = (run: Run) => {
+    fetcher.submit(
+      JSON.stringify({
+        intent: "UPDATE_RUN",
+        payload: { name: run.name },
+      }),
+      {
+        method: "PUT",
+        encType: "application/json",
+        action: `/projects/${projectId}/runs/${run._id}`,
+      },
+    );
+  };
+
+  const submitDeleteRun = (runId: string) => {
+    fetcher.submit(
+      JSON.stringify({
+        intent: "DELETE_RUN",
+        payload: {},
+      }),
+      {
+        method: "DELETE",
+        encType: "application/json",
+        action: `/projects/${projectId}/runs/${runId}`,
+      },
+    );
+  };
+
+  const openEditRunDialog = (run: Run) => {
+    addDialog(<EditRunDialog run={run} onEditRunClicked={submitEditRun} />);
+  };
+
+  const openDeleteRunDialog = (run: Run) => {
+    addDialog(
+      <DeleteRunDialog run={run} onDeleteRunClicked={submitDeleteRun} />,
+    );
+  };
+
+  return {
+    openEditRunDialog,
+    openDeleteRunDialog,
+    isSubmitting: fetcher.state !== "idle",
+  };
+}


### PR DESCRIPTION
Use a shared run actions hook for runs list and run detail, routing both dialogs through run.route action for UPDATE_RUN and DELETE_RUN.

Fixes #1516