### PR TITLE
Fixes workers watch to include bullMQ imports

### DIFF
--- a/workers/package.json
+++ b/workers/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --include './**/*.ts' -r dotenv/config ./index.ts dotenv_config_path=../.env",
+    "dev": "tsx watch --include '**/*' --exclude 'tmp/**' --exclude 'node_modules/**' -r dotenv/config ./index.ts dotenv_config_path=../.env",
     "prod": "tsx -r dotenv/config ./index.ts dotenv_config_path=../.env"
   },
   "dependencies": {


### PR DESCRIPTION
fixes #1527 

Reason for this change is because dynamic imports here:
https://github.com/National-Tutoring-Observatory/pipeline/blob/main/workers/index.ts#L11-L12

do not get included in the watch...so changes in task files do not trigger a reload in dev.