### PR TITLE
Add session list sidebar for navigating between sessions within a run

### DIFF
--- a/app/modules/runs/__tests__/runSessions.route.test.ts
+++ b/app/modules/runs/__tests__/runSessions.route.test.ts
@@ -197,4 +197,153 @@ describe("runSessions.route loader", () => {
     expect(loaderData.run.name).toBe("Test Run");
     expect(loaderData.run.data).toBeUndefined();
   });
+
+  it("returns paginatedSessions and doneSessionsCount", async () => {
+    const user = await UserService.create({ username: "test_user", teams: [] });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+
+    const targetSessionId = new Types.ObjectId().toString();
+    const run = await createTestRun({
+      name: "Test Run",
+      project: project._id,
+      isRunning: false,
+      isComplete: false,
+      sessions: [
+        {
+          sessionId: targetSessionId,
+          name: "session_alpha.json",
+          fileType: "json",
+          status: "DONE",
+          startedAt: new Date(),
+          finishedAt: new Date(),
+        },
+        {
+          sessionId: new Types.ObjectId().toString(),
+          name: "session_beta.json",
+          fileType: "json",
+          status: "DONE",
+          startedAt: new Date(),
+          finishedAt: new Date(),
+        },
+        {
+          sessionId: new Types.ObjectId().toString(),
+          name: "session_gamma.json",
+          fileType: "json",
+          status: "RUNNING",
+          startedAt: new Date(),
+          finishedAt: new Date(),
+        },
+      ],
+    });
+
+    const cookieHeader = await loginUser(user._id);
+
+    const res = await loader({
+      request: new Request(
+        "http://localhost/projects/" +
+          project._id +
+          "/runs/" +
+          run._id +
+          "/sessions/" +
+          targetSessionId,
+        { headers: { cookie: cookieHeader } },
+      ),
+      params: {
+        projectId: project._id,
+        runId: run._id,
+        sessionId: targetSessionId,
+      },
+    } as any);
+
+    expect(res).not.toBeInstanceOf(Response);
+    const loaderData = res as any;
+    expect(loaderData.doneSessionsCount).toBe(2);
+    expect(loaderData.paginatedSessions).toBeDefined();
+    expect(loaderData.paginatedSessions.data).toHaveLength(3);
+    expect(loaderData.paginatedSessions.totalPages).toBe(1);
+  });
+
+  it("filters paginatedSessions by sidebar search params", async () => {
+    const user = await UserService.create({ username: "test_user", teams: [] });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+
+    const targetSessionId = new Types.ObjectId().toString();
+    const run = await createTestRun({
+      name: "Test Run",
+      project: project._id,
+      isRunning: false,
+      isComplete: false,
+      sessions: [
+        {
+          sessionId: targetSessionId,
+          name: "session_alpha.json",
+          fileType: "json",
+          status: "DONE",
+          startedAt: new Date(),
+          finishedAt: new Date(),
+        },
+        {
+          sessionId: new Types.ObjectId().toString(),
+          name: "session_beta.json",
+          fileType: "json",
+          status: "DONE",
+          startedAt: new Date(),
+          finishedAt: new Date(),
+        },
+        {
+          sessionId: new Types.ObjectId().toString(),
+          name: "session_gamma.json",
+          fileType: "json",
+          status: "DONE",
+          startedAt: new Date(),
+          finishedAt: new Date(),
+        },
+      ],
+    });
+
+    const cookieHeader = await loginUser(user._id);
+
+    const res = await loader({
+      request: new Request(
+        "http://localhost/projects/" +
+          project._id +
+          "/runs/" +
+          run._id +
+          "/sessions/" +
+          targetSessionId +
+          "?sidebarSearchValue=alpha",
+        { headers: { cookie: cookieHeader } },
+      ),
+      params: {
+        projectId: project._id,
+        runId: run._id,
+        sessionId: targetSessionId,
+      },
+    } as any);
+
+    expect(res).not.toBeInstanceOf(Response);
+    const loaderData = res as any;
+    expect(loaderData.paginatedSessions.data).toHaveLength(1);
+    expect(loaderData.paginatedSessions.data[0].name).toBe(
+      "session_alpha.json",
+    );
+  });
 });

