### PR TITLE
Add stop all runs button to run set detail page

### DIFF
--- a/app/modules/runSets/__tests__/runSetDetail.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetDetail.route.test.ts
@@ -2,6 +2,7 @@ import { Types } from "mongoose";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ProjectService } from "~/modules/projects/project";
 import type { Project } from "~/modules/projects/projects.types";
+import { RunService } from "~/modules/runs/run";
 import type { Run } from "~/modules/runs/runs.types";
 import { RunSetService } from "~/modules/runSets/runSet";
 import type { RunSet } from "~/modules/runSets/runSets.types";
@@ -14,7 +15,7 @@ import type { User } from "~/modules/users/users.types";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
 import loginUser from "../../../../test/helpers/loginUser";
-import { loader } from "../containers/runSetDetail.route";
+import { action, loader } from "../containers/runSetDetail.route";
 
 type LoaderResult = {
   runSet: RunSet;
@@ -207,5 +208,92 @@ describe("runSetDetail.route loader", () => {
     expect(data.runSet).toHaveProperty("project");
     expect(data.runSet).toHaveProperty("sessions");
     expect(data.runSet).toHaveProperty("runs");
+  });
+});
+
+describe("runSetDetail.route action", () => {
+  let user: User;
+  let team: Team;
+  let project: Project;
+  let runSet: RunSet;
+  let cookieHeader: string;
+
+  beforeEach(async () => {
+    await clearDocumentDB();
+
+    user = await UserService.create({
+      username: "test_user",
+      teams: [],
+    });
+    team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+
+    cookieHeader = await loginUser(user._id);
+  });
+
+  it("stops all active runs in a run set", async () => {
+    const activeRun1 = await createTestRun({
+      name: "Active Run 1",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      isRunning: true,
+      isComplete: false,
+    });
+    const activeRun2 = await createTestRun({
+      name: "Active Run 2",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      isRunning: false,
+      isComplete: false,
+    });
+    const completedRun = await createTestRun({
+      name: "Completed Run",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      isRunning: false,
+      isComplete: true,
+    });
+
+    runSet = await RunSetService.create({
+      name: "Test Run Set",
+      project: project._id,
+      sessions: [],
+      runs: [activeRun1._id, activeRun2._id, completedRun._id],
+      annotationType: "PER_UTTERANCE",
+    });
+
+    const res = await action({
+      request: new Request("http://localhost/", {
+        method: "POST",
+        headers: {
+          cookie: cookieHeader,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ intent: "STOP_ALL_RUNS", payload: {} }),
+      }),
+      params: { projectId: project._id, runSetId: runSet._id },
+      unstable_pattern: "",
+      context: {},
+    } as any);
+
+    expect(res).toEqual({ intent: "STOP_ALL_RUNS" });
+
+    const run1 = await RunService.findById(activeRun1._id);
+    expect(run1!.stoppedAt).not.toBeNull();
+    expect(run1!.isRunning).toBe(false);
+
+    const run2 = await RunService.findById(activeRun2._id);
+    expect(run2!.stoppedAt).not.toBeNull();
+
+    const completedRunAfter = await RunService.findById(completedRun._id);
+    expect(completedRunAfter!.stoppedAt).toBeUndefined();
+    expect(completedRunAfter!.isComplete).toBe(true);
   });
 });

