### PR TITLE
Include session_id in all CSV and JSONL exports

### DIFF
--- a/app/functions/outputRunDataToCSV/__tests__/app.test.ts
+++ b/app/functions/outputRunDataToCSV/__tests__/app.test.ts
@@ -1,0 +1,263 @@
+import fse from "fs-extra";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handler } from "../app";
+
+vi.mock("fs-extra", () => ({
+  default: {
+    readJSON: vi.fn(),
+    outputFile: vi.fn(),
+    readFile: vi.fn().mockResolvedValue(Buffer.from("")),
+  },
+}));
+
+vi.mock("~/modules/storage/helpers/getStorageAdapter", () => ({
+  default: () => ({
+    download: vi.fn().mockResolvedValue("/tmp/fake-path.json"),
+    upload: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const makeRun = (overrides: Record<string, any> = {}) => ({
+  _id: "run1",
+  project: "proj1",
+  name: "Test Run",
+  annotationType: "PER_UTTERANCE",
+  prompt: "prompt1",
+  promptVersion: 1,
+  sessions: [
+    { sessionId: "mongo-id-abc", name: "session-abc.json" },
+    { sessionId: "mongo-id-def", name: "session-def.json" },
+  ],
+  snapshot: {
+    prompt: {
+      name: "Test Prompt",
+      userPrompt: "Annotate this",
+      annotationType: "PER_UTTERANCE",
+      version: 1,
+    },
+    model: { code: "gpt-4", name: "GPT-4", provider: "openai" },
+  },
+  ...overrides,
+});
+
+const makeTranscript = (
+  sessionId: string,
+  opts: { utteranceAnnotations?: boolean; sessionAnnotations?: boolean } = {},
+) => {
+  const transcript: any[] = [
+    {
+      _id: `${sessionId}-u1`,
+      session_id: sessionId,
+      role: "Tutor",
+      content: "Hello",
+    },
+    {
+      _id: `${sessionId}-u2`,
+      session_id: sessionId,
+      role: "Student",
+      content: "Hi there",
+    },
+  ];
+
+  if (opts.utteranceAnnotations) {
+    transcript[0].annotations = [
+      { _id: `${sessionId}-u1`, score: 5, label: "greeting" },
+    ];
+    transcript[1].annotations = [
+      { _id: `${sessionId}-u2`, score: 3, label: "response" },
+    ];
+  }
+
+  const result: any = { transcript };
+
+  if (opts.sessionAnnotations) {
+    result.annotations = [{ _id: sessionId, quality: "high", rating: 4 }];
+  }
+
+  return result;
+};
+
+describe("outputRunDataToCSV", () => {
+  let capturedCsvFiles: Record<string, string>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCsvFiles = {};
+
+    vi.mocked(fse.outputFile).mockImplementation(
+      async (path: any, content: any) => {
+        capturedCsvFiles[path] = content;
+      },
+    );
+  });
+
+  describe("PER_UTTERANCE", () => {
+    it("preserves original session_id from transcript data", async () => {
+      const run = makeRun({ annotationType: "PER_UTTERANCE" });
+
+      const transcripts = [
+        makeTranscript("ORIGINAL_S1", { utteranceAnnotations: true }),
+        makeTranscript("ORIGINAL_S2", { utteranceAnnotations: true }),
+      ];
+      let callIndex = 0;
+      vi.mocked(fse.readJSON).mockImplementation(
+        async () => transcripts[callIndex++],
+      );
+
+      await handler({
+        body: {
+          run: run as any,
+          inputFolder: "storage/proj1/runs/run1",
+          outputFolder: "storage/proj1/runs/run1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("utterances.csv"),
+      );
+      const csv = capturedCsvFiles[csvPath!];
+      const lines = csv.split("\n");
+      const headers = lines[0].split(",");
+      const sessionIdIndex = headers.indexOf("session_id");
+
+      expect(headers).toContain("session_id");
+      expect(lines[1].split(",")[sessionIdIndex]).toBe("ORIGINAL_S1");
+      expect(lines[3].split(",")[sessionIdIndex]).toBe("ORIGINAL_S2");
+    });
+
+    it("includes annotation columns", async () => {
+      const run = makeRun({ annotationType: "PER_UTTERANCE" });
+
+      const transcripts = [
+        makeTranscript("S1", { utteranceAnnotations: true }),
+        makeTranscript("S2", { utteranceAnnotations: true }),
+      ];
+      let callIndex = 0;
+      vi.mocked(fse.readJSON).mockImplementation(
+        async () => transcripts[callIndex++],
+      );
+
+      await handler({
+        body: {
+          run: run as any,
+          inputFolder: "storage/proj1/runs/run1",
+          outputFolder: "storage/proj1/runs/run1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("utterances.csv"),
+      );
+      const csv = capturedCsvFiles[csvPath!];
+      const headers = csv.split("\n")[0].split(",");
+
+      expect(headers).toContain("score-0");
+      expect(headers).toContain("label-0");
+    });
+  });
+
+  describe("PER_SESSION", () => {
+    it("includes _id and session_id columns in sessions CSV", async () => {
+      const run = makeRun({ annotationType: "PER_SESSION" });
+
+      const transcripts = [
+        makeTranscript("S1", { sessionAnnotations: true }),
+        makeTranscript("S2", { sessionAnnotations: true }),
+      ];
+      let callIndex = 0;
+      vi.mocked(fse.readJSON).mockImplementation(
+        async () => transcripts[callIndex++],
+      );
+
+      await handler({
+        body: {
+          run: run as any,
+          inputFolder: "storage/proj1/runs/run1",
+          outputFolder: "storage/proj1/runs/run1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("sessions.csv"),
+      );
+      expect(csvPath).toBeDefined();
+
+      const csv = capturedCsvFiles[csvPath!];
+      const lines = csv.split("\n");
+      const headers = lines[0].split(",");
+
+      expect(headers).toContain("_id");
+      expect(headers).toContain("session_id");
+
+      const idIndex = headers.indexOf("_id");
+      expect(lines[1].split(",")[idIndex]).toBe("mongo-id-abc");
+      expect(lines[2].split(",")[idIndex]).toBe("mongo-id-def");
+
+      const sessionIdIndex = headers.indexOf("session_id");
+      expect(lines[1].split(",")[sessionIdIndex]).toBe("S1");
+      expect(lines[2].split(",")[sessionIdIndex]).toBe("S2");
+    });
+
+    it("includes annotation columns", async () => {
+      const run = makeRun({ annotationType: "PER_SESSION" });
+
+      const transcripts = [
+        makeTranscript("S1", { sessionAnnotations: true }),
+        makeTranscript("S2", { sessionAnnotations: true }),
+      ];
+      let callIndex = 0;
+      vi.mocked(fse.readJSON).mockImplementation(
+        async () => transcripts[callIndex++],
+      );
+
+      await handler({
+        body: {
+          run: run as any,
+          inputFolder: "storage/proj1/runs/run1",
+          outputFolder: "storage/proj1/runs/run1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("sessions.csv"),
+      );
+      const csv = capturedCsvFiles[csvPath!];
+      const headers = csv.split("\n")[0].split(",");
+
+      expect(headers).toContain("quality-0");
+      expect(headers).toContain("rating-0");
+    });
+  });
+
+  it("always generates meta CSV", async () => {
+    const run = makeRun({ annotationType: "PER_SESSION" });
+
+    const transcripts = [
+      makeTranscript("S1", { sessionAnnotations: true }),
+      makeTranscript("S2", { sessionAnnotations: true }),
+    ];
+    let callIndex = 0;
+    vi.mocked(fse.readJSON).mockImplementation(
+      async () => transcripts[callIndex++],
+    );
+
+    await handler({
+      body: {
+        run: run as any,
+        inputFolder: "storage/proj1/runs/run1",
+        outputFolder: "storage/proj1/runs/run1/exports",
+      },
+    });
+
+    const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+      p.includes("meta.csv"),
+    );
+    expect(csvPath).toBeDefined();
+
+    const csv = capturedCsvFiles[csvPath!];
+    const headers = csv.split("\n")[0].split(",");
+    expect(headers).toContain("_id");
+    expect(headers).toContain("name");
+    expect(headers).toContain("annotationType");
+  });
+});

--- a/app/functions/outputRunDataToCSV/app.ts
+++ b/app/functions/outputRunDataToCSV/app.ts
@@ -43,7 +43,6 @@ export const handler = async (event: {
       const json = await fse.readJSON(downloadedPath);
 
       const transcript = map(json.transcript, (utterance) => {
-        utterance.sessionId = session.sessionId;
         if (utterance.annotations) {
           each(utterance.annotations, (annotation, index) => {
             each(annotation, (annotationValue, annotationKey) => {
@@ -64,6 +63,7 @@ export const handler = async (event: {
 
       const sessionObject: { _id: any; [key: string]: any } = {
         _id: session.sessionId,
+        session_id: json.transcript[0]?.session_id,
       };
 
       if (json.annotations) {
@@ -109,7 +109,11 @@ export const handler = async (event: {
     // OUTPUT SESSIONS
     if (run.annotationType === "PER_SESSION") {
       const sessionsCsv = json2csv(sessionsArray, {
-        keys: Object.keys(sessionAnnotationKeysAsObject),
+        keys: [
+          "_id",
+          "session_id",
+          ...Object.keys(sessionAnnotationKeysAsObject),
+        ],
         emptyFieldValue: "",
       });
 

--- a/app/functions/outputRunDataToJSON/__tests__/app.test.ts
+++ b/app/functions/outputRunDataToJSON/__tests__/app.test.ts
@@ -1,0 +1,136 @@
+import fse from "fs-extra";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handler } from "../app";
+
+vi.mock("fs-extra", () => ({
+  default: {
+    readJSON: vi.fn(),
+    outputFile: vi.fn(),
+    readFile: vi.fn().mockResolvedValue(Buffer.from("")),
+  },
+}));
+
+vi.mock("~/modules/storage/helpers/getStorageAdapter", () => ({
+  default: () => ({
+    download: vi.fn().mockResolvedValue("/tmp/fake-path.json"),
+    upload: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const makeRun = (overrides: Record<string, any> = {}) => ({
+  _id: "run1",
+  project: "proj1",
+  name: "Test Run",
+  annotationType: "PER_UTTERANCE",
+  prompt: "prompt1",
+  promptVersion: 1,
+  sessions: [
+    { sessionId: "session-abc", name: "session-abc.json" },
+    { sessionId: "session-def", name: "session-def.json" },
+  ],
+  snapshot: {
+    prompt: {
+      name: "Test Prompt",
+      userPrompt: "Annotate this",
+      annotationType: "PER_UTTERANCE",
+      annotationSchema: [],
+      version: 1,
+    },
+    model: { code: "gpt-4", name: "GPT-4", provider: "openai" },
+  },
+  ...overrides,
+});
+
+const makeTranscript = (sessionId: string) => ({
+  transcript: [
+    {
+      _id: `${sessionId}-u1`,
+      session_id: sessionId,
+      role: "Tutor",
+      content: "Hello",
+    },
+    {
+      _id: `${sessionId}-u2`,
+      session_id: sessionId,
+      role: "Student",
+      content: "Hi there",
+    },
+  ],
+  annotations: [{ _id: sessionId, quality: "high" }],
+});
+
+describe("outputRunDataToJSON", () => {
+  let capturedFiles: Record<string, string>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedFiles = {};
+
+    vi.mocked(fse.outputFile).mockImplementation(
+      async (path: any, content: any) => {
+        capturedFiles[path] = content;
+      },
+    );
+  });
+
+  it("includes session ID (_id) in each JSONL session line", async () => {
+    const run = makeRun();
+
+    let callIndex = 0;
+    vi.mocked(fse.readJSON).mockImplementation(async () => {
+      const sessionId = run.sessions[callIndex].sessionId;
+      callIndex++;
+      return makeTranscript(sessionId);
+    });
+
+    await handler({
+      body: {
+        run: run as any,
+        inputFolder: "storage/proj1/runs/run1",
+        outputFolder: "storage/proj1/runs/run1/exports",
+      },
+    });
+
+    const sessionsPath = Object.keys(capturedFiles).find((p) =>
+      p.includes("sessions.jsonl"),
+    );
+    expect(sessionsPath).toBeDefined();
+
+    const lines = capturedFiles[sessionsPath!].split("\n");
+    expect(lines).toHaveLength(2);
+
+    const session1 = JSON.parse(lines[0]);
+    const session2 = JSON.parse(lines[1]);
+    expect(session1._id).toBe("session-abc");
+    expect(session2._id).toBe("session-def");
+  });
+
+  it("generates meta JSONL with run info", async () => {
+    const run = makeRun();
+
+    let callIndex = 0;
+    vi.mocked(fse.readJSON).mockImplementation(async () => {
+      const sessionId = run.sessions[callIndex].sessionId;
+      callIndex++;
+      return makeTranscript(sessionId);
+    });
+
+    await handler({
+      body: {
+        run: run as any,
+        inputFolder: "storage/proj1/runs/run1",
+        outputFolder: "storage/proj1/runs/run1/exports",
+      },
+    });
+
+    const metaPath = Object.keys(capturedFiles).find((p) =>
+      p.includes("meta.jsonl"),
+    );
+    expect(metaPath).toBeDefined();
+
+    const meta = JSON.parse(capturedFiles[metaPath!]);
+    expect(meta._id).toBe("run1");
+    expect(meta.name).toBe("Test Run");
+    expect(meta.prompt.name).toBe("Test Prompt");
+  });
+});

--- a/app/functions/outputRunDataToJSON/app.ts
+++ b/app/functions/outputRunDataToJSON/app.ts
@@ -27,6 +27,7 @@ export const handler = async (event: {
       });
       const json = await fse.readJSON(downloadedPath);
 
+      json._id = session.sessionId;
       sessionsArray.push(json);
     }
 

--- a/app/functions/outputRunSetDataToCSV/__tests__/app.test.ts
+++ b/app/functions/outputRunSetDataToCSV/__tests__/app.test.ts
@@ -1,0 +1,302 @@
+import fse from "fs-extra";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handler } from "../app";
+
+vi.mock("fs-extra", () => ({
+  default: {
+    readJSON: vi.fn(),
+    outputFile: vi.fn(),
+    readFile: vi.fn().mockResolvedValue(Buffer.from("")),
+    ensureDir: vi.fn(),
+  },
+}));
+
+vi.mock("~/modules/storage/helpers/getStorageAdapter", () => ({
+  default: () => ({
+    download: vi.fn().mockResolvedValue("/tmp/fake-path.json"),
+    upload: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const makeRun = (index: number, overrides: Record<string, any> = {}) => ({
+  _id: `run${index}`,
+  project: "proj1",
+  name: `Test Run ${index}`,
+  annotationType: "PER_UTTERANCE",
+  prompt: `prompt${index}`,
+  promptVersion: 1,
+  sessions: [
+    { sessionId: "mongo-id-abc", name: "session-abc.json" },
+    { sessionId: "mongo-id-def", name: "session-def.json" },
+  ],
+  snapshot: {
+    prompt: {
+      name: "Test Prompt",
+      userPrompt: "Annotate this",
+      annotationType: "PER_UTTERANCE",
+      version: 1,
+    },
+    model: { code: "gpt-4", name: "GPT-4", provider: "openai" },
+  },
+  ...overrides,
+});
+
+const makeRunSet = (overrides: Record<string, any> = {}) => ({
+  _id: "runset1",
+  project: "proj1",
+  name: "Test Run Set",
+  annotationType: "PER_UTTERANCE",
+  runs: ["run1", "run2"],
+  sessions: [],
+  ...overrides,
+});
+
+const makeTranscript = (
+  sessionId: string,
+  opts: { utteranceAnnotations?: boolean; sessionAnnotations?: boolean } = {},
+) => {
+  const transcript: any[] = [
+    {
+      _id: `${sessionId}-u1`,
+      session_id: sessionId,
+      role: "Tutor",
+      content: "Hello",
+      sequence_id: "1",
+    },
+    {
+      _id: `${sessionId}-u2`,
+      session_id: sessionId,
+      role: "Student",
+      content: "Hi there",
+      sequence_id: "2",
+    },
+  ];
+
+  if (opts.utteranceAnnotations) {
+    transcript[0].annotations = [
+      { _id: `${sessionId}-u1`, score: 5, label: "greeting" },
+    ];
+    transcript[1].annotations = [
+      { _id: `${sessionId}-u2`, score: 3, label: "response" },
+    ];
+  }
+
+  const result: any = { transcript };
+
+  if (opts.sessionAnnotations) {
+    result.annotations = [{ _id: sessionId, quality: "high", rating: 4 }];
+  }
+
+  return result;
+};
+
+describe("outputRunSetDataToCSV", () => {
+  let capturedCsvFiles: Record<string, string>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCsvFiles = {};
+
+    vi.mocked(fse.outputFile).mockImplementation(
+      async (path: any, content: any) => {
+        capturedCsvFiles[path] = content;
+      },
+    );
+  });
+
+  function setupTranscripts(
+    runs: ReturnType<typeof makeRun>[],
+    opts: { utteranceAnnotations?: boolean; sessionAnnotations?: boolean },
+  ) {
+    const sessionIds: Record<string, string> = {
+      "mongo-id-abc": "ORIGINAL_S1",
+      "mongo-id-def": "ORIGINAL_S2",
+    };
+
+    let callIndex = 0;
+    const sessionOrder = runs.flatMap((r) =>
+      r.sessions.map((s) => s.sessionId),
+    );
+
+    vi.mocked(fse.readJSON).mockImplementation(async () => {
+      const mongoId = sessionOrder[callIndex++];
+      return makeTranscript(sessionIds[mongoId], opts);
+    });
+  }
+
+  describe("PER_UTTERANCE", () => {
+    it("preserves original session_id from transcript data", async () => {
+      const runs = [makeRun(1), makeRun(2)];
+      const runSet = makeRunSet({ annotationType: "PER_UTTERANCE" });
+      setupTranscripts(runs, { utteranceAnnotations: true });
+
+      await handler({
+        body: {
+          runSet: runSet as any,
+          runs: runs as any,
+          inputFolder: "storage/proj1/runs",
+          outputFolder: "storage/proj1/run-sets/runset1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("utterances.csv"),
+      );
+      const csv = capturedCsvFiles[csvPath!];
+      const lines = csv.split("\n");
+      const headers = lines[0].split(",");
+      const sessionIdIndex = headers.indexOf("session_id");
+
+      expect(headers).toContain("session_id");
+      expect(headers).toContain("sequence_id");
+      expect(lines[1].split(",")[sessionIdIndex]).toBe("ORIGINAL_S1");
+      expect(lines[3].split(",")[sessionIdIndex]).toBe("ORIGINAL_S2");
+    });
+
+    it("includes annotation and metadata columns from multiple runs", async () => {
+      const runs = [makeRun(1), makeRun(2)];
+      const runSet = makeRunSet({ annotationType: "PER_UTTERANCE" });
+      setupTranscripts(runs, { utteranceAnnotations: true });
+
+      await handler({
+        body: {
+          runSet: runSet as any,
+          runs: runs as any,
+          inputFolder: "storage/proj1/runs",
+          outputFolder: "storage/proj1/run-sets/runset1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("utterances.csv"),
+      );
+      const csv = capturedCsvFiles[csvPath!];
+      const headers = csv.split("\n")[0].split(",");
+
+      expect(headers).toContain("score-1");
+      expect(headers).toContain("label-1");
+      expect(headers).toContain("model-0");
+      expect(headers).toContain("model-1");
+    });
+
+    it("does not include _sessionRef in CSV output", async () => {
+      const runs = [makeRun(1), makeRun(2)];
+      const runSet = makeRunSet({ annotationType: "PER_UTTERANCE" });
+      setupTranscripts(runs, { utteranceAnnotations: true });
+
+      await handler({
+        body: {
+          runSet: runSet as any,
+          runs: runs as any,
+          inputFolder: "storage/proj1/runs",
+          outputFolder: "storage/proj1/run-sets/runset1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("utterances.csv"),
+      );
+      const csv = capturedCsvFiles[csvPath!];
+      const headers = csv.split("\n")[0].split(",");
+
+      expect(headers).not.toContain("_sessionRef");
+    });
+  });
+
+  describe("PER_SESSION", () => {
+    it("includes _id and session_id columns in sessions CSV", async () => {
+      const runs = [
+        makeRun(1, { annotationType: "PER_SESSION" }),
+        makeRun(2, { annotationType: "PER_SESSION" }),
+      ];
+      const runSet = makeRunSet({ annotationType: "PER_SESSION" });
+      setupTranscripts(runs, { sessionAnnotations: true });
+
+      await handler({
+        body: {
+          runSet: runSet as any,
+          runs: runs as any,
+          inputFolder: "storage/proj1/runs",
+          outputFolder: "storage/proj1/run-sets/runset1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("sessions.csv"),
+      );
+      expect(csvPath).toBeDefined();
+
+      const csv = capturedCsvFiles[csvPath!];
+      const lines = csv.split("\n");
+      const headers = lines[0].split(",");
+
+      expect(headers).toContain("_id");
+      expect(headers).toContain("session_id");
+
+      const idIndex = headers.indexOf("_id");
+      expect(lines[1].split(",")[idIndex]).toBe("mongo-id-abc");
+      expect(lines[2].split(",")[idIndex]).toBe("mongo-id-def");
+
+      const sessionIdIndex = headers.indexOf("session_id");
+      expect(lines[1].split(",")[sessionIdIndex]).toBe("ORIGINAL_S1");
+      expect(lines[2].split(",")[sessionIdIndex]).toBe("ORIGINAL_S2");
+    });
+
+    it("includes annotation and metadata columns from multiple runs", async () => {
+      const runs = [
+        makeRun(1, { annotationType: "PER_SESSION" }),
+        makeRun(2, { annotationType: "PER_SESSION" }),
+      ];
+      const runSet = makeRunSet({ annotationType: "PER_SESSION" });
+      setupTranscripts(runs, { sessionAnnotations: true });
+
+      await handler({
+        body: {
+          runSet: runSet as any,
+          runs: runs as any,
+          inputFolder: "storage/proj1/runs",
+          outputFolder: "storage/proj1/run-sets/runset1/exports",
+        },
+      });
+
+      const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+        p.includes("sessions.csv"),
+      );
+      const csv = capturedCsvFiles[csvPath!];
+      const headers = csv.split("\n")[0].split(",");
+
+      expect(headers).toContain("quality-0");
+      expect(headers).toContain("quality-1");
+      expect(headers).toContain("model-0");
+      expect(headers).toContain("model-1");
+    });
+  });
+
+  it("always generates meta CSV with all runs", async () => {
+    const runs = [makeRun(1), makeRun(2)];
+    const runSet = makeRunSet({ annotationType: "PER_UTTERANCE" });
+    setupTranscripts(runs, { utteranceAnnotations: true });
+
+    await handler({
+      body: {
+        runSet: runSet as any,
+        runs: runs as any,
+        inputFolder: "storage/proj1/runs",
+        outputFolder: "storage/proj1/run-sets/runset1/exports",
+      },
+    });
+
+    const csvPath = Object.keys(capturedCsvFiles).find((p) =>
+      p.includes("meta.csv"),
+    );
+    expect(csvPath).toBeDefined();
+
+    const csv = capturedCsvFiles[csvPath!];
+    const lines = csv.split("\n");
+    const headers = lines[0].split(",");
+
+    expect(headers).toContain("runId");
+    expect(headers).toContain("runName");
+    expect(lines).toHaveLength(3);
+  });
+});

--- a/app/functions/outputRunSetDataToCSV/app.ts
+++ b/app/functions/outputRunSetDataToCSV/app.ts
@@ -28,11 +28,12 @@ export const handler = async (event: {
 
   const utteranceKeys = [
     "_id",
-    "sessionId",
+    "session_id",
+    "sequence_id",
     "role",
+    "content",
     "start_time",
     "end_time",
-    "content",
   ];
   const utteranceAnnotationKeysAsObject: { [key: string]: boolean } = {};
   const sessionAnnotationKeysAsObject: { [key: string]: boolean } = {};
@@ -51,7 +52,7 @@ export const handler = async (event: {
 
       if (isBaseRun) {
         const transcript = map(json.transcript, (utterance) => {
-          utterance.sessionId = session.sessionId;
+          utterance._sessionRef = session.sessionId;
           delete utterance.annotations;
           return utterance;
         });
@@ -59,6 +60,7 @@ export const handler = async (event: {
 
         sessionsArray.push({
           _id: session.sessionId,
+          session_id: json.transcript[0]?.session_id,
         });
       }
 
@@ -67,7 +69,7 @@ export const handler = async (event: {
           if (utterance.annotations && utterance.annotations.length > 0) {
             const baseUtterance = utterancesArray.find(
               (u) =>
-                u._id === utterance._id && u.sessionId === session.sessionId,
+                u._id === utterance._id && u._sessionRef === session.sessionId,
             );
 
             if (baseUtterance) {
@@ -170,6 +172,7 @@ export const handler = async (event: {
     const sessionsCsv = json2csv(sessionsArray, {
       keys: [
         "_id",
+        "session_id",
         ...Object.keys(sessionAnnotationKeysAsObject),
         ...metadataKeys,
       ],

--- a/app/functions/outputRunSetDataToJSON/__tests__/app.test.ts
+++ b/app/functions/outputRunSetDataToJSON/__tests__/app.test.ts
@@ -1,0 +1,239 @@
+import fse from "fs-extra";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handler } from "../app";
+
+vi.mock("fs-extra", () => ({
+  default: {
+    readJSON: vi.fn(),
+    outputFile: vi.fn(),
+    readFile: vi.fn().mockResolvedValue(Buffer.from("")),
+    ensureDir: vi.fn(),
+  },
+}));
+
+vi.mock("~/modules/storage/helpers/getStorageAdapter", () => ({
+  default: () => ({
+    download: vi.fn().mockResolvedValue("/tmp/fake-path.json"),
+    upload: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const makeRun = (index: number, overrides: Record<string, any> = {}) => ({
+  _id: `run${index}`,
+  project: "proj1",
+  name: `Test Run ${index}`,
+  annotationType: "PER_SESSION",
+  prompt: `prompt${index}`,
+  promptVersion: 1,
+  sessions: [
+    { sessionId: "session-abc", name: "session-abc.json" },
+    { sessionId: "session-def", name: "session-def.json" },
+  ],
+  snapshot: {
+    prompt: {
+      name: "Test Prompt",
+      userPrompt: "Annotate this",
+      annotationType: "PER_SESSION",
+      version: 1,
+    },
+    model: { code: "gpt-4", name: "GPT-4", provider: "openai" },
+  },
+  ...overrides,
+});
+
+const makeRunSet = (overrides: Record<string, any> = {}) => ({
+  _id: "runset1",
+  project: "proj1",
+  name: "Test Run Set",
+  annotationType: "PER_SESSION",
+  runs: ["run1", "run2"],
+  sessions: [],
+  ...overrides,
+});
+
+const makeTranscript = (
+  sessionId: string,
+  opts: { utteranceAnnotations?: boolean; sessionAnnotations?: boolean } = {},
+) => {
+  const transcript = [
+    {
+      _id: `${sessionId}-u1`,
+      session_id: sessionId,
+      role: "Tutor",
+      content: "Hello",
+    },
+    {
+      _id: `${sessionId}-u2`,
+      session_id: sessionId,
+      role: "Student",
+      content: "Hi there",
+    },
+  ];
+
+  if (opts.utteranceAnnotations) {
+    (transcript[0] as any).annotations = [{ _id: `${sessionId}-u1`, score: 5 }];
+    (transcript[1] as any).annotations = [{ _id: `${sessionId}-u2`, score: 3 }];
+  }
+
+  const result: any = { transcript };
+
+  if (opts.sessionAnnotations) {
+    result.annotations = [{ _id: sessionId, quality: "high" }];
+  }
+
+  return result;
+};
+
+describe("outputRunSetDataToJSON", () => {
+  let capturedFiles: Record<string, string>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedFiles = {};
+
+    vi.mocked(fse.outputFile).mockImplementation(
+      async (path: any, content: any) => {
+        capturedFiles[path] = content;
+      },
+    );
+  });
+
+  it("includes session ID (_id) in each JSONL session line", async () => {
+    const runs = [makeRun(1), makeRun(2)];
+    const runSet = makeRunSet({ annotationType: "PER_SESSION" });
+
+    let callIndex = 0;
+    const sessionOrder = runs.flatMap((r) =>
+      r.sessions.map((s) => s.sessionId),
+    );
+    vi.mocked(fse.readJSON).mockImplementation(async () => {
+      const sessionId = sessionOrder[callIndex++];
+      return makeTranscript(sessionId, { sessionAnnotations: true });
+    });
+
+    await handler({
+      body: {
+        runSet: runSet as any,
+        runs: runs as any,
+        inputFolder: "storage/proj1/runs",
+        outputFolder: "storage/proj1/run-sets/runset1/exports",
+      },
+    });
+
+    const sessionsPath = Object.keys(capturedFiles).find((p) =>
+      p.includes("sessions.jsonl"),
+    );
+    expect(sessionsPath).toBeDefined();
+
+    const lines = capturedFiles[sessionsPath!].split("\n");
+    expect(lines).toHaveLength(2);
+
+    const session1 = JSON.parse(lines[0]);
+    const session2 = JSON.parse(lines[1]);
+    expect(session1._id).toBe("session-abc");
+    expect(session2._id).toBe("session-def");
+  });
+
+  it("includes annotations from all runs in PER_SESSION", async () => {
+    const runs = [makeRun(1), makeRun(2)];
+    const runSet = makeRunSet({ annotationType: "PER_SESSION" });
+
+    let callIndex = 0;
+    const sessionOrder = runs.flatMap((r) =>
+      r.sessions.map((s) => s.sessionId),
+    );
+    vi.mocked(fse.readJSON).mockImplementation(async () => {
+      const sessionId = sessionOrder[callIndex++];
+      return makeTranscript(sessionId, { sessionAnnotations: true });
+    });
+
+    await handler({
+      body: {
+        runSet: runSet as any,
+        runs: runs as any,
+        inputFolder: "storage/proj1/runs",
+        outputFolder: "storage/proj1/run-sets/runset1/exports",
+      },
+    });
+
+    const sessionsPath = Object.keys(capturedFiles).find((p) =>
+      p.includes("sessions.jsonl"),
+    );
+    const session1 = JSON.parse(capturedFiles[sessionsPath!].split("\n")[0]);
+
+    expect(session1.annotations).toHaveLength(2);
+    expect(session1.annotations[0]._metadata.runId).toBe("run1");
+    expect(session1.annotations[1]._metadata.runId).toBe("run2");
+  });
+
+  it("includes annotations from all runs in PER_UTTERANCE", async () => {
+    const runs = [
+      makeRun(1, { annotationType: "PER_UTTERANCE" }),
+      makeRun(2, { annotationType: "PER_UTTERANCE" }),
+    ];
+    const runSet = makeRunSet({ annotationType: "PER_UTTERANCE" });
+
+    let callIndex = 0;
+    const sessionOrder = runs.flatMap((r) =>
+      r.sessions.map((s) => s.sessionId),
+    );
+    vi.mocked(fse.readJSON).mockImplementation(async () => {
+      const sessionId = sessionOrder[callIndex++];
+      return makeTranscript(sessionId, { utteranceAnnotations: true });
+    });
+
+    await handler({
+      body: {
+        runSet: runSet as any,
+        runs: runs as any,
+        inputFolder: "storage/proj1/runs",
+        outputFolder: "storage/proj1/run-sets/runset1/exports",
+      },
+    });
+
+    const sessionsPath = Object.keys(capturedFiles).find((p) =>
+      p.includes("sessions.jsonl"),
+    );
+    const session1 = JSON.parse(capturedFiles[sessionsPath!].split("\n")[0]);
+
+    expect(session1.transcript[0].annotations).toHaveLength(2);
+    expect(session1.transcript[0].annotations[0]._metadata.runId).toBe("run1");
+    expect(session1.transcript[0].annotations[1]._metadata.runId).toBe("run2");
+  });
+
+  it("generates meta JSONL with all runs", async () => {
+    const runs = [makeRun(1), makeRun(2)];
+    const runSet = makeRunSet({ annotationType: "PER_SESSION" });
+
+    let callIndex = 0;
+    const sessionOrder = runs.flatMap((r) =>
+      r.sessions.map((s) => s.sessionId),
+    );
+    vi.mocked(fse.readJSON).mockImplementation(async () => {
+      const sessionId = sessionOrder[callIndex++];
+      return makeTranscript(sessionId, { sessionAnnotations: true });
+    });
+
+    await handler({
+      body: {
+        runSet: runSet as any,
+        runs: runs as any,
+        inputFolder: "storage/proj1/runs",
+        outputFolder: "storage/proj1/run-sets/runset1/exports",
+      },
+    });
+
+    const metaPath = Object.keys(capturedFiles).find((p) =>
+      p.includes("meta.jsonl"),
+    );
+    expect(metaPath).toBeDefined();
+
+    const lines = capturedFiles[metaPath!].split("\n");
+    expect(lines).toHaveLength(2);
+
+    const meta1 = JSON.parse(lines[0]);
+    const meta2 = JSON.parse(lines[1]);
+    expect(meta1.runId).toBe("run1");
+    expect(meta2.runId).toBe("run2");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1448 — PER_SESSION CSV exports were missing the user's `session_id`, making it impossible to merge exported annotation data with external datasets.

## What was wrong

The export code had several inconsistencies around two different "session ID" concepts:

- **`session.sessionId`** — the internal MongoDB ObjectId (e.g. `67a1b2c3d4e5f6a7b8c9d0e1`), used by the platform to reference Session documents
- **`utterance.session_id`** — the original value from the user's uploaded data (e.g. `Session_001`), set during file conversion in `convertFileToSession.ts`

The export code confused these two:

| Export | Issue |
|---|---|
| **Run CSV, PER_SESSION** | `_id` column (MongoDB ObjectId) was missing from the keys array entirely — no session identifier at all |
| **Run CSV, PER_UTTERANCE** | Code set `utterance.sessionId` (camelCase) but the CSV key was `"session_id"` (snake_case) — the column only worked by accident if the transcript already had `session_id` |
| **Run Set CSV, PER_UTTERANCE** | Used `"sessionId"` (camelCase) as the column name, inconsistent with the single run export's `"session_id"` |
| **Run Set CSV, PER_UTTERANCE** | Missing `sequence_id` column (present in single run export) |
| **Run JSONL** | No `_id` at the session level — no way to identify which session each JSONL line belongs to |
| **Both CSVs** | The assignment `utterance.sessionId = session.sessionId` was overwriting/conflating the user's original `session_id` with the MongoDB ObjectId |

This last point was partially addressed in commit `0ce064f7` ("Preserve session_id and sequence_id on export") which changed the CSV key from `"sessionId"` to `"session_id"` — but left the `utterance.sessionId = session.sessionId` assignment in place, creating a stray camelCase property that was silently ignored.

## What changed

**Stop touching `session_id` on utterances** — the transcript data already has the correct value from the user's upload. The export code no longer overwrites it.

**Add `session_id` to PER_SESSION CSV** — pulled from the first utterance of each session's transcript. This is the key fix: researchers can now merge PER_SESSION annotation results with their own data.

**Add `_id` to PER_SESSION CSV** — the platform's MongoDB ObjectId, so users can reference back to the platform.

**Use `_sessionRef` for internal matching** — the run set export needs to match utterances across runs. Previously it used `session_id` for this, conflating the two concepts. Now it uses an internal `_sessionRef` property (not included in CSV output).

**Align column names** — both single run and run set exports now use the same `utteranceKeys`: `_id, session_id, sequence_id, role, content, start_time, end_time`.

**Add `_id` to single run JSONL** — each session line now has the platform session ID at the top level.

## Export format after this change

### PER_SESSION CSV (sessions file) — the main fix

```
_id,session_id,quality-0,rating-0
67a1b2c3d4e5f6a7b8c9d0e1,Session_001,high,4
67a1b2c3d4e5f6a7b8c9d0e2,Session_002,medium,3
```

- `_id` = platform MongoDB ObjectId
- `session_id` = user's original value from uploaded data

### PER_UTTERANCE CSV (utterances file)

```
_id,session_id,sequence_id,role,content,start_time,end_time,score-0,label-0
0,Session_001,1,Tutor,Hello,,,5,greeting
1,Session_001,2,Student,Hi there,,,3,response
0,Session_002,1,Tutor,Let's begin,,,4,instruction
```

- `session_id` = user's original value (no longer overwritten with MongoDB ObjectId)

### JSONL (sessions file)

```json
{"_id":"67a1b2c3d4e5f6a7b8c9d0e1","transcript":[...],"annotations":[...]}
```

- `_id` at session level was missing before