### PR TITLE
Fix broken navigation after creating prompt from teams page

### DIFF
--- a/app/modules/teams/__tests__/teamPrompts.route.test.ts
+++ b/app/modules/teams/__tests__/teamPrompts.route.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { TeamService } from "~/modules/teams/team";
+import { UserService } from "~/modules/users/user";
+import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import loginUser from "../../../../test/helpers/loginUser";
+import { action } from "../containers/teamPrompts.route";
+
+describe("teamPrompts.route", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  describe("action - CREATE_PROMPT", () => {
+    it("returns created prompt nested under data key", async () => {
+      const team = await TeamService.create({ name: "test-team" });
+
+      const user = await UserService.create({
+        username: "admin",
+        role: "SUPER_ADMIN",
+        githubId: 1,
+        teams: [{ team: team._id, role: "ADMIN" }],
+      });
+
+      const cookieHeader = await loginUser(user._id);
+
+      const body = JSON.stringify({
+        intent: "CREATE_PROMPT",
+        payload: { name: "My Prompt", annotationType: "PER_UTTERANCE" },
+      });
+
+      const result = (await action({
+        request: new Request("http://localhost/", {
+          method: "POST",
+          headers: { cookie: cookieHeader },
+          body,
+        }),
+        params: { id: team._id },
+        unstable_pattern: "",
+        context: {},
+      } as any)) as any;
+
+      expect(result.intent).toBe("CREATE_PROMPT");
+      expect(result.data).toBeDefined();
+      expect(result.data._id).toBeDefined();
+      expect(result.data.productionVersion).toBe(1);
+    });
+  });
+});

--- a/app/modules/teams/containers/teamPrompts.route.tsx
+++ b/app/modules/teams/containers/teamPrompts.route.tsx
@@ -117,7 +117,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
     return {
       intent: "CREATE_PROMPT",
-      ...prompt,
+      data: prompt,
     };
   }
 


### PR DESCRIPTION
The action was spreading prompt properties at the top level, but the useEffect expected them nested under a `data` key, causing navigation to `/prompts/undefined/undefined`.

Fixes #1653