### PR TITLE
Show partial failures as yellow instead of red

### DIFF
--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -212,7 +212,16 @@ export default function RunDetail({
             </AlertDescription>
           </Alert>
         )}
-        {run.isComplete && run.hasErrored && (
+        {runStatus === "FAILED" && (
+          <Alert>
+            <TriangleAlert className="h-4 w-4" />
+            <AlertTitle>All sessions failed</AlertTitle>
+            <AlertDescription>
+              This run failed during annotation.
+            </AlertDescription>
+          </Alert>
+        )}
+        {runStatus === "PARTIAL_FAILURE" && (
           <Alert>
             <TriangleAlert className="h-4 w-4" />
             <AlertTitle>

--- a/app/modules/runs/helpers/__tests__/statusMeta.test.ts
+++ b/app/modules/runs/helpers/__tests__/statusMeta.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, it } from "vitest";
 import type { Run } from "../../runs.types";
 import { getRunStatusKey } from "../statusMeta";
 
-const base: Pick<Run, "isRunning" | "isComplete" | "hasErrored" | "stoppedAt"> =
-  {
-    isRunning: false,
-    isComplete: false,
-    hasErrored: false,
-    stoppedAt: null,
-  };
+const base: Pick<
+  Run,
+  "isRunning" | "isComplete" | "hasErrored" | "stoppedAt" | "sessions"
+> = {
+  isRunning: false,
+  isComplete: false,
+  hasErrored: false,
+  stoppedAt: null,
+  sessions: [],
+};
+
+const erroredSession = { status: "ERRORED" as const };
+const doneSession = { status: "DONE" as const };
 
 describe("getRunStatusKey", () => {
   it("returns QUEUED when no flags are set", () => {
@@ -27,10 +33,24 @@ describe("getRunStatusKey", () => {
     );
   });
 
-  it("returns FAILED when hasErrored is true", () => {
-    expect(getRunStatusKey({ ...base, hasErrored: true } as Run)).toBe(
-      "FAILED",
-    );
+  it("returns FAILED when all sessions errored", () => {
+    expect(
+      getRunStatusKey({
+        ...base,
+        hasErrored: true,
+        sessions: [erroredSession, erroredSession],
+      } as Run),
+    ).toBe("FAILED");
+  });
+
+  it("returns PARTIAL_FAILURE when some sessions errored", () => {
+    expect(
+      getRunStatusKey({
+        ...base,
+        hasErrored: true,
+        sessions: [erroredSession, doneSession],
+      } as Run),
+    ).toBe("PARTIAL_FAILURE");
   });
 
   it("returns STOPPED when stoppedAt is set", () => {

--- a/app/modules/runs/helpers/buildRunStatusMatch.ts
+++ b/app/modules/runs/helpers/buildRunStatusMatch.ts
@@ -4,6 +4,7 @@ const STATUS_MATCH: Record<StatusKey, Record<string, any>> = {
   RUNNING: { isRunning: true },
   STOPPED: { stoppedAt: { $exists: true } },
   FAILED: { hasErrored: true },
+  PARTIAL_FAILURE: { hasErrored: true },
   COMPLETE: { isComplete: true, hasErrored: false },
   QUEUED: {
     isRunning: false,

--- a/app/modules/runs/helpers/getRunsItemAttributes.tsx
+++ b/app/modules/runs/helpers/getRunsItemAttributes.tsx
@@ -17,18 +17,17 @@ interface Options {
 export default function getRunsItemAttributes(item: Run, options?: Options) {
   const promptName = get(item, "snapshot.prompt.name", "");
 
-  let statusMeta = STATUS_META[getRunStatusKey(item)];
+  const statusKey = getRunStatusKey(item);
+  let statusMeta = STATUS_META[statusKey];
 
-  if (item.isComplete && item.hasErrored) {
+  if (statusKey === "PARTIAL_FAILURE") {
     const failedCount = item.sessions.filter(
       (s) => s.status === "ERRORED",
     ).length;
-    if (failedCount > 0) {
-      statusMeta = {
-        ...statusMeta,
-        text: `${statusMeta.text} - ${failedCount} session${failedCount === 1 ? "" : "s"} failed`,
-      };
-    }
+    statusMeta = {
+      ...statusMeta,
+      text: `${failedCount} session${failedCount === 1 ? "" : "s"} failed`,
+    };
   }
 
   const meta = [

--- a/app/modules/runs/helpers/statusMeta.tsx
+++ b/app/modules/runs/helpers/statusMeta.tsx
@@ -4,6 +4,7 @@ import {
   Clock,
   LoaderCircle,
   OctagonX,
+  TriangleAlert,
 } from "lucide-react";
 import type { ReactElement } from "react";
 import type { Run, RunSession } from "~/modules/runs/runs.types";
@@ -11,6 +12,7 @@ import type { Run, RunSession } from "~/modules/runs/runs.types";
 export type StatusKey =
   | "RUNNING"
   | "FAILED"
+  | "PARTIAL_FAILURE"
   | "COMPLETE"
   | "QUEUED"
   | "STOPPED";
@@ -26,6 +28,10 @@ export const STATUS_META: Record<
   FAILED: {
     icon: <CircleX className="text-destructive" />,
     text: "Failed",
+  },
+  PARTIAL_FAILURE: {
+    icon: <TriangleAlert className="text-amber-500" />,
+    text: "Partial failure",
   },
   COMPLETE: {
     icon: <CircleCheck className="text-sandpiper-success" />,
@@ -44,7 +50,10 @@ export const STATUS_META: Record<
 export function getRunStatusKey(run: Run): StatusKey {
   if (run.isRunning) return "RUNNING";
   if (run.stoppedAt) return "STOPPED";
-  if (run.hasErrored) return "FAILED";
+  if (run.hasErrored) {
+    const allFailed = run.sessions.every((s) => s.status === "ERRORED");
+    return allFailed ? "FAILED" : "PARTIAL_FAILURE";
+  }
   if (run.isComplete) return "COMPLETE";
   return "QUEUED";
 }


### PR DESCRIPTION
When only some sessions fail, show "X sessions failed" with a yellow warning icon instead of marking the entire run as "Failed" in red. Only runs where every session errored display as fully "Failed".

Fixes #1702