### PR TITLE
Remove privacy policy link from login page

### DIFF
--- a/app/modules/authentication/components/login.tsx
+++ b/app/modules/authentication/components/login.tsx
@@ -8,7 +8,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { AlertCircle, ExternalLink } from "lucide-react";
-import { Link } from "react-router";
 
 export default function Login({
   errorTitle,
@@ -108,14 +107,6 @@ export default function Login({
           </Button>
         </CardFooter>
       </Card>
-      <div className="mt-4">
-        <Link
-          to="/privacy-policy"
-          className="text-muted-foreground text-xs hover:underline"
-        >
-          Privacy Policy
-        </Link>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
Already accessible from the help & support section in the sidebar.

Fixes #1703