### PR TITLE
Add voting reason for annotation up/down votes

### DIFF
--- a/app/modules/annotations/containers/annotations.route.tsx
+++ b/app/modules/annotations/containers/annotations.route.tsx
@@ -8,8 +8,23 @@ import { SessionService } from "~/modules/sessions/session";
 import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
 import type { Route } from "./+types/annotations.route";
 
+function updateAnnotationVote(
+  annotation: Record<string, unknown>,
+  payload: { markedAs?: string; votingReason?: string },
+) {
+  if (payload.markedAs) {
+    const isSameVote = annotation.markedAs === payload.markedAs;
+    annotation.markedAs = isSameVote ? undefined : payload.markedAs;
+    annotation.votingReason = undefined;
+  }
+
+  if ("votingReason" in payload) {
+    annotation.votingReason = payload.votingReason;
+  }
+}
+
 export async function action({ request, params }: Route.ActionArgs) {
-  const { markedAs } = await request.json();
+  const payload = await request.json();
 
   const user = await getSessionUser({ request });
   if (!user) {
@@ -61,21 +76,14 @@ export async function action({ request, params }: Route.ActionArgs) {
       currentUtterance?.annotations &&
       currentUtterance.annotations[annotationIndex]
     ) {
-      const annotation = currentUtterance.annotations[annotationIndex];
-      if (annotation.markedAs === markedAs) {
-        delete annotation.markedAs;
-      } else {
-        annotation.markedAs = markedAs;
-      }
+      updateAnnotationVote(
+        currentUtterance.annotations[annotationIndex],
+        payload,
+      );
     }
   } else {
     if (sessionFile.annotations && sessionFile.annotations[annotationIndex]) {
-      const annotation = sessionFile.annotations[annotationIndex];
-      if (annotation.markedAs === markedAs) {
-        delete annotation.markedAs;
-      } else {
-        annotation.markedAs = markedAs;
-      }
+      updateAnnotationVote(sessionFile.annotations[annotationIndex], payload);
     }
   }
 

--- a/app/modules/sessions/components/sessionViewer.tsx
+++ b/app/modules/sessions/components/sessionViewer.tsx
@@ -26,12 +26,15 @@ export default function SessionViewer({
   onJumpToFirstAnnotation,
   onDownVoteClicked,
   onUpVoteClicked,
+  onSaveVotingReason,
+  isSavingReason,
 }: {
   session: Session;
   sessionFile: SessionFile;
   selectedUtteranceAnnotations: Annotation[];
   selectedUtteranceId: string | null;
   isVoting: boolean;
+  isSavingReason: boolean;
   utteranceCount: number;
   selectedUtteranceIndex: number | null;
   annotatedUtteranceCount: number;
@@ -41,6 +44,11 @@ export default function SessionViewer({
   onJumpToFirstAnnotation: () => void;
   onDownVoteClicked: (utteranceId: string, annotationIndex: number) => void;
   onUpVoteClicked: (utteranceId: string, annotationIndex: number) => void;
+  onSaveVotingReason: (
+    utteranceId: string,
+    annotationIndex: number,
+    reason: string,
+  ) => void;
 }) {
   const hasSelectedAnnotation = selectedUtteranceIndex !== null;
 
@@ -79,14 +87,18 @@ export default function SessionViewer({
               {map(sessionFile.annotations, (annotation, index) => {
                 return (
                   <SessionViewerAnnotation
-                    key={`${annotation._id}-${index}`}
+                    key={`${annotation._id}-${index}-${annotation.votingReason || ""}`}
                     annotation={annotation}
                     isVoting={isVoting}
+                    isSavingReason={isSavingReason}
                     onDownVoteClicked={() =>
                       onDownVoteClicked(annotation._id, index)
                     }
                     onUpVoteClicked={() =>
                       onUpVoteClicked(annotation._id, index)
+                    }
+                    onSaveVotingReason={(reason) =>
+                      onSaveVotingReason(annotation._id, index, reason)
                     }
                   />
                 );
@@ -147,14 +159,18 @@ export default function SessionViewer({
               {map(selectedUtteranceAnnotations, (annotation, index) => {
                 return (
                   <SessionViewerAnnotation
-                    key={`${annotation._id}-${index}`}
+                    key={`${annotation._id}-${index}-${annotation.votingReason || ""}`}
                     annotation={annotation}
                     isVoting={isVoting}
+                    isSavingReason={isSavingReason}
                     onDownVoteClicked={() =>
                       onDownVoteClicked(annotation._id, index)
                     }
                     onUpVoteClicked={() =>
                       onUpVoteClicked(annotation._id, index)
+                    }
+                    onSaveVotingReason={(reason) =>
+                      onSaveVotingReason(annotation._id, index, reason)
                     }
                   />
                 );

--- a/app/modules/sessions/components/sessionViewerAnnotation.tsx
+++ b/app/modules/sessions/components/sessionViewerAnnotation.tsx
@@ -1,26 +1,44 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 import clsx from "clsx";
 import map from "lodash/map";
-import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { Check, ThumbsDown, ThumbsUp } from "lucide-react";
+import { useState } from "react";
 import type { Annotation } from "../sessions.types";
 import SessionViewerAnnotationValue from "./sessionViewerAnnotationValue";
+
+const HIDDEN_ANNOTATION_KEYS = new Set([
+  "_id",
+  "identifiedBy",
+  "markedAs",
+  "votingReason",
+]);
 
 export default function SessionViewerAnnotation({
   annotation,
   isVoting,
+  isSavingReason,
   onDownVoteClicked,
   onUpVoteClicked,
+  onSaveVotingReason,
 }: {
   annotation: Annotation & any;
   isVoting: boolean;
+  isSavingReason: boolean;
   onDownVoteClicked: () => void;
   onUpVoteClicked: () => void;
+  onSaveVotingReason: (reason: string) => void;
 }) {
+  const [reason, setReason] = useState(annotation.votingReason || "");
+
+  const hasVoted = !!annotation.markedAs;
+  const hasUnsavedChanges = reason !== (annotation.votingReason || "");
+
   return (
     <div className="bg-muted mb-2 rounded-md p-4">
       {map(annotation, (annotationValue, annotationKey) => {
-        if (annotationKey === "_id" || annotationKey === "identifiedBy") {
+        if (HIDDEN_ANNOTATION_KEYS.has(annotationKey)) {
           return null;
         }
 
@@ -70,6 +88,27 @@ export default function SessionViewerAnnotation({
           </Button>
         </div>
       </div>
+      {hasVoted && (
+        <div className="mt-3 flex gap-2">
+          <Textarea
+            placeholder="Reason for your decision..."
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            disabled={isSavingReason}
+            maxLength={280}
+            className="min-h-[60px] text-xs"
+          />
+          <Button
+            variant="outline"
+            size="icon"
+            disabled={isSavingReason || !hasUnsavedChanges}
+            onClick={() => onSaveVotingReason(reason)}
+            className="shrink-0"
+          >
+            <Check size={14} />
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/modules/sessions/containers/sessionViewerContainer.tsx
+++ b/app/modules/sessions/containers/sessionViewerContainer.tsx
@@ -90,7 +90,25 @@ export default function SessionViewerContainer({
     );
   };
 
+  const reasonFetcher = useFetcher();
+
+  const onSaveVotingReason = (
+    utteranceId: string,
+    annotationIndex: number,
+    reason: string,
+  ) => {
+    reasonFetcher.submit(
+      { votingReason: reason },
+      {
+        action: `/api/annotations/${run._id}/${session.sessionId}/${utteranceId}/${annotationIndex}`,
+        method: "post",
+        encType: "application/json",
+      },
+    );
+  };
+
   const isVoting = fetcher.state !== "idle";
+  const isSavingReason = reasonFetcher.state !== "idle";
 
   useEffect(() => {
     if (selectedUtteranceId) {
@@ -141,6 +159,8 @@ export default function SessionViewerContainer({
       onJumpToFirstAnnotation={onJumpToFirstAnnotation}
       onDownVoteClicked={onDownVoteClicked}
       onUpVoteClicked={onUpVoteClicked}
+      onSaveVotingReason={onSaveVotingReason}
+      isSavingReason={isSavingReason}
     />
   );
 }

--- a/app/modules/sessions/sessions.types.ts
+++ b/app/modules/sessions/sessions.types.ts
@@ -38,4 +38,6 @@ export interface Utterance {
 export interface Annotation {
   _id: string;
   identifiedBy: string;
+  markedAs?: "UP_VOTED" | "DOWN_VOTED";
+  votingReason?: string;
 }


### PR DESCRIPTION
## Summary
- When a researcher up/down votes an annotation, a textarea appears below the vote buttons to enter a reason for their decision
- The reason is saved independently from the vote via a separate API call to the same endpoint
- Changing or removing a vote clears the reason (both server-side and in the UI)
- The `votingReason` field is automatically included in CSV and JSON exports
- Extracted `updateAnnotationVote` helper in the API route to consolidate vote/reason mutation logic
- Hidden `markedAs` and `votingReason` from the annotation key-value display since they have dedicated UI