### PR TITLE
Improve time and cost estimates for run sets

### DIFF
--- a/app/modules/runSets/__tests__/calculateEstimates.test.ts
+++ b/app/modules/runSets/__tests__/calculateEstimates.test.ts
@@ -31,6 +31,7 @@ function expectedCost(
   numPrompts: number,
   modelIndices: number[],
   numSessions: number,
+  verificationMultiplier = 1,
 ) {
   const inputTokens = 250;
   const outputTokens = 250;
@@ -40,6 +41,7 @@ function expectedCost(
       sum +
       numPrompts *
         numSessions *
+        verificationMultiplier *
         ((inputTokens / 1_000_000) * pricing.inputCostPer1M +
           (outputTokens / 1_000_000) * pricing.outputCostPer1M)
     );
@@ -47,7 +49,7 @@ function expectedCost(
 }
 
 function expectedTime(numDefinitions: number, numSessions: number) {
-  return (numDefinitions * numSessions * 2) / 3;
+  return (numDefinitions * numSessions * 10) / 5;
 }
 
 describe("calculateEstimates", () => {
@@ -77,5 +79,52 @@ describe("calculateEstimates", () => {
 
     expect(result.estimatedCost).toBe(0);
     expect(result.estimatedTimeSeconds).toBe(0);
+  });
+
+  it("doubles time and cost when verification is enabled", () => {
+    const definitions = [makeDefinition("promptA", 1, allModels[0])];
+    const result = calculateEstimates(definitions, Array(10).fill({}), {
+      shouldRunVerification: true,
+    });
+
+    expect(result.estimatedCost).toBeCloseTo(expectedCost(1, [0], 10, 2), 5);
+    expect(result.estimatedTimeSeconds).toBeCloseTo(expectedTime(1, 10) * 2, 1);
+  });
+
+  it("uses historical avgSecondsPerSession when provided", () => {
+    const definitions = [makeDefinition("promptA", 1, allModels[0])];
+    const result = calculateEstimates(definitions, Array(10).fill({}), {
+      avgSecondsPerSession: 8,
+    });
+
+    expect(result.estimatedTimeSeconds).toBe(1 * 10 * 8);
+  });
+
+  it("uses historical avgSecondsPerSession with verification", () => {
+    const definitions = [makeDefinition("promptA", 1, allModels[0])];
+    const result = calculateEstimates(definitions, Array(10).fill({}), {
+      avgSecondsPerSession: 8,
+      shouldRunVerification: true,
+    });
+
+    expect(result.estimatedTimeSeconds).toBe(1 * 10 * 8 * 2);
+  });
+
+  it("falls back to default when avgSecondsPerSession is null", () => {
+    const definitions = [makeDefinition("promptA", 1, allModels[0])];
+    const result = calculateEstimates(definitions, Array(10).fill({}), {
+      avgSecondsPerSession: null,
+    });
+
+    expect(result.estimatedTimeSeconds).toBeCloseTo(expectedTime(1, 10), 1);
+  });
+
+  it("falls back to default when avgSecondsPerSession is 0", () => {
+    const definitions = [makeDefinition("promptA", 1, allModels[0])];
+    const result = calculateEstimates(definitions, Array(10).fill({}), {
+      avgSecondsPerSession: 0,
+    });
+
+    expect(result.estimatedTimeSeconds).toBeCloseTo(expectedTime(1, 10), 1);
   });
 });

--- a/app/modules/runSets/__tests__/formatEstimates.test.ts
+++ b/app/modules/runSets/__tests__/formatEstimates.test.ts
@@ -21,22 +21,30 @@ describe("formatCost", () => {
 });
 
 describe("formatTime", () => {
-  it("formats seconds", () => {
-    expect(formatTime(0)).toBe("0s");
-    expect(formatTime(30)).toBe("30s");
-    expect(formatTime(59)).toBe("59s");
+  it("shows < 30s for values under 30 seconds", () => {
+    expect(formatTime(0)).toBe("< 30s");
+    expect(formatTime(15)).toBe("< 30s");
+    expect(formatTime(29)).toBe("< 30s");
   });
 
-  it("formats minutes", () => {
-    expect(formatTime(60)).toBe("1m");
-    expect(formatTime(90)).toBe("1m 30s");
-    expect(formatTime(120)).toBe("2m");
+  it("shows ~ 1 min for values between 30 and 59 seconds", () => {
+    expect(formatTime(30)).toBe("~ 1 min");
+    expect(formatTime(45)).toBe("~ 1 min");
+    expect(formatTime(59)).toBe("~ 1 min");
+  });
+
+  it("rounds to nearest minute", () => {
+    expect(formatTime(60)).toBe("~ 1 min");
+    expect(formatTime(70)).toBe("~ 1 min");
+    expect(formatTime(90)).toBe("~ 2 min");
+    expect(formatTime(120)).toBe("~ 2 min");
+    expect(formatTime(150)).toBe("~ 3 min");
   });
 
   it("formats hours and minutes", () => {
-    expect(formatTime(3600)).toBe("1h");
-    expect(formatTime(3660)).toBe("1h 1m");
-    expect(formatTime(5400)).toBe("1h 30m");
-    expect(formatTime(7200)).toBe("2h");
+    expect(formatTime(3600)).toBe("~ 1h");
+    expect(formatTime(3660)).toBe("~ 1h 1 min");
+    expect(formatTime(5400)).toBe("~ 1h 30 min");
+    expect(formatTime(7200)).toBe("~ 2h");
   });
 });

--- a/app/modules/runSets/components/estimateSummary.tsx
+++ b/app/modules/runSets/components/estimateSummary.tsx
@@ -28,7 +28,7 @@ export default function EstimateSummary({
           </div>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Estimate based on ~2s per API call with parallelism</p>
+          <p>Estimated processing time</p>
         </TooltipContent>
       </Tooltip>
 

--- a/app/modules/runSets/containers/runSetCreate.route.tsx
+++ b/app/modules/runSets/containers/runSetCreate.route.tsx
@@ -178,7 +178,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     }
   }
 
-  return { project, prefillData };
+  const avgSecondsPerSession = await RunService.getAverageSecondsPerSession(
+    params.projectId,
+  );
+
+  return { project, prefillData, avgSecondsPerSession };
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -250,7 +254,8 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export default function RunSetCreateRoute() {
-  const { project, prefillData } = useLoaderData<typeof loader>();
+  const { project, prefillData, avgSecondsPerSession } =
+    useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const fetcher = useFetcher();
 
@@ -303,6 +308,7 @@ export default function RunSetCreateRoute() {
 
       <RunSetCreatorContainer
         prefillData={prefillData}
+        avgSecondsPerSession={avgSecondsPerSession}
         onSubmit={handleSubmit}
         isLoading={fetcher.state !== "idle"}
         errors={(fetcher.data as any)?.errors || {}}

--- a/app/modules/runSets/containers/runSetCreateRuns.container.tsx
+++ b/app/modules/runSets/containers/runSetCreateRuns.container.tsx
@@ -18,6 +18,7 @@ import type { PromptReference, RunSet } from "../runSets.types";
 interface RunSetCreateRunsContainerProps {
   runSet: RunSet;
   usedPromptModels: PromptModelPair[];
+  avgSecondsPerSession: number | null;
   onSubmit: (requestBody: string) => void;
   onCancel: () => void;
   isLoading: boolean;
@@ -27,6 +28,7 @@ interface RunSetCreateRunsContainerProps {
 export default function RunSetCreateRunsContainer({
   runSet,
   usedPromptModels,
+  avgSecondsPerSession,
   onSubmit,
   onCancel,
   isLoading,
@@ -53,7 +55,10 @@ export default function RunSetCreateRunsContainer({
     usedKeys.has(d.key),
   );
 
-  const estimation = calculateEstimates(runDefinitions, runSet.sessions || []);
+  const estimation = calculateEstimates(runDefinitions, runSet.sessions || [], {
+    shouldRunVerification,
+    avgSecondsPerSession,
+  });
 
   const handleRemoveCard = (key: string) => {
     setRemovedKeys((prev) => new Set(prev).add(key));

--- a/app/modules/runSets/containers/runSetCreateRuns.route.tsx
+++ b/app/modules/runSets/containers/runSetCreateRuns.route.tsx
@@ -47,10 +47,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const usedPromptModels = getUsedPromptModels(existingRuns);
 
+  const avgSecondsPerSession = await RunService.getAverageSecondsPerSession(
+    params.projectId,
+  );
+
   return {
     runSet,
     project,
     usedPromptModels,
+    avgSecondsPerSession,
   };
 }
 
@@ -123,7 +128,8 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export default function RunSetCreateRunsRoute() {
-  const { runSet, project, usedPromptModels } = useLoaderData<typeof loader>();
+  const { runSet, project, usedPromptModels, avgSecondsPerSession } =
+    useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const fetcher = useFetcher();
 
@@ -185,6 +191,7 @@ export default function RunSetCreateRunsRoute() {
       <RunSetCreateRunsContainer
         runSet={runSet}
         usedPromptModels={usedPromptModels as PromptModelPair[]}
+        avgSecondsPerSession={avgSecondsPerSession}
         onSubmit={handleSubmit}
         onCancel={handleCancel}
         isLoading={fetcher.state !== "idle"}

--- a/app/modules/runSets/containers/runSetCreator.container.tsx
+++ b/app/modules/runSets/containers/runSetCreator.container.tsx
@@ -26,11 +26,13 @@ function getDefaultName(prefillData?: PrefillData | null): string {
 
 export default function RunSetCreatorContainer({
   prefillData,
+  avgSecondsPerSession,
   onSubmit,
   isLoading,
   errors,
 }: {
   prefillData?: PrefillData | null;
+  avgSecondsPerSession: number | null;
   onSubmit: (requestBody: string) => void;
   isLoading: boolean;
   errors: Record<string, string>;
@@ -61,7 +63,10 @@ export default function RunSetCreatorContainer({
     removedKeys.has(d.key),
   );
 
-  const estimation = calculateEstimates(runDefinitions, selectedSessions);
+  const estimation = calculateEstimates(runDefinitions, selectedSessions, {
+    shouldRunVerification,
+    avgSecondsPerSession,
+  });
 
   const handleAnnotationTypeChange = (type: string) => {
     setAnnotationType(type);

--- a/app/modules/runSets/helpers/calculateEstimates.ts
+++ b/app/modules/runSets/helpers/calculateEstimates.ts
@@ -6,8 +6,8 @@ import type {
 } from "~/modules/runSets/runSets.types";
 
 const AVG_TOKENS_PER_SESSION = 500;
-const AVG_SECONDS_PER_CALL = 2;
-const PARALLELISM_FACTOR = 3;
+const DEFAULT_SECONDS_PER_CALL = 10;
+const DEFAULT_PARALLELISM_FACTOR = 5;
 
 function getModelPricing(modelCode: string) {
   const providers = aiGatewayConfig.providers as Provider[];
@@ -25,11 +25,18 @@ function getModelPricing(modelCode: string) {
   return { inputCostPer1M: 0, outputCostPer1M: 0 };
 }
 
+interface CalculateEstimatesOptions {
+  shouldRunVerification?: boolean;
+  avgSecondsPerSession?: number | null;
+}
+
 export function calculateEstimates(
   runDefinitions: RunDefinition[],
   selectedSessions: { length: number },
+  options?: CalculateEstimatesOptions,
 ): EstimationResult {
   const numSessions = selectedSessions.length;
+  const verificationMultiplier = options?.shouldRunVerification ? 2 : 1;
 
   const inputTokens = AVG_TOKENS_PER_SESSION / 2;
   const outputTokens = AVG_TOKENS_PER_SESSION / 2;
@@ -48,13 +55,25 @@ export function calculateEstimates(
     totalCost +=
       count *
       numSessions *
+      verificationMultiplier *
       ((inputTokens / 1_000_000) * pricing.inputCostPer1M +
         (outputTokens / 1_000_000) * pricing.outputCostPer1M);
   }
 
   const totalCalls = runDefinitions.length * numSessions;
-  const estimatedTimeSeconds =
-    (totalCalls * AVG_SECONDS_PER_CALL) / PARALLELISM_FACTOR;
+  const avgSecondsPerSession = options?.avgSecondsPerSession;
+
+  // When using historical data, parallelism is already reflected in the average
+  // since it's derived from wall-clock run duration divided by session count.
+  let estimatedTimeSeconds: number;
+  if (avgSecondsPerSession != null && avgSecondsPerSession > 0) {
+    estimatedTimeSeconds =
+      totalCalls * avgSecondsPerSession * verificationMultiplier;
+  } else {
+    estimatedTimeSeconds =
+      (totalCalls * DEFAULT_SECONDS_PER_CALL * verificationMultiplier) /
+      DEFAULT_PARALLELISM_FACTOR;
+  }
 
   return { estimatedCost: totalCost, estimatedTimeSeconds };
 }

--- a/app/modules/runSets/helpers/formatEstimates.ts
+++ b/app/modules/runSets/helpers/formatEstimates.ts
@@ -11,26 +11,26 @@ export function formatCost(cost: number): string {
 }
 
 export function formatTime(seconds: number): string {
+  if (seconds < 30) {
+    return "< 30s";
+  }
+
   if (seconds < 60) {
-    return `${Math.round(seconds)}s`;
+    return "~ 1 min";
   }
 
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = Math.round(seconds % 60);
+  const roundedMinutes = Math.round(seconds / 60);
 
-  if (minutes < 60) {
-    if (remainingSeconds === 0) {
-      return `${minutes}m`;
-    }
-    return `${minutes}m ${remainingSeconds}s`;
+  if (roundedMinutes < 60) {
+    return `~ ${roundedMinutes} min`;
   }
 
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
+  const hours = Math.floor(roundedMinutes / 60);
+  const remainingMinutes = roundedMinutes % 60;
 
   if (remainingMinutes === 0) {
-    return `${hours}h`;
+    return `~ ${hours}h`;
   }
 
-  return `${hours}h ${remainingMinutes}m`;
+  return `~ ${hours}h ${remainingMinutes} min`;
 }

--- a/app/modules/runs/run.ts
+++ b/app/modules/runs/run.ts
@@ -7,6 +7,7 @@ import type { CreateRunProps, Run, RunSession } from "./runs.types";
 import aggregateProgressService from "./services/aggregateProgress.server";
 import buildRunSnapshot from "./services/buildRunSnapshot.server";
 import createRunAnnotations from "./services/createRunAnnotations.server";
+import getAverageSecondsPerSession from "./services/getAverageSecondsPerSession.server";
 import paginateSessionsService from "./services/paginateSessions.server";
 
 const RunModel = mongoose.models.Run || mongoose.model("Run", runSchema);
@@ -144,6 +145,10 @@ export class RunService {
 
   static aggregateProgress(runIds: string[]) {
     return aggregateProgressService(runIds);
+  }
+
+  static getAverageSecondsPerSession(projectId: string) {
+    return getAverageSecondsPerSession(projectId);
   }
 
   static paginateSessions(

--- a/app/modules/runs/services/getAverageSecondsPerSession.server.ts
+++ b/app/modules/runs/services/getAverageSecondsPerSession.server.ts
@@ -1,0 +1,52 @@
+import mongoose from "mongoose";
+
+const RunModel = mongoose.models.Run;
+
+export default async function getAverageSecondsPerSession(
+  projectId: string,
+): Promise<number | null> {
+  const result = await RunModel.aggregate([
+    {
+      $match: {
+        project: new mongoose.Types.ObjectId(projectId),
+        isComplete: true,
+        startedAt: { $exists: true },
+        finishedAt: { $exists: true },
+      },
+    },
+    { $sort: { finishedAt: -1 } },
+    { $limit: 50 },
+    {
+      $project: {
+        // $subtract gives ms. Divide by 1000 to get seconds.
+        // Verification runs do 2 LLM calls per session, so divide by 2000
+        // instead to normalize everything to a single-call baseline.
+        durationSeconds: {
+          $divide: [
+            { $subtract: ["$finishedAt", "$startedAt"] },
+            {
+              $cond: [
+                { $ifNull: ["$shouldRunVerification", false] },
+                2000,
+                1000,
+              ],
+            },
+          ],
+        },
+        sessionCount: { $size: "$sessions" },
+      },
+    },
+    { $match: { durationSeconds: { $gt: 0 }, sessionCount: { $gt: 0 } } },
+    {
+      $group: {
+        _id: null,
+        totalSeconds: { $sum: "$durationSeconds" },
+        totalSessions: { $sum: "$sessionCount" },
+      },
+    },
+  ]);
+
+  if (result.length === 0 || result[0].totalSessions === 0) return null;
+
+  return result[0].totalSeconds / result[0].totalSessions;
+}


### PR DESCRIPTION
## Summary
- Uses historical averages from the last 50 completed runs in the project to estimate processing time, instead of hardcoded constants
- Falls back to updated defaults (10s/call, parallelism factor 5) when no historical data exists
- Accounts for verification runs doubling both time and cost estimates
- Normalizes verification run durations in the aggregation so historical averages reflect a single-call baseline
- Rounds time display to approximate values (`< 30s`, `~ 3 min`, `~ 1h 30 min`) since estimates are inherently imprecise

Fixes #1601