### PR TITLE
Reduce session list sidebar width and make transcript panel flexible

### DIFF
--- a/app/modules/codebooks/components/codebook.tsx
+++ b/app/modules/codebooks/components/codebook.tsx
@@ -33,7 +33,7 @@ export default function Codebook({
   onEditCodebookButtonClicked,
 }: CodebookProps) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/codebooks/components/codebooks.tsx
+++ b/app/modules/codebooks/components/codebooks.tsx
@@ -42,7 +42,7 @@ export default function Codebooks({
   onSortValueChanged,
 }: CodebooksProps) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/evaluations/components/evaluationCreateRunsSelector.tsx
+++ b/app/modules/evaluations/components/evaluationCreateRunsSelector.tsx
@@ -26,7 +26,7 @@ export default function EvaluationCreateRunsSelector({
   onAnnotationFieldToggled: (fieldKey: string) => void;
 }) {
   return (
-    <div className="max-w-6xl">
+    <div className="max-w-7xl">
       <div className="space-y-2">
         <Label>Select your runs for evaluation</Label>
 

--- a/app/modules/featureFlags/components/featureFlags.tsx
+++ b/app/modules/featureFlags/components/featureFlags.tsx
@@ -27,7 +27,7 @@ export default function FeatureFlags({
   onCreateFeatureFlagButtonClicked: () => void;
 }) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/files/containers/uploadFiles.route.tsx
+++ b/app/modules/files/containers/uploadFiles.route.tsx
@@ -127,7 +127,7 @@ export default function UploadFilesPageRoute({
   ];
 
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/migrations/components/migrations.tsx
+++ b/app/modules/migrations/components/migrations.tsx
@@ -62,7 +62,7 @@ export default function Migrations({
   });
 
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs}></Breadcrumbs>

--- a/app/modules/projects/components/project.tsx
+++ b/app/modules/projects/components/project.tsx
@@ -57,7 +57,7 @@ export default function Project({
   const canDelete = ProjectAuthorization.canDelete(user, project);
 
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/projects/components/projects.tsx
+++ b/app/modules/projects/components/projects.tsx
@@ -47,7 +47,7 @@ export default function Projects({
   onSortValueChanged,
 }: ProjectsProps) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/prompts/components/prompt.tsx
+++ b/app/modules/prompts/components/prompt.tsx
@@ -35,7 +35,7 @@ export default function Prompt({
   onDeletePromptButtonClicked,
 }: PromptProps) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/prompts/components/prompts.tsx
+++ b/app/modules/prompts/components/prompts.tsx
@@ -47,7 +47,7 @@ export default function Prompts({
   onSortValueChanged,
 }: PromptsProps) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/queues/components/queuesLayout.tsx
+++ b/app/modules/queues/components/queuesLayout.tsx
@@ -12,7 +12,7 @@ const QueuesLayout = ({
   breadcrumbs: Breadcrumb[];
 }) => {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/runSets/components/runSetEvaluations.tsx
+++ b/app/modules/runSets/components/runSetEvaluations.tsx
@@ -33,7 +33,7 @@ export default function RunSetEvaluations({
   onActionClicked: (action: string) => void;
 }) {
   return (
-    <div className="max-w-6xl">
+    <div className="max-w-7xl">
       <CollectionUI
         items={evaluations}
         itemsLayout="list"

--- a/app/modules/runSets/components/runSetOverview.tsx
+++ b/app/modules/runSets/components/runSetOverview.tsx
@@ -66,7 +66,7 @@ export default function RunSetOverview({
 }) {
   return (
     <div>
-      <div className="grid max-w-6xl grid-cols-3 justify-start gap-6">
+      <div className="grid max-w-7xl grid-cols-3 justify-start gap-6">
         <StatItem label="Created">{getDateString(runSet.createdAt)}</StatItem>
         <StatItem label="Sessions">{runSet.sessions?.length || 0}</StatItem>
         <StatItem label="Runs">{runSet.runs?.length || 0}</StatItem>

--- a/app/modules/runs/components/createRun.tsx
+++ b/app/modules/runs/components/createRun.tsx
@@ -18,7 +18,7 @@ export default function CreateRunComponent({
   duplicateWarnings?: string[];
 }) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -111,7 +111,7 @@ export default function RunDetail({
   const projectId =
     typeof run.project === "string" ? run.project : run.project._id;
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/runs/components/runSessions.tsx
+++ b/app/modules/runs/components/runSessions.tsx
@@ -43,7 +43,7 @@ export default function RunSessions({
   onSidebarPaginationChanged: (value: number) => void;
 }) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/sessions/components/sessionListSidebar.tsx
+++ b/app/modules/sessions/components/sessionListSidebar.tsx
@@ -43,7 +43,7 @@ export default function SessionListSidebar({
   }, []);
 
   return (
-    <div className="flex h-full w-72 shrink-0 flex-col border-r">
+    <div className="flex h-full w-60 shrink-0 flex-col border-r">
       <div className="border-b p-3">
         <div className="relative">
           <SearchIcon className="text-muted-foreground absolute top-2.5 left-3 size-4" />

--- a/app/modules/sessions/components/sessionViewer.tsx
+++ b/app/modules/sessions/components/sessionViewer.tsx
@@ -48,7 +48,7 @@ export default function SessionViewer({
     <div className="flex h-full flex-1">
       <div
         id="session-viewer-scroll-container"
-        className="flex h-full w-[480px] shrink-0 flex-col overflow-y-scroll scroll-smooth border-r p-4"
+        className="flex h-full w-3/5 min-w-0 flex-col overflow-y-scroll scroll-smooth border-r p-4"
       >
         {map(sessionFile.transcript, (utterance: Utterance, index: number) => {
           const isSelected = selectedUtteranceId === utterance._id;
@@ -64,7 +64,7 @@ export default function SessionViewer({
           );
         })}
       </div>
-      <div className="flex h-full w-80 min-w-0 shrink-0 flex-col pt-8">
+      <div className="flex h-full w-2/5 min-w-0 flex-col pt-8">
         <SessionViewerDetails
           session={session}
           utteranceCount={utteranceCount}

--- a/app/modules/teams/components/team.tsx
+++ b/app/modules/teams/components/team.tsx
@@ -40,7 +40,7 @@ export default function Team({
   };
 
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/teams/components/teams.tsx
+++ b/app/modules/teams/components/teams.tsx
@@ -47,7 +47,7 @@ export default function Teams({
   onSortValueChanged,
 }: TeamsProps) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/app/modules/users/components/adminUsers.tsx
+++ b/app/modules/users/components/adminUsers.tsx
@@ -61,7 +61,7 @@ export default function AdminUsers({
   onAuditSortChanged,
 }: AdminUsersProps) {
   return (
-    <div className="max-w-6xl p-8">
+    <div className="max-w-7xl p-8">
       <PageHeader>
         <PageHeaderLeft>
           <Breadcrumbs breadcrumbs={breadcrumbs} />


### PR DESCRIPTION
Narrows the session list sidebar from w-72 to w-60 and makes the transcript viewer panel flex instead of fixed-width, giving more space to the transcript and annotation panels in the 3-column layout.

Fixes #1638