### PR TITLE
Add Sandpiper color palette behind HAS_SANDPIPER_THEME feature flag

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -7,13 +7,34 @@
   --font-sans:
     "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
     "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+
+  --color-sandpiper-canvas: var(--sp-canvas);
+  --color-sandpiper-surface: var(--sp-surface);
+  --color-sandpiper-border: var(--sp-border);
+
+  --color-sandpiper-text: var(--sp-text);
+  --color-sandpiper-muted: var(--sp-muted);
+
+  --color-sandpiper-primary: var(--sp-primary);
+  --color-sandpiper-primary-hover: var(--sp-primary-hover);
+  --color-sandpiper-accent: var(--sp-accent);
+  --color-sandpiper-destructive: var(--sp-destructive);
+
+  --color-sandpiper-success: var(--sp-success);
+  --color-sandpiper-warning: var(--sp-warning);
+
+  --color-sandpiper-gold: var(--sp-gold);
+  --color-sandpiper-silver: var(--sp-silver);
+  --color-sandpiper-bronze: var(--sp-bronze);
+  --color-sandpiper-elevated: var(--sp-elevated);
+
+  /* TODO: delete sandpiper-info and sandpiper-progress once sandpiper theme is fully rolled out */
+  --color-sandpiper-info: var(--sp-info);
+  --color-sandpiper-progress: var(--sp-progress);
 }
 
-html,
-body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
+  html {
     color-scheme: dark;
   }
 }
