### PR TITLE
Store session_id at top level of transcript JSON

### DIFF
--- a/app/functions/outputRunDataToCSV/app.ts
+++ b/app/functions/outputRunDataToCSV/app.ts
@@ -63,7 +63,7 @@ export const handler = async (event: {
 
       const sessionObject: { _id: any; [key: string]: any } = {
         _id: session.sessionId,
-        session_id: json.transcript[0]?.session_id,
+        session_id: json.session_id || json.transcript[0]?.session_id,
       };
 
       if (json.annotations) {

--- a/app/functions/outputRunDataToJSON/app.ts
+++ b/app/functions/outputRunDataToJSON/app.ts
@@ -28,6 +28,7 @@ export const handler = async (event: {
       const json = await fse.readJSON(downloadedPath);
 
       json._id = session.sessionId;
+      json.session_id = json.session_id || json.transcript[0]?.session_id;
       sessionsArray.push(json);
     }
 

--- a/app/functions/outputRunSetDataToCSV/app.ts
+++ b/app/functions/outputRunSetDataToCSV/app.ts
@@ -60,7 +60,7 @@ export const handler = async (event: {
 
         sessionsArray.push({
           _id: session.sessionId,
-          session_id: json.transcript[0]?.session_id,
+          session_id: json.session_id || json.transcript[0]?.session_id,
         });
       }
 

--- a/app/functions/outputRunSetDataToJSON/app.ts
+++ b/app/functions/outputRunSetDataToJSON/app.ts
@@ -38,6 +38,7 @@ export const handler = async (event: {
       if (isBaseRun) {
         const sessionObject: any = {
           _id: session.sessionId,
+          session_id: json.session_id || json.transcript[0]?.session_id,
           transcript: map(json.transcript, (utterance) => {
             const cleanUtterance = { ...utterance };
             delete cleanUtterance.annotations;

--- a/workers/tasks/convertFileToSession.ts
+++ b/workers/tasks/convertFileToSession.ts
@@ -52,6 +52,7 @@ export default async function convertFileToSession(job: any) {
         };
       });
       const json = {
+        session_id: jsonFile[0]?.session_id,
         transcript,
         leadRole: attributesMapping.leadRole,
         annotations: [],


### PR DESCRIPTION
## Summary
- During file upload/conversion, stores `session_id` at the top level of the transcript JSON (alongside `transcript`, `leadRole`, `annotations`)
- Exports now read `json.session_id` with fallback to `json.transcript[0]?.session_id` for backward compatibility with existing sessions

Fixes #1448