### PR TITLE
Remove legacy collections/ storage path fallback

### DIFF
--- a/app/migrations/20260305084540-remove-legacy-collections-exports.ts
+++ b/app/migrations/20260305084540-remove-legacy-collections-exports.ts
@@ -1,0 +1,51 @@
+import type { Db } from "mongodb";
+import type {
+  MigrationFile,
+  MigrationResult,
+} from "~/modules/migrations/types";
+import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
+
+export default {
+  id: "20260305084540-remove-legacy-collections-exports",
+  name: "Remove Legacy Collections Exports",
+  description:
+    "Delete old export files at storage/{projectId}/collections/{runSetId}/exports left over from the collections → run-sets rename",
+
+  async up(db: Db): Promise<MigrationResult> {
+    console.log("Starting Remove Legacy Collections Exports migration...");
+
+    const storage = getStorageAdapter();
+
+    const runSets = await db
+      .collection("runsets")
+      .find({}, { projection: { _id: 1, project: 1 } })
+      .toArray();
+
+    console.log(`Found ${runSets.length} run sets to check`);
+
+    let removed = 0;
+    let failed = 0;
+
+    for (const runSet of runSets) {
+      const legacyPath = `storage/${runSet.project}/collections/${runSet._id}/exports`;
+      try {
+        await storage.removeDir({ sourcePath: legacyPath });
+        removed++;
+        console.log(`Removed legacy exports: ${legacyPath}`);
+      } catch (error) {
+        failed++;
+        console.log(
+          `Failed to remove ${legacyPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    console.log(`\n✓ Migration complete: ${removed} removed, ${failed} failed`);
+
+    return {
+      success: failed === 0,
+      message: `Removed legacy exports for ${removed} run sets (${failed} failed)`,
+      stats: { migrated: removed, failed },
+    };
+  },
+} satisfies MigrationFile;

--- a/app/modules/runSets/__tests__/downloadRunSet.route.test.ts
+++ b/app/modules/runSets/__tests__/downloadRunSet.route.test.ts
@@ -224,37 +224,4 @@ describe("downloadRunSet.route loader", () => {
       runSet._id,
     );
   });
-
-  it("falls back to legacy collections/ path for pre-migration exports", async () => {
-    const legacyDirectory = `storage/${runSet.project}/collections/${runSet._id}/exports`;
-    const metaCsv = Buffer.from("runId,runName\n123,Test Run");
-    const utterancesCsv = Buffer.from("sessionId,utteranceId,text\n1,1,Hello");
-
-    await storage.upload({
-      file: { buffer: metaCsv, size: metaCsv.length, type: "text/csv" },
-      uploadPath: `${legacyDirectory}/${runSet.project}-${runSet._id}-meta.csv`,
-    });
-    await storage.upload({
-      file: {
-        buffer: utterancesCsv,
-        size: utterancesCsv.length,
-        type: "text/csv",
-      },
-      uploadPath: `${legacyDirectory}/${runSet.project}-${runSet._id}-utterances.csv`,
-    });
-
-    const res = await loader({
-      request: new Request(
-        `http://localhost/api/downloads/${project._id}/run-sets/${runSet._id}?exportType=CSV`,
-        { headers: { cookie: cookieHeader } },
-      ),
-      params: { projectId: project._id, runSetId: runSet._id },
-      context: {},
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Content-Type")).toBe(
-      "application/zip",
-    );
-  });
 });

--- a/app/modules/runSets/containers/downloadRunSet.route.tsx
+++ b/app/modules/runSets/containers/downloadRunSet.route.tsx
@@ -11,18 +11,12 @@ import type { StorageAdapter } from "~/modules/storage/storage.types";
 import { RunSetService } from "../runSet";
 import type { Route } from "./+types/downloadRunSet.route";
 
-// TODO #1436 cleanup: remove LEGACY_PATH, buildExportFilePaths, downloadFiles,
-// and the try/catch fallback in the loader once the migration has run in production.
-const CURRENT_PATH = "run-sets";
-const LEGACY_PATH = "collections";
-
 function buildExportFilePaths(
   runSet: RunSet,
-  pathSegment: string,
+  outputDirectory: string,
   exportType: string | null,
   annotationType: string | undefined,
 ) {
-  const outputDirectory = `storage/${runSet.project}/${pathSegment}/${runSet._id}/exports`;
   const files: { path: string; name: string }[] = [];
 
   if (exportType === "CSV") {
@@ -98,25 +92,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const storage = getStorageAdapter();
 
-  // Try current path first, fall back to legacy path for pre-migration exports
-  let localPaths;
-  try {
-    const files = buildExportFilePaths(
-      runSet,
-      CURRENT_PATH,
-      exportType,
-      annotationType,
-    );
-    localPaths = await downloadFiles(storage, files);
-  } catch {
-    const legacyFiles = buildExportFilePaths(
-      runSet,
-      LEGACY_PATH,
-      exportType,
-      annotationType,
-    );
-    localPaths = await downloadFiles(storage, legacyFiles);
-  }
+  const outputDirectory = `storage/${runSet.project}/run-sets/${runSet._id}/exports`;
+  const files = buildExportFilePaths(
+    runSet,
+    outputDirectory,
+    exportType,
+    annotationType,
+  );
+  const localPaths = await downloadFiles(storage, files);
 
   const archive = archiver("zip", {
     zlib: { level: 9 },

--- a/workers/general/deleteRunSetData.ts
+++ b/workers/general/deleteRunSetData.ts
@@ -13,9 +13,5 @@ export default async function deleteRunSetData(job: Job) {
   const exportsDir = `storage/${projectId}/run-sets/${runSetId}/exports`;
   await storage.removeDir({ sourcePath: exportsDir });
 
-  // TODO #1436 cleanup: remove legacy path deletion once migration has run
-  const legacyExportsDir = `storage/${projectId}/collections/${runSetId}/exports`;
-  await storage.removeDir({ sourcePath: legacyExportsDir });
-
   return { status: "OK", runSetId };
 }


### PR DESCRIPTION
## Summary
- Remove backward-compatibility code that tried the old `collections/` path when `run-sets/` failed (added in #1436)
- Simplify `downloadRunSet` loader to use `run-sets/` path directly
- Remove legacy `collections/` path deletion from `deleteRunSetData` worker
- Remove legacy fallback test
- Add migration to clean up old export files at `collections/` path

Fixes #1523