@@ -57,24 +78,43 @@ body {
 }
 
 :root {
+  --sp-canvas: oklch(1 0 0);
+  --sp-surface: oklch(0.97 0 0);
+  --sp-border: oklch(0.922 0 0);
+  --sp-text: oklch(0.145 0 0);
+  --sp-muted: oklch(0.556 0 0);
+  --sp-primary: oklch(0.205 0 0);
+  --sp-primary-hover: oklch(0.15 0 0);
+  --sp-accent: #7c3aed;
+  --sp-destructive: oklch(0.577 0.245 27.325);
+  --sp-success: #16a34a;
+  --sp-warning: #d97706;
+  --sp-gold: #c9a227;
+  --sp-silver: #8a9a9e;
+  --sp-bronze: #a67c52;
+  --sp-elevated: #f8f5fe;
+  /* TODO: delete --sp-info and --sp-progress once sandpiper theme is fully rolled out */
+  --sp-info: #3b82f6;
+  --sp-progress: #fb923c;
+
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  --background: var(--sp-canvas);
+  --foreground: var(--sp-text);
+  --card: var(--sp-canvas);
+  --card-foreground: var(--sp-text);
+  --popover: var(--sp-canvas);
+  --popover-foreground: var(--sp-text);
+  --primary: var(--sp-primary);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
+  --secondary: var(--sp-surface);
+  --secondary-foreground: var(--sp-text);
+  --muted: var(--sp-surface);
+  --muted-foreground: var(--sp-muted);
+  --accent: var(--sp-surface);
+  --accent-foreground: var(--sp-text);
+  --destructive: var(--sp-destructive);
+  --border: var(--sp-border);
+  --input: var(--sp-border);
   --ring: oklch(0.708 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
@@ -82,13 +122,50 @@ body {
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
   --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-foreground: var(--sp-text);
+  --sidebar-primary: var(--sp-primary);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-accent: var(--sp-surface);
+  --sidebar-accent-foreground: var(--sp-text);
+  --sidebar-border: var(--sp-border);
   --sidebar-ring: oklch(0.708 0 0);
+}
+
+/* TODO: Once HAS_SANDPIPER_THEME is fully rolled out, move these values
+   into :root (replacing the defaults above) and delete this selector.
+   See also: app/modules/featureFlags/components/sandpiperTheme.tsx */
+.sandpiper-theme {
+  --sp-canvas: #f9f7f1;
+  --sp-surface: #e6e2d6;
+  --sp-border: #d1cec8;
+  --sp-text: #1e1a14;
+  --sp-muted: #524840;
+  --sp-primary: #3e2723;
+  --sp-primary-hover: #6b4f48;
+  --sp-accent: #367181;
+  --sp-destructive: #b8432a;
+  --sp-success: #3e6e42;
+  --sp-warning: #7a6118;
+  --sp-gold: #c9a227;
+  --sp-silver: #8a9a9e;
+  --sp-bronze: #a67c52;
+  --sp-elevated: #ffffff;
+  --sp-info: var(--sp-accent);
+  --sp-progress: var(--sp-primary);
+
+  --primary-foreground: #ffffff;
+  --destructive: var(--sp-destructive);
+  --ring: var(--sp-primary);
+  --chart-1: var(--sp-primary);
+  --chart-2: var(--sp-accent);
+  --chart-3: var(--sp-success);
+  --chart-4: var(--sp-warning);
+  --chart-5: var(--sp-gold);
+  --sidebar: var(--sp-surface);
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: var(--sp-canvas);
+  --sidebar-accent-foreground: var(--sp-primary);
+  --sidebar-ring: var(--sp-primary);
 }
 
 .dark {

--- a/app/modules/authentication/containers/authentication.container.tsx
+++ b/app/modules/authentication/containers/authentication.container.tsx
@@ -3,6 +3,7 @@ import { LoaderPinwheel } from "lucide-react";
 import { useEffect, useRef, type ReactNode } from "react";
 import { Outlet, useFetcher, useLocation, useMatch } from "react-router";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
+import SandpiperTheme from "~/modules/featureFlags/components/sandpiperTheme";
 import { connectSockets } from "~/modules/sockets/sockets";
 import type { User } from "~/modules/users/users.types";
 import LoginContainer from "./login.container";
@@ -72,6 +73,7 @@ export default function AuthenticationContainer({
 
   return (
     <AuthenticationContext value={authentication}>
+      <SandpiperTheme />
       {children}
     </AuthenticationContext>
   );

--- a/app/modules/codebooks/components/codebook.tsx
+++ b/app/modules/codebooks/components/codebook.tsx
@@ -68,7 +68,7 @@ export default function Codebook({
               <Button
                 size="icon"
                 variant="ghost"
-                className="size-4 cursor-pointer hover:text-indigo-600"
+                className="hover:text-sandpiper-accent size-4 cursor-pointer"
                 onClick={onCreateCodebookVersionClicked}
                 asChild
               >

--- a/app/modules/codebooks/components/codebookCategoryItem.tsx
+++ b/app/modules/codebooks/components/codebookCategoryItem.tsx
@@ -13,7 +13,7 @@ export default function CodebookCategoryItem({
     <div
       className={cn(
         "cursor-pointer border-b p-2 text-sm",
-        isSelected && "bg-indigo-50",
+        isSelected && "bg-sandpiper-accent/10",
       )}
       onClick={onClick}
     >

--- a/app/modules/codebooks/components/codebookEditor.tsx
+++ b/app/modules/codebooks/components/codebookEditor.tsx
@@ -86,7 +86,7 @@ export default function CodebookEditor({
           {!isProduction && codebookVersion.hasBeenSaved && (
             <Button
               variant="ghost"
-              className="cursor-pointer hover:text-indigo-600"
+              className="hover:text-sandpiper-accent cursor-pointer"
               onClick={onMakeCodebookVersionProduction}
             >
               <BookCheck />
@@ -96,7 +96,7 @@ export default function CodebookEditor({
           {!codebookVersion.hasBeenSaved && (
             <Button
               variant="ghost"
-              className="cursor-pointer hover:text-indigo-600"
+              className="hover:text-sandpiper-accent cursor-pointer"
               disabled={!hasChanges || isLoading}
               onClick={onSaveClicked}
             >

--- a/app/modules/codebooks/components/codebookVersionItem.tsx
+++ b/app/modules/codebooks/components/codebookVersionItem.tsx
@@ -23,7 +23,7 @@ export default function CodebookVersionItem({
   isProduction,
 }: CodebookVersionItemProps) {
   const className = clsx("block border-b p-2", {
-    "bg-indigo-50": isSelected,
+    "bg-sandpiper-accent/10": isSelected,
   });
 
   return (
@@ -33,16 +33,21 @@ export default function CodebookVersionItem({
       className={className}
     >
       <div className="mb-2">
-        <Badge variant="outline" className="bg-white">{`# ${version}`}</Badge>
+        <Badge
+          variant="outline"
+          className="bg-background"
+        >{`# ${version}`}</Badge>
         {isProduction && (
-          <Badge variant="secondary" className="ml-2 bg-indigo-100">
+          <Badge variant="secondary" className="bg-sandpiper-accent/15 ml-2">
             <BookCheck />
             Production
           </Badge>
         )}
       </div>
-      <div className="text-sm text-black/40">{name}</div>
-      <div className="text-xs text-black/40">{getDateString(createdAt)}</div>
+      <div className="text-muted-foreground text-sm">{name}</div>
+      <div className="text-muted-foreground text-xs">
+        {getDateString(createdAt)}
+      </div>
     </Link>
   );
 }

--- a/app/modules/evaluations/components/evaluationCreate.tsx
+++ b/app/modules/evaluations/components/evaluationCreate.tsx
@@ -94,10 +94,10 @@ export default function EvaluationCreate({
         />
       </div>
 
-      <div className="sticky bottom-0 -mx-8 flex items-center gap-8 rounded-b-lg border-t bg-white px-8 py-4">
+      <div className="bg-background sticky bottom-0 -mx-8 flex items-center gap-8 rounded-b-lg border-t px-8 py-4">
         <div className="flex-1">
-          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
-            <p className="text-sm text-blue-900">
+          <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
+            <p className="text-foreground text-sm">
               {baseRun && selectedRuns.length > 0 ? (
                 <>
                   This evaluation will compare{" "}

--- a/app/modules/evaluations/helpers/getKappaCellClass.ts
+++ b/app/modules/evaluations/helpers/getKappaCellClass.ts
@@ -3,10 +3,10 @@ import getKappaInterpretation from "./getKappaInterpretation";
 export default function getKappaCellClass(kappa: number): string {
   const interpretation = getKappaInterpretation(kappa);
   if (interpretation === "Almost Perfect" || interpretation === "Substantial") {
-    return "bg-green-50 dark:bg-green-950/30";
+    return "bg-sandpiper-success/10 dark:bg-sandpiper-success/10";
   }
   if (interpretation === "Moderate") {
-    return "bg-amber-50 dark:bg-amber-950/30";
+    return "bg-sandpiper-warning/10 dark:bg-sandpiper-warning/10";
   }
-  return "bg-red-50 dark:bg-red-950/30";
+  return "bg-sandpiper-destructive/10 dark:bg-sandpiper-destructive/10";
 }

--- a/app/modules/featureFlags/components/sandpiperTheme.tsx
+++ b/app/modules/featureFlags/components/sandpiperTheme.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import useHasFeatureFlag from "../hooks/useHasFeatureFlag";
+
+// TODO: Remove this component once HAS_SANDPIPER_THEME is fully rolled out.
+// When removing:
+// 1. Delete this file
+// 2. Remove <SandpiperTheme /> from authentication.container.tsx
+// 3. In app.css: move .sandpiper-theme overrides into :root, delete the
+//    old defaults, and remove the .sandpiper-theme selector
+export default function SandpiperTheme() {
+  const hasTheme = useHasFeatureFlag("HAS_SANDPIPER_THEME");
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("sandpiper-theme", hasTheme);
+    return () => document.documentElement.classList.remove("sandpiper-theme");
+  }, [hasTheme]);
+
+  return null;
+}

--- a/app/modules/humanAnnotations/components/selectCsvStep.tsx
+++ b/app/modules/humanAnnotations/components/selectCsvStep.tsx
@@ -13,7 +13,7 @@ const SelectCsvStep = ({
   isDragActive: boolean;
 }) => {
   const dropzoneClassName = clsx(
-    "border border-dashed border-black/20 p-12 rounded-md hover:bg-gray-50 dark:hover:bg-gray-900 text-center cursor-pointer",
+    "border border-dashed border-border p-12 rounded-md hover:bg-muted dark:hover:bg-gray-900 text-center cursor-pointer",
   );
 
   return (

--- a/app/modules/prompts/components/prompt.tsx
+++ b/app/modules/prompts/components/prompt.tsx
@@ -76,7 +76,7 @@ export default function Prompt({
               <Button
                 size="icon"
                 variant="ghost"
-                className="size-4 cursor-pointer hover:text-indigo-600"
+                className="hover:text-sandpiper-accent size-4 cursor-pointer"
                 onClick={onCreatePromptVersionClicked}
                 asChild
               >

--- a/app/modules/prompts/components/promptEditor.tsx
+++ b/app/modules/prompts/components/promptEditor.tsx
@@ -70,7 +70,7 @@ export default function PromptEditor({
           {!isProduction && promptVersion.hasBeenSaved && (
             <Button
               variant="ghost"
-              className="cursor-pointer hover:text-indigo-600"
+              className="hover:text-sandpiper-accent cursor-pointer"
               onClick={onMakePromptVersionProductionClicked}
             >
               <BookCheck />
@@ -80,7 +80,7 @@ export default function PromptEditor({
           {!promptVersion.hasBeenSaved && (
             <Button
               variant="ghost"
-              className="cursor-pointer hover:text-indigo-600"
+              className="hover:text-sandpiper-accent cursor-pointer"
               disabled={!hasChanges || isLoading}
               onClick={onSavePromptVersionClicked}
             >

--- a/app/modules/prompts/components/promptSelector.tsx
+++ b/app/modules/prompts/components/promptSelector.tsx
@@ -144,7 +144,7 @@ export default function PromptSelector({
                         selectedPromptVersionItem.version && (
                         <Badge
                           variant="secondary"
-                          className="ml-2 bg-indigo-100"
+                          className="bg-sandpiper-accent/15 ml-2"
                         >
                           <BookCheck className="size-3" />
                           Production
@@ -193,7 +193,7 @@ export default function PromptSelector({
                             productionVersion === promptVersion.version && (
                               <Badge
                                 variant="secondary"
-                                className="ml-2 bg-indigo-100"
+                                className="bg-sandpiper-accent/15 ml-2"
                               >
                                 <BookCheck className="size-3" />
                                 Production
@@ -227,7 +227,10 @@ export default function PromptSelector({
                   {`#${selectedPromptVersionItem.version}`}
                   {productionVersion &&
                     productionVersion === selectedPromptVersionItem.version && (
-                      <Badge variant="secondary" className="ml-2 bg-indigo-100">
+                      <Badge
+                        variant="secondary"
+                        className="bg-sandpiper-accent/15 ml-2"
+                      >
                         <BookCheck />
                         Production
                       </Badge>

--- a/app/modules/prompts/components/promptVersionItem.tsx
+++ b/app/modules/prompts/components/promptVersionItem.tsx
@@ -23,22 +23,27 @@ export default function PromptVersionItem({
   isProduction,
 }: PromptVersionItemProps) {
   const className = clsx("block border-b p-2", {
-    "bg-indigo-50": isSelected,
+    "bg-sandpiper-accent/10": isSelected,
   });
 
   return (
     <Link to={`/prompts/${prompt}/${version}`} replace className={className}>
       <div className="mb-2">
-        <Badge variant="outline" className="bg-white">{`# ${version}`}</Badge>
+        <Badge
+          variant="outline"
+          className="bg-background"
+        >{`# ${version}`}</Badge>
         {isProduction && (
-          <Badge variant="secondary" className="ml-2 bg-indigo-100">
+          <Badge variant="secondary" className="bg-sandpiper-accent/15 ml-2">
             <BookCheck />
             Production
           </Badge>
         )}
       </div>
-      <div className="text-sm text-black/40">{name}</div>
-      <div className="text-xs text-black/40">{getDateString(createdAt)}</div>
+      <div className="text-muted-foreground text-sm">{name}</div>
+      <div className="text-muted-foreground text-xs">
+        {getDateString(createdAt)}
+      </div>
     </Link>
   );
 }

--- a/app/modules/runSets/components/estimateSummary.tsx
+++ b/app/modules/runSets/components/estimateSummary.tsx
@@ -20,7 +20,7 @@ export default function EstimateSummary({
     <div className="flex items-center gap-4">
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex cursor-help items-center gap-1 text-blue-700">
+          <div className="text-sandpiper-info flex cursor-help items-center gap-1">
             <Clock className="h-4 w-4" />
             <span className="text-sm">
               {formatTime(estimation.estimatedTimeSeconds)}
@@ -34,7 +34,7 @@ export default function EstimateSummary({
 
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex cursor-help items-center gap-1 text-blue-700">
+          <div className="text-sandpiper-info flex cursor-help items-center gap-1">
             <DollarSign className="h-4 w-4" />
             <span className="text-sm">
               {formatCost(estimation.estimatedCost)}

--- a/app/modules/runSets/components/runSetCreateRunsFooter.tsx
+++ b/app/modules/runSets/components/runSetCreateRunsFooter.tsx
@@ -44,17 +44,17 @@ export default function RunSetCreateRunsFooter({
   const footerState = getFooterState();
 
   return (
-    <div className="sticky bottom-0 flex items-center gap-8 rounded-b-4xl border-t bg-white px-8 py-4">
+    <div className="bg-background sticky bottom-0 flex items-center gap-8 rounded-b-4xl border-t px-8 py-4">
       <div className="flex-1">
         {footerState === "ready" && (
-          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+          <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
             <div className="flex items-center justify-between gap-4">
-              <p className="text-sm text-blue-900">
+              <p className="text-foreground text-sm">
                 This will create <strong>{newRunsCount}</strong> new run(s) with{" "}
                 {selectedPromptsCount} prompt(s) × {selectedModelsCount}{" "}
                 model(s) across {runSet.sessions?.length || 0} session(s)
                 {duplicateCount > 0 && (
-                  <span className="text-amber-700">
+                  <span className="text-sandpiper-warning">
                     {" "}
                     ({duplicateCount} duplicate combination(s) will be skipped)
                   </span>

--- a/app/modules/runSets/components/runSetCreateRunsInfo.tsx
+++ b/app/modules/runSets/components/runSetCreateRunsInfo.tsx
@@ -9,7 +9,7 @@ export default function RunSetCreateRunsInfo({
   runSet,
 }: RunSetCreateRunsInfoProps) {
   return (
-    <div className="rounded-lg border bg-slate-50 p-4">
+    <div className="bg-muted rounded-lg border p-4">
       <h3 className="mb-4 text-sm font-semibold">RunSet Info</h3>
       <div className="grid grid-cols-2 gap-4">
         <StatItem label="Name">{runSet.name}</StatItem>

--- a/app/modules/runSets/components/runSetCreatorFooter.tsx
+++ b/app/modules/runSets/components/runSetCreatorFooter.tsx
@@ -25,7 +25,7 @@ export default function RunSetCreatorFooter({
     selectedSessions.length === 0;
 
   return (
-    <div className="sticky bottom-0 flex items-center gap-8 rounded-b-4xl border-t bg-white px-8 py-4">
+    <div className="bg-background sticky bottom-0 flex items-center gap-8 rounded-b-4xl border-t px-8 py-4">
       <div className="flex-1">
         {isSubmitDisabled ? (
           <RunSetValidationAlert
@@ -34,9 +34,9 @@ export default function RunSetCreatorFooter({
             selectedSessions={selectedSessions}
           />
         ) : (
-          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+          <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
             <div className="flex items-center justify-between gap-4">
-              <p className="text-sm text-blue-900">
+              <p className="text-foreground text-sm">
                 This will create <strong>{runsCount}</strong> run(s) across{" "}
                 {selectedSessions.length} session(s)
               </p>

--- a/app/modules/runSets/components/runSetCreatorFormAlerts.tsx
+++ b/app/modules/runSets/components/runSetCreatorFormAlerts.tsx
@@ -38,9 +38,11 @@ export default function RunSetCreatorFormAlerts({
       )}
 
       {Object.keys(errors).length > 0 && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-          <h3 className="mb-2 text-sm font-semibold text-red-900">Errors</h3>
-          <ul className="space-y-1 text-sm text-red-700">
+        <div className="border-sandpiper-destructive/20 bg-sandpiper-destructive/5 rounded-lg border p-4">
+          <h3 className="text-sandpiper-destructive mb-2 text-sm font-semibold">
+            Errors
+          </h3>
+          <ul className="text-sandpiper-destructive/80 space-y-1 text-sm">
             {Object.entries(errors).map(([field, message]) => (
               <li key={field}>• {message}</li>
             ))}

--- a/app/modules/runSets/components/runSetCreatorModels.tsx
+++ b/app/modules/runSets/components/runSetCreatorModels.tsx
@@ -51,7 +51,7 @@ export default function RunSetModelsField({
             {selectedModels.map((model) => (
               <div
                 key={model}
-                className="flex items-center justify-between rounded bg-white p-2"
+                className="bg-background flex items-center justify-between rounded p-2"
               >
                 <span className="text-sm">{model}</span>
                 <Button

--- a/app/modules/runSets/components/runSetCreatorPrompts.tsx
+++ b/app/modules/runSets/components/runSetCreatorPrompts.tsx
@@ -92,7 +92,7 @@ export default function RunSetPromptsField({
             {selectedPrompts.map((prompt) => (
               <div
                 key={`${prompt.promptId}-${prompt.version}`}
-                className="flex items-center justify-between rounded bg-white p-2"
+                className="bg-background flex items-center justify-between rounded p-2"
               >
                 <span className="text-sm">
                   {prompt.promptName} (v{prompt.version})

--- a/app/modules/runSets/components/runSetRunPreview.tsx
+++ b/app/modules/runSets/components/runSetRunPreview.tsx
@@ -29,23 +29,23 @@ export default function RunSetRunPreview({
 
   return (
     <div
-      className="sticky top-4 min-w-0 flex-1 self-start overflow-y-auto rounded-lg border bg-slate-50"
+      className="bg-muted sticky top-4 min-w-0 flex-1 self-start overflow-y-auto rounded-lg border"
       style={{ height: "calc(100vh - 144px)" }}
     >
       {hasContent ? (
         <div className="space-y-4">
-          <div className="sticky top-0 rounded-t-lg border-b bg-white px-4 py-4">
+          <div className="bg-background sticky top-0 rounded-t-lg border-b px-4 py-4">
             <h3 className="mb-2 text-sm font-semibold">Run Preview</h3>
             <p className="text-muted-foreground text-xs">
               {runDefinitions.length} run(s) • {sessionsCount} session(s)
               {excludedDefinitions.length > 0 && (
-                <span className="text-gray-500">
+                <span className="text-muted-foreground">
                   {" "}
                   • {excludedDefinitions.length} excluded
                 </span>
               )}
               {duplicateDefinitions.length > 0 && (
-                <span className="text-amber-600">
+                <span className="text-sandpiper-warning">
                   {" "}
                   • {duplicateDefinitions.length} duplicate(s) will be skipped
                 </span>
@@ -56,12 +56,12 @@ export default function RunSetRunPreview({
             {runDefinitions.map((definition) => (
               <div
                 key={definition.key}
-                className="group relative rounded-lg border bg-white p-3 text-sm"
+                className="group bg-background relative rounded-lg border p-3 text-sm"
               >
                 <button
                   type="button"
                   onClick={() => onRemoveCard(definition.key)}
-                  className="absolute top-2 right-2 rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                  className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-2 right-2 rounded p-0.5"
                 >
                   <X className="h-3.5 w-3.5" />
                 </button>
@@ -74,12 +74,12 @@ export default function RunSetRunPreview({
             {excludedDefinitions.map((definition) => (
               <div
                 key={definition.key}
-                className="group relative rounded-lg border border-dashed border-gray-300 bg-gray-50 p-3 text-sm opacity-50"
+                className="group bg-muted relative rounded-lg border border-dashed p-3 text-sm opacity-50"
               >
                 <button
                   type="button"
                   onClick={() => onRestoreCard(definition.key)}
-                  className="absolute top-2 right-2 rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                  className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-2 right-2 rounded p-0.5"
                 >
                   <Plus className="h-3.5 w-3.5" />
                 </button>
@@ -92,9 +92,9 @@ export default function RunSetRunPreview({
             {duplicateDefinitions.map((definition) => (
               <div
                 key={definition.key}
-                className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm opacity-60"
+                className="border-sandpiper-warning/20 bg-sandpiper-warning/5 rounded-lg border p-3 text-sm opacity-60"
               >
-                <div className="mb-2 flex items-center gap-1 text-xs text-amber-600">
+                <div className="text-sandpiper-warning mb-2 flex items-center gap-1 text-xs">
                   <AlertTriangle className="h-3 w-3" />
                   Already exists
                 </div>
@@ -108,7 +108,7 @@ export default function RunSetRunPreview({
         </div>
       ) : (
         <div className="sticky top-8 p-8">
-          <Empty className="border border-slate-300">
+          <Empty className="border">
             <EmptyContent>
               <EmptyTitle>Select prompts and models to preview runs</EmptyTitle>
             </EmptyContent>

--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -249,7 +249,7 @@ export default function RunDetail({
             <StatItem label="Verification">
               {run.shouldRunVerification ? (
                 <Badge variant="outline" className="mt-1 gap-1.5">
-                  <BadgeCheck className="h-4 w-4 text-green-600" />
+                  <BadgeCheck className="text-sandpiper-success h-4 w-4" />
                   Enabled
                 </Badge>
               ) : (

--- a/app/modules/runs/helpers/getRunsItemAttributes.tsx
+++ b/app/modules/runs/helpers/getRunsItemAttributes.tsx
@@ -50,7 +50,7 @@ export default function getRunsItemAttributes(item: Run, options?: Options) {
 
   if (options?.hasRunVerification && item.shouldRunVerification) {
     meta.push({
-      icon: <BadgeCheck className="text-green-600 dark:text-green-400" />,
+      icon: <BadgeCheck className="text-sandpiper-success" />,
       text: "Verified",
     });
   }

--- a/app/modules/runs/helpers/statusMeta.tsx
+++ b/app/modules/runs/helpers/statusMeta.tsx
@@ -28,7 +28,7 @@ export const STATUS_META: Record<
     text: "Failed",
   },
   COMPLETE: {
-    icon: <CircleCheck className="text-green-600 dark:text-green-400" />,
+    icon: <CircleCheck className="text-sandpiper-success" />,
     text: "Complete",
   },
   QUEUED: {

--- a/app/modules/sessions/components/sessionViewerAnnotation.tsx
+++ b/app/modules/sessions/components/sessionViewerAnnotation.tsx
@@ -42,13 +42,13 @@ export default function SessionViewerAnnotation({
             disabled={isVoting}
             onClick={onDownVoteClicked}
             className={clsx({
-              "border-purple-700": annotation.markedAs === "DOWN_VOTED",
+              "border-sandpiper-accent": annotation.markedAs === "DOWN_VOTED",
             })}
           >
             <ThumbsDown
               size={10}
               className={clsx({
-                "stroke-purple-700": annotation.markedAs === "DOWN_VOTED",
+                "stroke-sandpiper-accent": annotation.markedAs === "DOWN_VOTED",
               })}
             />
           </Button>
@@ -58,13 +58,13 @@ export default function SessionViewerAnnotation({
             disabled={isVoting}
             onClick={onUpVoteClicked}
             className={clsx({
-              "border-purple-700": annotation.markedAs === "UP_VOTED",
+              "border-sandpiper-accent": annotation.markedAs === "UP_VOTED",
             })}
           >
             <ThumbsUp
               size={10}
               className={clsx({
-                "stroke-purple-700": annotation.markedAs === "UP_VOTED",
+                "stroke-sandpiper-accent": annotation.markedAs === "UP_VOTED",
               })}
             />
           </Button>

--- a/app/modules/sessions/components/sessionViewerUtterance.tsx
+++ b/app/modules/sessions/components/sessionViewerUtterance.tsx
@@ -28,12 +28,12 @@ export default function SessionViewerUtterance({
       <div className="flex max-w-3/4 flex-col">
         <div
           id={`session-viewer-utterance-${utterance._id}`}
-          className={clsx("bg-muted scroll-mt-4 rounded-4xl border p-4", {
-            "border-purple-300 bg-purple-100": isSelected,
-            "bg-muted": !isSelected,
-            "rounded-bl-none border-purple-100 bg-purple-50":
-              utterance.role === leadRole,
-            "rounded-br-none border-gray-200": utterance.role !== leadRole,
+          className={clsx("scroll-mt-4 rounded-4xl border p-4", {
+            "border-sandpiper-accent/30 bg-sandpiper-accent/10": isSelected,
+            "bg-sandpiper-elevated rounded-bl-none":
+              !isSelected && utterance.role === leadRole,
+            "border-sandpiper-surface bg-sandpiper-surface rounded-br-none":
+              !isSelected && utterance.role !== leadRole,
           })}
         >
           {utterance.content}
@@ -46,10 +46,10 @@ export default function SessionViewerUtterance({
             <Button
               variant="link"
               size={"sm"}
-              className="decoration-purple-500"
+              className="decoration-sandpiper-accent"
               onClick={() => onUtteranceClicked(utterance._id)}
             >
-              <div className="ml-4 flex items-center text-xs text-purple-500 decoration-purple-500">
+              <div className="text-sandpiper-accent decoration-sandpiper-accent ml-4 flex items-center text-xs">
                 <NotebookPen className="mr-1 size-3" />
                 {utterance.annotations.length} annotation
                 {utterance.annotations.length > 1 ? "s" : ""}

--- a/app/modules/support/components/supportArticlesHeader.tsx
+++ b/app/modules/support/components/supportArticlesHeader.tsx
@@ -21,7 +21,7 @@ export default function SupportArticlesHeader({
   onSearchClicked: () => void;
 }) {
   return (
-    <SheetHeader className="sticky top-0 bg-white">
+    <SheetHeader className="bg-background sticky top-0">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <SheetTitle className="flex items-center">

--- a/app/modules/teams/components/inviteUserToTeamDialog.tsx
+++ b/app/modules/teams/components/inviteUserToTeamDialog.tsx
@@ -98,7 +98,7 @@ export default function InviteUserToTeamDialog({
           <div>
             {inviteLink && (
               <div className="relative">
-                <div className="rounded-2xl bg-gray-100 p-2 pr-10 text-sm break-all">
+                <div className="bg-muted rounded-2xl p-2 pr-10 text-sm break-all">
                   {inviteLink}
                 </div>
                 <Button
@@ -112,11 +112,11 @@ export default function InviteUserToTeamDialog({
                   {!hasCopiedInviteLink && <CopyIcon />}
                 </Button>
                 {hasCopiedInviteLink && (
-                  <div className="absolute right-4 -bottom-6 text-xs text-green-500">
+                  <div className="text-sandpiper-success absolute right-4 -bottom-6 text-xs">
                     Invite link copied!
                   </div>
                 )}
-                <div className="mt-4 text-xs text-gray-500">
+                <div className="text-muted-foreground mt-4 text-xs">
                   {`This invite link will expire in ${INVITE_LINK_TTL_DAYS} days.`}
                 </div>
               </div>

--- a/app/modules/users/components/assignSuperAdminForm.tsx
+++ b/app/modules/users/components/assignSuperAdminForm.tsx
@@ -39,22 +39,21 @@ export default function AssignSuperAdminForm({
       </DialogHeader>
 
       <div className="space-y-4">
-        <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-900">
+        <div className="bg-muted rounded p-3 text-sm">
           <div>
-            <p className="text-xs text-gray-600 dark:text-gray-400">User:</p>
+            <p className="text-muted-foreground text-xs">User:</p>
             <p className="mb-2 font-medium">
               {targetUser.username || "Unknown User"}
             </p>
-            <p className="text-xs text-gray-600 dark:text-gray-400">
-              Current Role:
-            </p>
+            <p className="text-muted-foreground text-xs">Current Role:</p>
             <p className="font-medium">{targetUser.role || "USER"}</p>
           </div>
         </div>
 
         <div>
           <Label htmlFor="reason" className="mb-2 block text-sm">
-            Reason for Promotion <span className="text-red-500">*</span>
+            Reason for Promotion{" "}
+            <span className="text-sandpiper-destructive">*</span>
           </Label>
           <Textarea
             id="reason"
@@ -63,7 +62,7 @@ export default function AssignSuperAdminForm({
             onChange={onReasonChanged}
             className="min-h-24"
           />
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-muted-foreground mt-1 text-xs">
             This will be recorded in the audit log for security purposes.
           </p>
         </div>

--- a/app/modules/users/components/revokeSuperAdminForm.tsx
+++ b/app/modules/users/components/revokeSuperAdminForm.tsx
@@ -39,22 +39,21 @@ export default function RevokeSuperAdminForm({
       </DialogHeader>
 
       <div className="space-y-4">
-        <div className="rounded bg-red-50 p-3 text-sm dark:bg-red-950">
+        <div className="bg-sandpiper-destructive/5 rounded p-3 text-sm">
           <div>
-            <p className="text-xs text-red-600 dark:text-red-400">User:</p>
+            <p className="text-sandpiper-destructive text-xs">User:</p>
             <p className="mb-2 font-medium">
               {targetUser.username || "Unknown User"}
             </p>
-            <p className="text-xs text-red-600 dark:text-red-400">
-              Current Role:
-            </p>
+            <p className="text-sandpiper-destructive text-xs">Current Role:</p>
             <p className="font-medium">{targetUser.role || "USER"}</p>
           </div>
         </div>
 
         <div>
           <Label htmlFor="reason" className="mb-2 block text-sm">
-            Reason for Revocation <span className="text-red-500">*</span>
+            Reason for Revocation{" "}
+            <span className="text-sandpiper-destructive">*</span>
           </Label>
           <Textarea
             id="reason"
@@ -63,7 +62,7 @@ export default function RevokeSuperAdminForm({
             onChange={onReasonChanged}
             className="min-h-24"
           />
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-muted-foreground mt-1 text-xs">
             This will be recorded in the audit log for security purposes.
           </p>
         </div>

--- a/app/modules/users/helpers/getAuditLogItemAttributes.tsx
+++ b/app/modules/users/helpers/getAuditLogItemAttributes.tsx
@@ -16,9 +16,9 @@ export default function getAuditLogItemAttributes(
 ): CollectionItemAttributes {
   const icon =
     audit.action === "ADD_SUPERADMIN" ? (
-      <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+      <CheckCircle2 className="text-sandpiper-success h-4 w-4" />
     ) : audit.action === "REMOVE_SUPERADMIN" ? (
-      <AlertCircle className="h-4 w-4 text-orange-600 dark:text-orange-400" />
+      <AlertCircle className="text-sandpiper-warning h-4 w-4" />
     ) : null;
 
   const details = [

--- a/app/uikit/components/ui/actionBar.tsx
+++ b/app/uikit/components/ui/actionBar.tsx
@@ -82,7 +82,7 @@ function ActionBar({
 
       <div
         className={clsx(
-          `sticky top-4 mb-2 flex justify-between rounded-2xl border bg-white p-2 transition-all`,
+          `bg-background sticky top-4 mb-2 flex justify-between rounded-2xl border p-2 transition-all`,
           {
             "-mx-2 shadow": isStuck,
           },
@@ -135,7 +135,7 @@ function ActionBar({
         {isSyncing && (
           <div
             className={clsx(
-              "absolute top-full left-1/2 -translate-x-1/2 rounded-b-md border-x border-b bg-white px-6 pb-1",
+              "bg-background absolute top-full left-1/2 -translate-x-1/2 rounded-b-md border-x border-b px-6 pb-1",
               {
                 shadow: isStuck,
               },

--- a/app/uikit/components/ui/filters.tsx
+++ b/app/uikit/components/ui/filters.tsx
@@ -38,7 +38,7 @@ const Filters = ({
         <Button variant="ghost" size="icon" className="relative">
           <FilterIcon />
           {hasAtLeastOneFilter && (
-            <Badge className="absolute top-1 right-1 h-1.5 w-1.5 bg-blue-500 p-0 text-white dark:bg-blue-600" />
+            <Badge className="bg-sandpiper-accent absolute top-1 right-1 h-1.5 w-1.5 p-0 text-white" />
           )}
         </Button>
       </PopoverTrigger>

--- a/app/uikit/components/ui/navigation-progress.tsx
+++ b/app/uikit/components/ui/navigation-progress.tsx
@@ -17,7 +17,7 @@ function NavigationProgress() {
         )}
         aria-hidden="true"
       >
-        <div className="animate-shimmer h-full w-1/3 bg-orange-400" />
+        <div className="animate-shimmer bg-sandpiper-progress h-full w-1/3" />
       </div>
     </>
   );


### PR DESCRIPTION
Implement the Shorebird Warm color palette with a feature flag toggle so it can be rolled out gradually. When the flag is off, the app looks exactly as before. When on, the warm sandpiper theme applies.

- Define sandpiper design tokens (canvas, surface, primary, accent, destructive, success, warning, etc.) as CSS custom properties
- Wire shadcn/ui theme variables through --sp-* tokens so toggling .sandpiper-theme on <html> switches the entire palette
- Replace all hardcoded Tailwind gray/white/slate/red/green/amber classes with semantic theme tokens (bg-background, bg-muted, text-muted-foreground, etc.)
- Add SandpiperTheme component that toggles the CSS class based on the HAS_SANDPIPER_THEME feature flag
- Use sandpiper-accent for session viewer highlights (purple in default theme, teal in sandpiper)
- Use sandpiper-destructive (carnelian) for error/danger states
- All colors pass WCAG AA contrast requirements

Fixes #1425