### PR TITLE
Show session-based progress for run sets

### DIFF
--- a/app/modules/runSets/components/runSetDetail.tsx
+++ b/app/modules/runSets/components/runSetDetail.tsx
@@ -33,7 +33,7 @@ export default function RunSetDetail({
   runSet,
   project,
   breadcrumbs,
-  runsProgress,
+  annotationProgress,
   onExportRunSetButtonClicked,
   onAddRunsClicked,
   onMergeClicked,
@@ -46,9 +46,11 @@ export default function RunSetDetail({
   runSet: RunSet;
   project: { _id: string; name: string };
   breadcrumbs: Breadcrumb[];
-  runsProgress: {
-    total: number;
-    completed: number;
+  annotationProgress: {
+    totalRuns: number;
+    completedRuns: number;
+    totalSessions: number;
+    completedSessions: number;
     running: number;
     startedAt: string | null;
   };
@@ -112,24 +114,39 @@ export default function RunSetDetail({
           </div>
         </PageHeaderRight>
       </PageHeader>
-      {runsProgress.running > 0 && (
-        <div className="relative mb-4">
-          <div className="absolute top-3 right-0 text-xs opacity-40">
-            Annotating runs {runsProgress.completed}/{runsProgress.total}
-            {(() => {
-              const estimate = formatTimeRemaining(
-                runsProgress.startedAt,
-                runsProgress.completed,
-                runsProgress.total,
-              );
-              return estimate ? ` · ${estimate}` : null;
-            })()}
+      {annotationProgress.running > 0 &&
+        annotationProgress.completedSessions <
+          annotationProgress.totalSessions && (
+          <div className="relative mb-6">
+            <div className="absolute top-3 right-0 text-xs opacity-40">
+              {annotationProgress.completedSessions === 0 ? (
+                "Starting..."
+              ) : (
+                <>
+                  {annotationProgress.completedRuns}/
+                  {annotationProgress.totalRuns} runs ·{" "}
+                  {annotationProgress.completedSessions}/
+                  {annotationProgress.totalSessions} sessions completed
+                  {(() => {
+                    const estimate = formatTimeRemaining(
+                      annotationProgress.startedAt,
+                      annotationProgress.completedSessions,
+                      annotationProgress.totalSessions,
+                    );
+                    return estimate ? ` · ${estimate}` : null;
+                  })()}
+                </>
+              )}
+            </div>
+            <Progress
+              value={
+                (annotationProgress.completedSessions /
+                  annotationProgress.totalSessions) *
+                100
+              }
+            />
           </div>
-          <Progress
-            value={(runsProgress.completed / runsProgress.total) * 100}
-          />
-        </div>
-      )}
+        )}
       <Flag flag="HAS_EVALUATIONS">
         <Tabs
           value={activeView}

--- a/app/modules/runSets/containers/runSetDetail.route.tsx
+++ b/app/modules/runSets/containers/runSetDetail.route.tsx
@@ -45,39 +45,27 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
 
   const runIds = runSet.runs ?? [];
-  const totalRuns = runIds.length;
-  let runsProgress = {
-    total: totalRuns,
-    completed: 0,
+  let annotationProgress = {
+    totalRuns: runIds.length,
+    completedRuns: 0,
+    totalSessions: 0,
+    completedSessions: 0,
     running: 0,
     startedAt: null as string | null,
   };
 
-  if (totalRuns > 0) {
-    const [completed, running, [earliestRun]] = await Promise.all([
-      RunService.count({ _id: { $in: runIds }, isComplete: true }),
-      RunService.count({ _id: { $in: runIds }, isRunning: true }),
-      RunService.find({
-        match: {
-          _id: { $in: runIds },
-          startedAt: { $exists: true, $ne: null },
-        },
-        sort: { startedAt: 1 },
-        pagination: { skip: 0, limit: 1 },
-      }),
-    ]);
-    runsProgress = {
-      total: totalRuns,
-      completed,
-      running,
-      startedAt: earliestRun ? String(earliestRun.startedAt) : null,
+  if (runIds.length > 0) {
+    const progress = await RunService.aggregateProgress(runIds);
+    annotationProgress = {
+      totalRuns: runIds.length,
+      ...progress,
     };
   }
 
   return {
     runSet,
     project,
-    runsProgress,
+    annotationProgress,
   };
 }
 
@@ -115,7 +103,8 @@ const debounceRevalidate = throttle((revalidate) => {
 }, 500);
 
 export default function RunSetDetailRoute() {
-  const { runSet, project, runsProgress } = useLoaderData<typeof loader>();
+  const { runSet, project, annotationProgress } =
+    useLoaderData<typeof loader>();
   const runIds = runSet.runs ?? [];
   const submit = useSubmit();
   const navigate = useNavigate();
@@ -164,11 +153,20 @@ export default function RunSetDetailRoute() {
 
   useHandleSockets({
     event: "ANNOTATE_RUN",
-    matches: runIds.map((runId) => ({
-      runId,
-      task: "ANNOTATE_RUN:FINISH",
-      status: "FINISHED",
-    })),
+    matches: runIds
+      .map((runId) => [
+        {
+          runId,
+          task: "ANNOTATE_RUN:PROCESS",
+          status: "FINISHED",
+        },
+        {
+          runId,
+          task: "ANNOTATE_RUN:FINISH",
+          status: "FINISHED",
+        },
+      ])
+      .flat(),
     callback: () => {
       debounceRevalidate(revalidate);
     },
@@ -218,7 +216,7 @@ export default function RunSetDetailRoute() {
       runSet={runSet}
       project={project}
       breadcrumbs={breadcrumbs}
-      runsProgress={runsProgress}
+      annotationProgress={annotationProgress}
       onExportRunSetButtonClicked={onExportRunSetButtonClicked}
       onAddRunsClicked={() =>
         navigate(`/projects/${project._id}/run-sets/${runSet._id}/add-runs`)

--- a/app/modules/runs/helpers/buildRunSessions.server.ts
+++ b/app/modules/runs/helpers/buildRunSessions.server.ts
@@ -12,7 +12,7 @@ export default async function buildRunSessions(
       name: session.name,
       fileType: session.fileType || "",
       sessionId,
-      status: "RUNNING",
+      status: "NOT_STARTED",
       startedAt: new Date(),
       finishedAt: new Date(),
     });

--- a/app/modules/runs/helpers/formatTimeRemaining.ts
+++ b/app/modules/runs/helpers/formatTimeRemaining.ts
@@ -1,16 +1,9 @@
-const MIN_COMPLETED_FOR_ESTIMATE = 3;
-
 export default function formatTimeRemaining(
   startedAt: Date | string | undefined | null,
   completed: number,
   total: number,
 ): string | null {
-  if (
-    !startedAt ||
-    completed < MIN_COMPLETED_FOR_ESTIMATE ||
-    completed >= total
-  )
-    return null;
+  if (!startedAt || completed < 1 || completed >= total) return null;
 
   const elapsedMs = Date.now() - new Date(startedAt).getTime();
   if (elapsedMs <= 0) return null;

--- a/app/modules/runs/run.ts
+++ b/app/modules/runs/run.ts
@@ -4,6 +4,7 @@ import runSchema from "~/lib/schemas/run.schema";
 import type { FindOptions, PaginateProps } from "~/modules/common/types";
 import buildRunSessions from "./helpers/buildRunSessions.server";
 import type { CreateRunProps, Run, RunSession } from "./runs.types";
+import aggregateProgressService from "./services/aggregateProgress.server";
 import buildRunSnapshot from "./services/buildRunSnapshot.server";
 import createRunAnnotations from "./services/createRunAnnotations.server";
 import paginateSessionsService from "./services/paginateSessions.server";
@@ -139,6 +140,10 @@ export class RunService {
   static async findOne(match: Record<string, any>): Promise<Run | null> {
     const docs = await this.find({ match });
     return docs[0] || null;
+  }
+
+  static aggregateProgress(runIds: string[]) {
+    return aggregateProgressService(runIds);
   }
 
   static paginateSessions(

--- a/app/modules/runs/services/__tests__/aggregateProgress.test.ts
+++ b/app/modules/runs/services/__tests__/aggregateProgress.test.ts
@@ -1,0 +1,130 @@
+import { Types } from "mongoose";
+import { beforeEach, describe, expect, it } from "vitest";
+import clearDocumentDB from "../../../../../test/helpers/clearDocumentDB";
+import createTestRun from "../../../../../test/helpers/createTestRun";
+import type { RunSession } from "../../runs.types";
+import aggregateProgress from "../aggregateProgress.server";
+
+const projectId = new Types.ObjectId().toString();
+const sessionId = () => new Types.ObjectId().toString();
+
+const buildSessions = (statuses: RunSession["status"][]) =>
+  statuses.map((status) => ({
+    sessionId: sessionId(),
+    name: `Session ${status}`,
+    status,
+    fileType: "txt",
+    startedAt: new Date(),
+    finishedAt: new Date(),
+  }));
+
+describe("aggregateProgress", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  it("returns zeros for empty run list", async () => {
+    const result = await aggregateProgress([]);
+    expect(result).toEqual({
+      completedRuns: 0,
+      totalSessions: 0,
+      completedSessions: 0,
+      running: 0,
+      startedAt: null,
+    });
+  });
+
+  it("counts sessions by status across runs", async () => {
+    const run1 = await createTestRun({
+      name: "Run 1",
+      project: projectId as any,
+      sessions: buildSessions(["DONE", "DONE", "NOT_STARTED"]),
+    });
+    const run2 = await createTestRun({
+      name: "Run 2",
+      project: projectId as any,
+      sessions: buildSessions(["RUNNING", "NOT_STARTED"]),
+    });
+
+    const result = await aggregateProgress([run1._id, run2._id]);
+
+    expect(result.totalSessions).toBe(5);
+    expect(result.completedSessions).toBe(2);
+  });
+
+  it("counts ERRORED and STOPPED as completed", async () => {
+    const run = await createTestRun({
+      name: "Run",
+      project: projectId as any,
+      sessions: buildSessions(["DONE", "ERRORED", "STOPPED", "NOT_STARTED"]),
+    });
+
+    const result = await aggregateProgress([run._id]);
+
+    expect(result.completedSessions).toBe(3);
+    expect(result.totalSessions).toBe(4);
+  });
+
+  it("counts completed and running runs", async () => {
+    const run1 = await createTestRun({
+      name: "Complete",
+      project: projectId as any,
+      isComplete: true,
+      isRunning: false,
+      sessions: buildSessions(["DONE"]),
+    });
+    const run2 = await createTestRun({
+      name: "Running",
+      project: projectId as any,
+      isComplete: false,
+      isRunning: true,
+      sessions: buildSessions(["RUNNING"]),
+    });
+    const run3 = await createTestRun({
+      name: "Queued",
+      project: projectId as any,
+      isComplete: false,
+      isRunning: false,
+      sessions: buildSessions(["NOT_STARTED"]),
+    });
+
+    const result = await aggregateProgress([run1._id, run2._id, run3._id]);
+
+    expect(result.completedRuns).toBe(1);
+    expect(result.running).toBe(1);
+  });
+
+  it("returns the earliest startedAt", async () => {
+    const early = new Date("2025-01-01");
+    const late = new Date("2025-06-01");
+
+    const run1 = await createTestRun({
+      name: "Late",
+      project: projectId as any,
+      startedAt: late,
+      sessions: [],
+    });
+    const run2 = await createTestRun({
+      name: "Early",
+      project: projectId as any,
+      startedAt: early,
+      sessions: [],
+    });
+
+    const result = await aggregateProgress([run1._id, run2._id]);
+
+    expect(result.startedAt).toBe(String(early));
+  });
+
+  it("returns null startedAt when no runs have started", async () => {
+    const run = await createTestRun({
+      name: "Not started",
+      project: projectId as any,
+      sessions: buildSessions(["NOT_STARTED"]),
+    });
+
+    const result = await aggregateProgress([run._id]);
+
+    expect(result.startedAt).toBeNull();
+  });
+});

--- a/app/modules/runs/services/aggregateProgress.server.ts
+++ b/app/modules/runs/services/aggregateProgress.server.ts
@@ -1,0 +1,70 @@
+import mongoose from "mongoose";
+import runSchema from "~/lib/schemas/run.schema";
+
+const RunModel = mongoose.models.Run || mongoose.model("Run", runSchema);
+
+export interface AggregateProgressResult {
+  completedRuns: number;
+  totalSessions: number;
+  completedSessions: number;
+  running: number;
+  startedAt: string | null;
+}
+
+export default async function aggregateProgress(
+  runIds: string[],
+): Promise<AggregateProgressResult> {
+  const objectIds = runIds.map((id) => new mongoose.Types.ObjectId(id));
+  const [result] = await RunModel.aggregate([
+    { $match: { _id: { $in: objectIds } } },
+    {
+      $facet: {
+        progress: [
+          {
+            $group: {
+              _id: null,
+              completedRuns: {
+                $sum: { $cond: ["$isComplete", 1, 0] },
+              },
+              running: {
+                $sum: { $cond: ["$isRunning", 1, 0] },
+              },
+              totalSessions: {
+                $sum: { $size: "$sessions" },
+              },
+              completedSessions: {
+                $sum: {
+                  $size: {
+                    $filter: {
+                      input: "$sessions",
+                      cond: {
+                        $in: ["$$this.status", ["DONE", "ERRORED", "STOPPED"]],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        earliest: [
+          { $match: { startedAt: { $exists: true, $ne: null } } },
+          { $sort: { startedAt: 1 } },
+          { $limit: 1 },
+          { $project: { startedAt: 1 } },
+        ],
+      },
+    },
+  ]);
+
+  const progress = result?.progress?.[0];
+  const earliest = result?.earliest?.[0];
+
+  return {
+    completedRuns: progress?.completedRuns ?? 0,
+    totalSessions: progress?.totalSessions ?? 0,
+    completedSessions: progress?.completedSessions ?? 0,
+    running: progress?.running ?? 0,
+    startedAt: earliest ? String(earliest.startedAt) : null,
+  };
+}


### PR DESCRIPTION
Fixes #1592

- Track progress by completed sessions (DONE/ERRORED/STOPPED) instead of runs
- Fix initial session status from RUNNING to NOT_STARTED
- Use MongoDB aggregation for calculations
- Show Starting until first session completes
- Lower time estimate threshold from 3 to 1 completed