--- a/app/modules/runSets/components/runSetDetail.tsx
+++ b/app/modules/runSets/components/runSetDetail.tsx
@@ -19,6 +19,7 @@ import {
   FileInput,
   GitMerge,
   MoreHorizontal,
+  OctagonX,
   Pencil,
   Plus,
   Trash2,
@@ -38,6 +39,7 @@ export default function RunSetDetail({
   project,
   breadcrumbs,
   annotationProgress,
+  onStopAllRunsClicked,
   onExportRunSetButtonClicked,
   onAddRunsClicked,
   onUploadHumanAnnotationsClicked,
@@ -62,6 +64,7 @@ export default function RunSetDetail({
     processing: number;
     startedAt: string | null;
   };
+  onStopAllRunsClicked: () => void;
   onExportRunSetButtonClicked: ({ exportType }: { exportType: string }) => void;
   onAddRunsClicked: () => void;
   onUploadHumanAnnotationsClicked: () => void;
@@ -148,8 +151,25 @@ export default function RunSetDetail({
       {annotationProgress.processing > 0 &&
         annotationProgress.completedSessions <
           annotationProgress.totalSessions && (
-          <div className="relative mb-6">
-            <div className="absolute top-3 right-0 text-xs opacity-40">
+          <div className="mb-6">
+            <div className="mb-1 flex justify-end">
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={onStopAllRunsClicked}
+              >
+                <OctagonX className="mr-1 h-4 w-4" />
+                Stop all runs
+              </Button>
+            </div>
+            <Progress
+              value={
+                (annotationProgress.completedSessions /
+                  annotationProgress.totalSessions) *
+                100
+              }
+            />
+            <div className="mt-1 text-right text-xs opacity-40">
               {annotationProgress.completedSessions === 0 ? (
                 "Starting..."
               ) : (
@@ -169,13 +189,6 @@ export default function RunSetDetail({
                 </>
               )}
             </div>
-            <Progress
-              value={
-                (annotationProgress.completedSessions /
-                  annotationProgress.totalSessions) *
-                100
-              }
-            />
           </div>
         )}
       <Flag flag="HAS_EVALUATIONS">

--- a/app/modules/runSets/components/stopRunSetDialog.tsx
+++ b/app/modules/runSets/components/stopRunSetDialog.tsx
@@ -1,0 +1,45 @@
+import { Button } from "@/components/ui/button";
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const StopRunSetDialog = ({
+  onStopRunSetClicked,
+}: {
+  onStopRunSetClicked: () => void;
+}) => {
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Stop all runs</DialogTitle>
+        <DialogDescription>
+          All active runs in this run set will be stopped. Sessions currently
+          being annotated will finish, but remaining sessions will be skipped.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter className="justify-end">
+        <DialogClose asChild>
+          <Button type="button" variant="secondary">
+            Cancel
+          </Button>
+        </DialogClose>
+        <DialogClose asChild>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onStopRunSetClicked}
+          >
+            Stop all runs
+          </Button>
+        </DialogClose>
+      </DialogFooter>
+    </DialogContent>
+  );
+};
+
+export default StopRunSetDialog;

--- a/app/modules/runSets/containers/runSetDetail.route.tsx
+++ b/app/modules/runSets/containers/runSetDetail.route.tsx
@@ -22,6 +22,7 @@ import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
 import RunSetDetail from "~/modules/runSets/components/runSetDetail";
+import StopRunSetDialog from "~/modules/runSets/components/stopRunSetDialog";
 import exportRunSet from "~/modules/runSets/helpers/exportRunSet";
 import { useRunSetActions } from "~/modules/runSets/hooks/useRunSetActions";
 import { RunSetService } from "~/modules/runSets/runSet";
@@ -100,6 +101,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   const { intent, payload = {} } = await request.json();
 
   switch (intent) {
+    case "STOP_ALL_RUNS": {
+      const runSet = await RunSetService.findById(params.runSetId);
+      if (!runSet) throw new Error("Run set not found");
+      await RunSetService.stopAllRuns(runSet._id);
+      return { intent: "STOP_ALL_RUNS" };
+    }
     case "EXPORT_RUN_SET": {
       const runSet = await RunSetService.findById(params.runSetId);
       if (!runSet) throw new Error("Run set not found");
@@ -186,6 +193,17 @@ export default function RunSetDetailRoute() {
         onDownloadClicked={submitDownload}
       />,
     );
+  };
+
+  const submitStopAllRuns = () => {
+    submit(JSON.stringify({ intent: "STOP_ALL_RUNS", payload: {} }), {
+      method: "POST",
+      encType: "application/json",
+    });
+  };
+
+  const openStopRunSetDialog = () => {
+    addDialog(<StopRunSetDialog onStopRunSetClicked={submitStopAllRuns} />);
   };
 
   const onExportRunSetButtonClicked = ({
@@ -299,6 +317,7 @@ export default function RunSetDetailRoute() {
       project={project}
       breadcrumbs={breadcrumbs}
       annotationProgress={annotationProgress}
+      onStopAllRunsClicked={openStopRunSetDialog}
       onExportRunSetButtonClicked={onExportRunSetButtonClicked}
       onAddRunsClicked={() =>
         navigate(`/projects/${project._id}/run-sets/${runSet._id}/add-runs`)

--- a/app/modules/runSets/runSet.ts
+++ b/app/modules/runSets/runSet.ts
@@ -13,6 +13,7 @@ import findEligibleRunSetsForRunService from "./services/findEligibleRunSetsForR
 import findEligibleRunsService from "./services/findEligibleRuns.server";
 import findMergeableRunSetsService from "./services/findMergeableRunSets.server";
 import mergeRunSetsService from "./services/mergeRunSets.server";
+import stopAllRunsService from "./services/stopAllRuns.server";
 
 const RunSetModel =
   mongoose.models.RunSet || mongoose.model("RunSet", runSetSchema);
@@ -203,5 +204,9 @@ export class RunSetService {
     shouldRunVerification?: boolean;
   }) {
     return createRunsForRunSetService(payload);
+  }
+
+  static async stopAllRuns(runSetId: string): Promise<number> {
+    return stopAllRunsService(runSetId);
   }
 }

--- a/app/modules/runSets/services/stopAllRuns.server.ts
+++ b/app/modules/runSets/services/stopAllRuns.server.ts
@@ -1,0 +1,22 @@
+import { RunService } from "~/modules/runs/run";
+import { RunSetService } from "~/modules/runSets/runSet";
+
+export default async function stopAllRuns(runSetId: string): Promise<number> {
+  const runSet = await RunSetService.findById(runSetId);
+  if (!runSet) throw new Error("Run set not found");
+
+  const runIds = runSet.runs ?? [];
+  if (runIds.length === 0) return 0;
+
+  const activeRuns = await RunService.find({
+    match: {
+      _id: { $in: runIds },
+      isComplete: false,
+      stoppedAt: null,
+    },
+  });
+
+  await Promise.all(activeRuns.map((run) => RunService.stop(run._id)));
+
+  return activeRuns.length;
+}

--- a/workers/tasks/startAnnotateRun.ts
+++ b/workers/tasks/startAnnotateRun.ts
@@ -9,17 +9,23 @@ export default async function startAnnotateRun(job: Job) {
     throw new Error("startAnnotateRun: runId is required");
   }
 
-  const result = await RunService.updateById(runId, {
+  const run = await RunService.findById(runId);
+  if (!run) {
+    throw new Error(`startAnnotateRun: Run not found: ${runId}`);
+  }
+
+  if (run.stoppedAt) {
+    await emitFromJob(job, { runId }, "FINISHED");
+    return { status: "STOPPED" };
+  }
+
+  await RunService.updateById(runId, {
     isRunning: true,
     isComplete: false,
     hasErrored: false,
     stoppedAt: null,
     startedAt: new Date(),
   });
-
-  if (!result) {
-    throw new Error(`startAnnotateRun: Run not found: ${runId}`);
-  }
 
   await emitFromJob(job, { runId }, "FINISHED");
 


### PR DESCRIPTION
Adds a destructive "Stop all runs" button next to the progress bar on the run set detail page. Clicking it opens a confirmation dialog, then stops all active (non-complete, non-stopped) runs in the set.

Also fixes a bug where the startAnnotateRun worker would clear stoppedAt on queued runs, causing stopped runs to restart and the progress bar to reappear.

Fixes #1709