### PR TITLE
Stabilize in-progress time estimate display

### DIFF
--- a/app/modules/runs/helpers/__tests__/formatTimeRemaining.test.ts
+++ b/app/modules/runs/helpers/__tests__/formatTimeRemaining.test.ts
@@ -6,8 +6,10 @@ describe("formatTimeRemaining", () => {
     expect(formatTimeRemaining(null, 1, 5)).toBeNull();
   });
 
-  it("returns null when completed is less than 1", () => {
+  it("returns null when fewer than 3 sessions completed", () => {
     expect(formatTimeRemaining("2026-01-01T00:00:00.000Z", 0, 5)).toBeNull();
+    expect(formatTimeRemaining("2026-01-01T00:00:00.000Z", 1, 5)).toBeNull();
+    expect(formatTimeRemaining("2026-01-01T00:00:00.000Z", 2, 5)).toBeNull();
   });
 
   it("returns null when completed is greater than or equal to total", () => {
@@ -19,7 +21,7 @@ describe("formatTimeRemaining", () => {
     vi.setSystemTime(new Date("2026-01-01T00:01:40.000Z"));
 
     expect(formatTimeRemaining("2026-01-01T00:00:00.000Z", 3, 9)).toBe(
-      "~3 min remaining",
+      "~4 min remaining",
     );
 
     vi.useRealTimers();

--- a/app/modules/runs/helpers/formatTimeRemaining.ts
+++ b/app/modules/runs/helpers/formatTimeRemaining.ts
@@ -3,7 +3,13 @@ export default function formatTimeRemaining(
   completed: number,
   total: number,
 ): string | null {
-  if (!startedAt || completed < 1 || completed >= total) return null;
+  const MIN_COMPLETED_FOR_ESTIMATE = 3;
+  if (
+    !startedAt ||
+    completed < MIN_COMPLETED_FOR_ESTIMATE ||
+    completed >= total
+  )
+    return null;
 
   const elapsedMs = Date.now() - new Date(startedAt).getTime();
   if (elapsedMs <= 0) return null;
@@ -15,7 +21,7 @@ export default function formatTimeRemaining(
   if (remainingSeconds < 60) return "< 1 min remaining";
 
   const hours = Math.floor(remainingSeconds / 3600);
-  const minutes = Math.round((remainingSeconds % 3600) / 60);
+  const minutes = Math.ceil((remainingSeconds % 3600) / 60);
 
   if (hours === 0) return `~${minutes} min remaining`;
   if (minutes === 0) return `~${hours} hr remaining`;


### PR DESCRIPTION
Wait for 3 completed sessions before showing time remaining to avoid wild early estimates. Round minutes up (ceil) so the run tends to finish before the displayed estimate.

Fixes #1685