### PR TITLE
Prevent double-submission when creating a run

### DIFF
--- a/app/modules/app/__tests__/useSubmitGuard.test.ts
+++ b/app/modules/app/__tests__/useSubmitGuard.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import useSubmitGuard from "../hooks/useSubmitGuard";
+
+function createMockFetcher(state = "idle" as string, data?: any) {
+  return { state, data } as ReturnType<
+    typeof import("react-router").useFetcher
+  >;
+}
+
+describe("useSubmitGuard", () => {
+  it("allows the first call through", () => {
+    const fetcher = createMockFetcher();
+    const { result } = renderHook(() => useSubmitGuard(fetcher));
+
+    const fn = vi.fn();
+    act(() => {
+      result.current.guard(fn)("arg1");
+    });
+
+    expect(fn).toHaveBeenCalledWith("arg1");
+  });
+
+  it("blocks a second click before React re-renders", () => {
+    const fetcher = createMockFetcher();
+    const { result } = renderHook(() => useSubmitGuard(fetcher));
+
+    const submit = vi.fn();
+    const guarded = result.current.guard(submit);
+
+    act(() => {
+      guarded();
+      guarded();
+    });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets guard when fetcher returns to idle", () => {
+    let fetcher = createMockFetcher();
+    const { result, rerender } = renderHook(() => useSubmitGuard(fetcher));
+
+    const fn = vi.fn();
+    act(() => {
+      result.current.guard(fn)();
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    fetcher = createMockFetcher("submitting");
+    rerender();
+
+    fetcher = createMockFetcher("idle");
+    rerender();
+
+    act(() => {
+      result.current.guard(fn)();
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps isSubmitting true after success while waiting for navigation", () => {
+    const actionSucceeded = true;
+    const fetcher = createMockFetcher("idle");
+    const { result } = renderHook(() =>
+      useSubmitGuard(fetcher, actionSucceeded),
+    );
+
+    expect(result.current.isSubmitting).toBe(true);
+  });
+
+  it("stays guarded after success while waiting for navigation", () => {
+    let fetcher = createMockFetcher();
+    let actionSucceeded = false;
+    const { result, rerender } = renderHook(() =>
+      useSubmitGuard(fetcher, actionSucceeded),
+    );
+
+    const submit = vi.fn();
+    act(() => {
+      result.current.guard(submit)();
+    });
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    actionSucceeded = true;
+    fetcher = createMockFetcher("submitting");
+    rerender();
+
+    fetcher = createMockFetcher("idle");
+    rerender();
+
+    act(() => {
+      result.current.guard(submit)();
+    });
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows resubmission after an error", () => {
+    let fetcher = createMockFetcher();
+    const actionSucceeded = false;
+    const { result, rerender } = renderHook(() =>
+      useSubmitGuard(fetcher, actionSucceeded),
+    );
+
+    const submit = vi.fn();
+    act(() => {
+      result.current.guard(submit)();
+    });
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    fetcher = createMockFetcher("submitting");
+    rerender();
+
+    fetcher = createMockFetcher("idle");
+    rerender();
+
+    act(() => {
+      result.current.guard(submit)();
+    });
+    expect(submit).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports isSubmitting based on fetcher state", () => {
+    let fetcher = createMockFetcher("submitting");
+    const { result, rerender } = renderHook(() => useSubmitGuard(fetcher));
+
+    expect(result.current.isSubmitting).toBe(true);
+
+    fetcher = createMockFetcher("idle");
+    rerender();
+
+    expect(result.current.isSubmitting).toBe(false);
+  });
+});

--- a/app/modules/app/hooks/useSubmitGuard.ts
+++ b/app/modules/app/hooks/useSubmitGuard.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from "react";
+import type { useFetcher } from "react-router";
+
+export default function useSubmitGuard(
+  fetcher: ReturnType<typeof useFetcher>,
+  shouldStayBusy = false,
+) {
+  const guardRef = useRef(false);
+
+  useEffect(() => {
+    if (fetcher.state === "idle" && !shouldStayBusy) {
+      guardRef.current = false;
+    }
+  }, [fetcher.state, shouldStayBusy]);
+
+  const isSubmitting = fetcher.state !== "idle" || shouldStayBusy;
+
+  const guard = <T extends (...args: any[]) => void>(fn: T): T => {
+    return ((...args: any[]) => {
+      if (guardRef.current) return;
+      guardRef.current = true;
+      fn(...args);
+    }) as T;
+  };
+
+  return { isSubmitting, guard };
+}

--- a/app/modules/runs/containers/createRun.route.tsx
+++ b/app/modules/runs/containers/createRun.route.tsx
@@ -2,6 +2,7 @@ import map from "lodash/map";
 import { useEffect } from "react";
 import { redirect, useFetcher, useLoaderData, useNavigate } from "react-router";
 import { toast } from "sonner";
+import useSubmitGuard from "~/modules/app/hooks/useSubmitGuard";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
@@ -80,8 +81,10 @@ export default function ProjectCreateRunRoute() {
   const { project, initialRun, duplicateWarnings } = useLoaderData();
   const fetcher = useFetcher();
   const navigate = useNavigate();
-  const isSubmitting =
-    fetcher.state !== "idle" || fetcher.data?.intent === "CREATE_AND_START_RUN";
+  const { isSubmitting, guard } = useSubmitGuard(
+    fetcher,
+    fetcher.data?.intent === "CREATE_AND_START_RUN",
+  );
 
   const onStartRunClicked = ({
     name,
@@ -129,7 +132,7 @@ export default function ProjectCreateRunRoute() {
   return (
     <CreateRunComponent
       breadcrumbs={breadcrumbs}
-      onStartRunClicked={onStartRunClicked}
+      onStartRunClicked={guard(onStartRunClicked)}
       isSubmitting={isSubmitting}
       initialRun={initialRun}
       duplicateWarnings={duplicateWarnings}


### PR DESCRIPTION
Adds a synchronous ref guard to block rapid re-clicks before React re-renders with the updated fetcher state.

Fixes #1406