### PR TITLE
Show failed session count on runs with errors

### DIFF
--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -29,6 +29,7 @@ import {
   Pencil,
   Stamp,
   Trash2,
+  TriangleAlert,
 } from "lucide-react";
 import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
@@ -208,6 +209,19 @@ export default function RunDetail({
             <AlertTitle>Run stopped</AlertTitle>
             <AlertDescription>
               This run was stopped before all sessions were annotated.
+            </AlertDescription>
+          </Alert>
+        )}
+        {run.isComplete && run.hasErrored && (
+          <Alert>
+            <TriangleAlert className="h-4 w-4" />
+            <AlertTitle>
+              {run.sessions.filter((s) => s.status === "ERRORED").length} of{" "}
+              {run.sessions.length} session
+              {run.sessions.length === 1 ? "" : "s"} failed
+            </AlertTitle>
+            <AlertDescription>
+              This run completed but some sessions failed during annotation.
             </AlertDescription>
           </Alert>
         )}

--- a/app/modules/runs/helpers/getRunsItemAttributes.tsx
+++ b/app/modules/runs/helpers/getRunsItemAttributes.tsx
@@ -17,8 +17,22 @@ interface Options {
 export default function getRunsItemAttributes(item: Run, options?: Options) {
   const promptName = get(item, "snapshot.prompt.name", "");
 
+  let statusMeta = STATUS_META[getRunStatusKey(item)];
+
+  if (item.isComplete && item.hasErrored) {
+    const failedCount = item.sessions.filter(
+      (s) => s.status === "ERRORED",
+    ).length;
+    if (failedCount > 0) {
+      statusMeta = {
+        ...statusMeta,
+        text: `${statusMeta.text} - ${failedCount} session${failedCount === 1 ? "" : "s"} failed`,
+      };
+    }
+  }
+
   const meta = [
-    STATUS_META[getRunStatusKey(item)],
+    statusMeta,
     {
       text: `Annotation type - ${getAnnotationLabel(item.annotationType)}`,
     },


### PR DESCRIPTION
## Summary

- In the runs list, the status now shows "Failed - X session(s) failed" instead of just "Failed" when a run completes with some errored sessions
- On the run detail page, an alert banner shows "X of Y sessions failed" with context, similar to the existing "Run stopped" alert

Fixes #1589