--- a/app/modules/runs/components/runSessions.tsx
+++ b/app/modules/runs/components/runSessions.tsx
@@ -1,7 +1,13 @@
-import { PageHeader, PageHeaderLeft } from "@/components/ui/pageHeader";
+import {
+  PageHeader,
+  PageHeaderLeft,
+  PageHeaderRight,
+} from "@/components/ui/pageHeader";
+import { Spinner } from "@/components/ui/spinner";
 import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
-import type { Run } from "~/modules/runs/runs.types";
+import type { Run, RunSession } from "~/modules/runs/runs.types";
+import SessionListSidebar from "~/modules/sessions/components/sessionListSidebar";
 import SessionViewerContainer from "~/modules/sessions/containers/sessionViewerContainer";
 import type { Session, SessionFile } from "~/modules/sessions/sessions.types";
 
@@ -10,11 +16,31 @@ export default function RunSessions({
   sessionFile,
   session,
   breadcrumbs,
+  runLink,
+  currentSessionId,
+  doneSessionsCount,
+  paginatedSessions,
+  sidebarSearchValue,
+  sidebarCurrentPage,
+  sidebarIsSyncing,
+  isLoadingSession,
+  onSidebarSearchValueChanged,
+  onSidebarPaginationChanged,
 }: {
   run: Run;
   sessionFile: SessionFile;
   session: Session;
   breadcrumbs: Breadcrumb[];
+  runLink: string;
+  currentSessionId: string;
+  doneSessionsCount: number;
+  paginatedSessions: { data: RunSession[]; count: number; totalPages: number };
+  sidebarSearchValue: string;
+  sidebarCurrentPage: number;
+  sidebarIsSyncing: boolean;
+  isLoadingSession: boolean;
+  onSidebarSearchValueChanged: (value: string) => void;
+  onSidebarPaginationChanged: (value: number) => void;
 }) {
   return (
     <div className="max-w-6xl p-8">
@@ -22,12 +48,37 @@ export default function RunSessions({
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />
         </PageHeaderLeft>
+        <PageHeaderRight>
+          <span className="text-sm">
+            {doneSessionsCount} of {run.sessions.length} done
+          </span>
+        </PageHeaderRight>
       </PageHeader>
-      <SessionViewerContainer
-        run={run}
-        session={session}
-        sessionFile={sessionFile}
-      />
+      <div className="flex h-[calc(100vh-140px)] rounded-md border">
+        <SessionListSidebar
+          sessions={paginatedSessions.data}
+          totalPages={paginatedSessions.totalPages}
+          count={paginatedSessions.count}
+          currentSessionId={currentSessionId}
+          runLink={runLink}
+          searchValue={sidebarSearchValue}
+          currentPage={sidebarCurrentPage}
+          isSyncing={sidebarIsSyncing}
+          onSearchValueChanged={onSidebarSearchValueChanged}
+          onPaginationChanged={onSidebarPaginationChanged}
+        />
+        {isLoadingSession ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Spinner className="size-6" />
+          </div>
+        ) : (
+          <SessionViewerContainer
+            run={run}
+            session={session}
+            sessionFile={sessionFile}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/app/modules/runs/containers/runSessions.route.tsx
+++ b/app/modules/runs/containers/runSessions.route.tsx
@@ -1,7 +1,10 @@
 import fse from "fs-extra";
+import filter from "lodash/filter";
 import find from "lodash/find";
 import map from "lodash/map";
-import { redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData, useNavigation } from "react-router";
+import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
+import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
@@ -43,11 +46,44 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const runSetId = params.runSetId;
   const runSet = runSetId ? await RunSetService.findById(runSetId) : null;
 
-  return { project, run, session, sessionFile, runSet };
+  const sidebarQueryParams = getQueryParamsFromRequest(
+    request,
+    { searchValue: "", currentPage: 1, sort: "name", filters: {} },
+    { paramPrefix: "sidebar" },
+  );
+
+  const paginatedSessions = RunService.paginateSessions(run.sessions, {
+    searchValue: sidebarQueryParams.searchValue,
+    sort: sidebarQueryParams.sort,
+    page: sidebarQueryParams.currentPage,
+    filters: sidebarQueryParams.filters,
+  });
+
+  const doneSessionsCount = filter(run.sessions, { status: "DONE" }).length;
+
+  return {
+    project,
+    run,
+    session,
+    sessionFile,
+    runSet,
+    paginatedSessions,
+    doneSessionsCount,
+  };
 }
 
-export default function ProjectRunSessionsRoute() {
-  const { project, run, sessionFile, session, runSet } = useLoaderData();
+export default function ProjectRunSessionsRoute({
+  params,
+}: Route.ComponentProps) {
+  const {
+    project,
+    run,
+    sessionFile,
+    session,
+    runSet,
+    paginatedSessions,
+    doneSessionsCount,
+  } = useLoaderData();
 
   const parentBreadcrumbs = runSet
     ? [
@@ -90,12 +126,39 @@ export default function ProjectRunSessionsRoute() {
     },
   ];
 
+  const {
+    searchValue: sidebarSearchValue,
+    setSearchValue: setSidebarSearchValue,
+    currentPage: sidebarCurrentPage,
+    setCurrentPage: setSidebarCurrentPage,
+    isSyncing: sidebarIsSyncing,
+  } = useSearchQueryParams(
+    { searchValue: "", currentPage: 1, sortValue: "name" },
+    { paramPrefix: "sidebar" },
+  );
+
+  const navigation = useNavigation();
+  const isLoadingSession =
+    navigation.state === "loading" &&
+    navigation.location?.pathname.endsWith(`/sessions/${params.sessionId}`) ===
+      false;
+
   return (
     <RunSessions
       run={run}
       session={session}
       sessionFile={sessionFile}
       breadcrumbs={breadcrumbs}
+      runLink={runLink}
+      currentSessionId={params.sessionId}
+      doneSessionsCount={doneSessionsCount}
+      paginatedSessions={paginatedSessions}
+      sidebarSearchValue={sidebarSearchValue}
+      sidebarCurrentPage={sidebarCurrentPage}
+      sidebarIsSyncing={sidebarIsSyncing}
+      isLoadingSession={isLoadingSession}
+      onSidebarSearchValueChanged={setSidebarSearchValue}
+      onSidebarPaginationChanged={setSidebarCurrentPage}
     />
   );
 }

--- a/app/modules/runs/run.ts
+++ b/app/modules/runs/run.ts
@@ -152,6 +152,7 @@ export class RunService {
       searchValue?: string;
       sort?: string;
       page?: string | number;
+      pageSize?: number;
       filters?: Record<string, string>;
     },
   ) {

--- a/app/modules/runs/services/paginateSessions.server.ts
+++ b/app/modules/runs/services/paginateSessions.server.ts
@@ -7,6 +7,7 @@ interface PaginateSessionsProps {
   searchValue?: string;
   sort?: string;
   page?: string | number;
+  pageSize?: number;
   filters?: Record<string, string>;
 }
 
@@ -30,12 +31,12 @@ export default function paginateSessions(
   const field = desc ? sortField.slice(1) : sortField;
   const sorted = orderBy(filtered, [field], [desc ? "desc" : "asc"]);
 
-  const { skip, limit } = getPaginationParams(props.page);
+  const { skip, limit } = getPaginationParams(props.page, props.pageSize);
   const data = sorted.slice(skip, skip + limit);
 
   return {
     data,
     count: filtered.length,
-    totalPages: getTotalPages(filtered.length),
+    totalPages: getTotalPages(filtered.length, props.pageSize),
   };
 }

--- a/app/modules/sessions/components/sessionListSidebar.tsx
+++ b/app/modules/sessions/components/sessionListSidebar.tsx
@@ -1,0 +1,138 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import clsx from "clsx";
+import { ChevronLeft, ChevronRight, SearchIcon } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { Link } from "react-router";
+import {
+  STATUS_META,
+  getRunSessionStatusKey,
+} from "~/modules/runs/helpers/statusMeta";
+import type { RunSession } from "~/modules/runs/runs.types";
+
+export default function SessionListSidebar({
+  sessions,
+  totalPages,
+  count,
+  currentSessionId,
+  runLink,
+  searchValue,
+  currentPage,
+  isSyncing,
+  onSearchValueChanged,
+  onPaginationChanged,
+}: {
+  sessions: RunSession[];
+  totalPages: number;
+  count: number;
+  currentSessionId: string;
+  runLink: string;
+  searchValue: string;
+  currentPage: number;
+  isSyncing: boolean;
+  onSearchValueChanged: (value: string) => void;
+  onPaginationChanged: (value: number) => void;
+}) {
+  const activeRef = useRef<HTMLAnchorElement | null>(null);
+
+  useEffect(() => {
+    if (activeRef.current) {
+      activeRef.current.scrollIntoView({ block: "nearest" });
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full w-72 shrink-0 flex-col border-r">
+      <div className="border-b p-3">
+        <div className="relative">
+          <SearchIcon className="text-muted-foreground absolute top-2.5 left-3 size-4" />
+          <Input
+            placeholder="Search sessions..."
+            value={searchValue}
+            className="pl-9 shadow-none"
+            onChange={(e) => onSearchValueChanged(e.target.value)}
+          />
+        </div>
+        <div className="text-muted-foreground mt-2 flex items-center gap-1.5 text-xs">
+          <span>
+            {count} session{count !== 1 ? "s" : ""}
+          </span>
+          {isSyncing && <Spinner className="size-3" />}
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {sessions.map((session) => {
+          const isCurrent = session.sessionId === currentSessionId;
+          const isDone = session.status === "DONE";
+          const statusMeta =
+            STATUS_META[getRunSessionStatusKey(session.status)];
+
+          const content = (
+            <div className="py-1">
+              <div className="truncate text-sm font-medium">{session.name}</div>
+              <div className="text-muted-foreground mt-0.5 flex items-center gap-1 text-xs">
+                <span className="flex items-center gap-1 [&_svg]:size-3">
+                  {statusMeta.icon}
+                </span>
+                <span>{statusMeta.text}</span>
+              </div>
+            </div>
+          );
+
+          if (!isDone) {
+            return (
+              <div
+                key={session.sessionId}
+                className="cursor-default border-b px-3 py-2 opacity-50"
+              >
+                {content}
+              </div>
+            );
+          }
+
+          return (
+            <Link
+              key={session.sessionId}
+              ref={isCurrent ? activeRef : undefined}
+              to={`${runLink}/sessions/${session.sessionId}`}
+              className={clsx("block border-b px-3 py-2", {
+                "bg-accent": isCurrent,
+                "hover:bg-muted": !isCurrent,
+              })}
+            >
+              {content}
+            </Link>
+          );
+        })}
+      </div>
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between border-t px-3 py-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            aria-label="Previous page"
+            disabled={currentPage <= 1}
+            onClick={() => onPaginationChanged(currentPage - 1)}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <span className="text-muted-foreground text-xs">
+            {currentPage} / {totalPages}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            aria-label="Next page"
+            disabled={currentPage >= totalPages}
+            onClick={() => onPaginationChanged(currentPage + 1)}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/modules/sessions/components/sessionViewer.tsx
+++ b/app/modules/sessions/components/sessionViewer.tsx
@@ -45,10 +45,10 @@ export default function SessionViewer({
   const hasSelectedAnnotation = selectedUtteranceIndex !== null;
 
   return (
-    <div className="flex h-[calc(100vh-140px)] rounded-md border">
+    <div className="flex h-full flex-1">
       <div
         id="session-viewer-scroll-container"
-        className="flex h-full w-3/5 flex-col overflow-y-scroll scroll-smooth border-r p-4"
+        className="flex h-full w-[480px] shrink-0 flex-col overflow-y-scroll scroll-smooth border-r p-4"
       >
         {map(sessionFile.transcript, (utterance: Utterance, index: number) => {
           const isSelected = selectedUtteranceId === utterance._id;
@@ -64,7 +64,7 @@ export default function SessionViewer({
           );
         })}
       </div>
-      <div className="flex h-full w-2/5 flex-col pt-8">
+      <div className="flex h-full w-80 min-w-0 shrink-0 flex-col pt-8">
         <SessionViewerDetails
           session={session}
           utteranceCount={utteranceCount}


### PR DESCRIPTION
Converts the session viewer from a 2-column layout (transcript + annotations) to a 3-column layout with a searchable, paginated session list sidebar. Researchers can now navigate between annotated sessions without returning to the run detail page. Also adds pageSize support to paginateSessions and loader tests for the new sidebar data.

Fixes #571