### PR TITLE
Pass BULLMQ_PRO_TOKEN to Docker builds via build args

### DIFF
--- a/.github/workflows/ecs_build_image.yml
+++ b/.github/workflows/ecs_build_image.yml
@@ -1,0 +1,129 @@
+name: ECS Build Image
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "GitHub environment name (e.g. staging|production)"
+        required: true
+        type: string
+
+      aws-region:
+        description: "AWS region"
+        required: false
+        type: string
+        default: us-east-1
+
+      dockerfile:
+        description: "Path to Dockerfile"
+        required: false
+        type: string
+        default: Dockerfile
+
+      image-suffix:
+        description: "Optional suffix for image tag (e.g. -worker)"
+        required: false
+        type: string
+        default: ""
+
+      output-name:
+        description: "Name of the output image variable"
+        required: true
+        type: string
+
+      tag:
+        description: "Optional image tag (defaults to short commit SHA)"
+        required: false
+        type: string
+
+      build-args:
+        description: "Docker build arguments (newline-separated KEY=VALUE pairs)"
+        required: false
+        type: string
+        default: ""
+
+    secrets:
+      AWS_ROLE_ARN:
+        required: true
+      BULLMQ_PRO_TOKEN:
+        required: false
+
+    outputs:
+      image:
+        description: "Fully qualified image URI"
+        value: ${{ jobs.build.outputs.image }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: Build & Push Image (${{ inputs.output-name }})
+    runs-on: ubuntu-latest
+
+    environment: ${{ inputs.environment }}
+
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Derive image tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push image
+        id: image
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          test -n "${{ vars.ECR_REPOSITORY }}" || { echo "ECR_REPOSITORY is not set"; exit 1; }
+
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          ECR_URI="$ACCOUNT_ID.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com/${{ vars.ECR_REPOSITORY }}"
+
+          IMAGE_TAG="$TAG${{ inputs.image-suffix }}"
+
+          BUILD_ARGS=""
+          if [ -n "${{ inputs.build-args }}" ]; then
+            while IFS= read -r arg; do
+              [ -n "$arg" ] && BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
+            done <<< "${{ inputs.build-args }}"
+          fi
+
+          DOCKER_BUILDKIT=1 docker build \
+            $BUILD_ARGS \
+            --secret id=BULLMQ_PRO_TOKEN,env=BULLMQ_PRO_TOKEN \
+            -f "${{ inputs.dockerfile }}" \
+            -t "${{ vars.ECR_REPOSITORY }}:$IMAGE_TAG" .
+
+          docker tag \
+            "${{ vars.ECR_REPOSITORY }}:$IMAGE_TAG" \
+            "$ECR_URI:$IMAGE_TAG"
+
+          docker push "$ECR_URI:$IMAGE_TAG"
+
+          echo "image=$ECR_URI:$IMAGE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     needs:
       - resolve
       - preflight-production
-    uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_build_image.yml@main
+    uses: ./.github/workflows/ecs_build_image.yml
     with:
       environment: production
       aws-region: us-east-1
@@ -58,12 +58,13 @@ jobs:
       tag: ${{ needs.resolve.outputs.version }}
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
   build-worker:
     name: Build Worker Image
     needs:
       - resolve
       - preflight-production
-    uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_build_image.yml@main
+    uses: ./.github/workflows/ecs_build_image.yml
     with:
       environment: production
       aws-region: us-east-1
@@ -73,6 +74,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.version }}
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
   deploy-web:
     name: Deploy Web Service
     needs: build-web

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,7 +24,7 @@ jobs:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
   build-web-staging:
     needs: preflight
-    uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_build_image.yml@main
+    uses: ./.github/workflows/ecs_build_image.yml
     with:
       environment: staging
       dockerfile: Dockerfile
@@ -32,9 +32,10 @@ jobs:
       output-name: web_image
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
   build-worker-staging:
     needs: preflight
-    uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_build_image.yml@main
+    uses: ./.github/workflows/ecs_build_image.yml
     with:
       environment: staging
       dockerfile: workers/Dockerfile
@@ -42,6 +43,7 @@ jobs:
       output-name: worker_image
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
   deploy-web-staging:
     needs: build-web-staging
     uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_deploy_service.yml@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,18 @@ RUN apk add --no-cache yarn
 COPY ./package.json yarn.lock /app/
 WORKDIR /app
 ENV REDISMS_DISABLE_POSTINSTALL=1
-RUN yarn install --frozen-lockfile
+RUN --mount=type=secret,id=BULLMQ_PRO_TOKEN \
+    BULLMQ_PRO_TOKEN="$(cat /run/secrets/BULLMQ_PRO_TOKEN 2>/dev/null || true)" \
+    yarn install --frozen-lockfile && rm -f .npmrc
 
 FROM node:25-alpine AS production-dependencies-env
 RUN apk add --no-cache yarn
 COPY ./package.json yarn.lock /app/
 WORKDIR /app
 ENV REDISMS_DISABLE_POSTINSTALL=1
-RUN yarn install --frozen-lockfile --production
+RUN --mount=type=secret,id=BULLMQ_PRO_TOKEN \
+    BULLMQ_PRO_TOKEN="$(cat /run/secrets/BULLMQ_PRO_TOKEN 2>/dev/null || true)" \
+    yarn install --frozen-lockfile --production && rm -f .npmrc
 
 FROM node:25-alpine AS build-env
 RUN apk add --no-cache yarn

--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -4,7 +4,9 @@ COPY package.json yarn.lock global-bundle.pem tsconfig.json /app/
 COPY workers/package.json /app/workers/
 WORKDIR /app
 ENV REDISMS_DISABLE_POSTINSTALL=1
-RUN yarn install --frozen-lockfile --production
+RUN --mount=type=secret,id=BULLMQ_PRO_TOKEN \
+    BULLMQ_PRO_TOKEN="$(cat /run/secrets/BULLMQ_PRO_TOKEN 2>/dev/null || true)" \
+    yarn install --frozen-lockfile --production && rm -f .npmrc
 COPY ./workers ./workers
 COPY ./app ./app
 RUN node ./app/adapters.js


### PR DESCRIPTION
Add ARG BULLMQ_PRO_TOKEN to both Dockerfiles so the postinstall script can install bullmq-pro during image builds. Bring ecs_build_image workflow local with build-args support and update staging/release workflows to pass the token.

Fixes #1613