### PR TITLE
Show progress bar immediately for queued and running runs

### DIFF
--- a/app/modules/runSets/components/runSetDetail.tsx
+++ b/app/modules/runSets/components/runSetDetail.tsx
@@ -59,7 +59,7 @@ export default function RunSetDetail({
     completedRuns: number;
     totalSessions: number;
     completedSessions: number;
-    running: number;
+    processing: number;
     startedAt: string | null;
   };
   onExportRunSetButtonClicked: ({ exportType }: { exportType: string }) => void;
@@ -145,7 +145,7 @@ export default function RunSetDetail({
           </div>
         </PageHeaderRight>
       </PageHeader>
-      {annotationProgress.running > 0 &&
+      {annotationProgress.processing > 0 &&
         annotationProgress.completedSessions <
           annotationProgress.totalSessions && (
           <div className="relative mb-6">

--- a/app/modules/runSets/containers/runSetDetail.route.tsx
+++ b/app/modules/runSets/containers/runSetDetail.route.tsx
@@ -54,7 +54,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     completedRuns: 0,
     totalSessions: 0,
     completedSessions: 0,
-    running: 0,
+    processing: 0,
     startedAt: null as string | null,
   };
 

--- a/app/modules/runs/services/__tests__/aggregateProgress.test.ts
+++ b/app/modules/runs/services/__tests__/aggregateProgress.test.ts
@@ -29,7 +29,7 @@ describe("aggregateProgress", () => {
       completedRuns: 0,
       totalSessions: 0,
       completedSessions: 0,
-      running: 0,
+      processing: 0,
       startedAt: null,
     });
   });
@@ -65,7 +65,7 @@ describe("aggregateProgress", () => {
     expect(result.totalSessions).toBe(4);
   });
 
-  it("counts completed and running runs", async () => {
+  it("counts completed and processing runs", async () => {
     const run1 = await createTestRun({
       name: "Complete",
       project: projectId as any,
@@ -91,7 +91,7 @@ describe("aggregateProgress", () => {
     const result = await aggregateProgress([run1._id, run2._id, run3._id]);
 
     expect(result.completedRuns).toBe(1);
-    expect(result.running).toBe(1);
+    expect(result.processing).toBe(2);
   });
 
   it("returns the earliest startedAt", async () => {

--- a/app/modules/runs/services/aggregateProgress.server.ts
+++ b/app/modules/runs/services/aggregateProgress.server.ts
@@ -7,7 +7,7 @@ export interface AggregateProgressResult {
   completedRuns: number;
   totalSessions: number;
   completedSessions: number;
-  running: number;
+  processing: number;
   startedAt: string | null;
 }
 
@@ -26,8 +26,24 @@ export default async function aggregateProgress(
           completedRuns: {
             $sum: { $cond: ["$isComplete", 1, 0] },
           },
-          running: {
-            $sum: { $cond: ["$isRunning", 1, 0] },
+          processing: {
+            $sum: {
+              $cond: [
+                {
+                  $and: [
+                    { $eq: ["$isComplete", false] },
+                    {
+                      $or: [
+                        { $eq: [{ $type: "$stoppedAt" }, "missing"] },
+                        { $eq: ["$stoppedAt", null] },
+                      ],
+                    },
+                  ],
+                },
+                1,
+                0,
+              ],
+            },
           },
           totalSessions: {
             $sum: { $size: "$sessions" },
@@ -63,7 +79,7 @@ export default async function aggregateProgress(
     completedRuns: progress?.completedRuns ?? 0,
     totalSessions: progress?.totalSessions ?? 0,
     completedSessions: progress?.completedSessions ?? 0,
-    running: progress?.running ?? 0,
+    processing: progress?.processing ?? 0,
     startedAt: earliest ? String(earliest.startedAt) : null,
   };
 }


### PR DESCRIPTION
## Summary
- The progress bar on the run set detail page only appeared once the worker set `isRunning: true`, causing a visible delay after starting runs
- Renamed `running` to `processing` in the aggregation and widened the count to include any run that is not complete and not stopped (covers both queued and actively running)

Fixes #1637