### PR TITLE
Fix spend analytics charts rendering in Safari

### DIFF
--- a/app/modules/teams/components/spendAnalytics.tsx
+++ b/app/modules/teams/components/spendAnalytics.tsx
@@ -61,7 +61,7 @@ function SpendByModelChart({ data }: { data: CostByModel[] }) {
   if (data.length === 0) return <EmptyState />;
 
   return (
-    <ChartContainer config={costChartConfig} className="max-h-72 w-full">
+    <ChartContainer config={costChartConfig} className="h-72 w-full">
       <BarChart data={data} layout="vertical" margin={{ left: 20 }}>
         <CartesianGrid horizontal={false} />
         <YAxis
@@ -115,7 +115,7 @@ function SpendBySourceChart({
   if (data.length === 0) return <EmptyState />;
 
   return (
-    <ChartContainer config={costChartConfig} className="max-h-72 w-full">
+    <ChartContainer config={costChartConfig} className="h-72 w-full">
       <BarChart data={data} layout="vertical" margin={{ left: 20 }}>
         <CartesianGrid horizontal={false} />
         <YAxis
@@ -165,7 +165,7 @@ function SpendOverTimeChart({
           </SelectContent>
         </Select>
       </div>
-      <ChartContainer config={costChartConfig} className="max-h-72 w-full">
+      <ChartContainer config={costChartConfig} className="h-72 w-full">
         <BarChart data={data}>
           <CartesianGrid vertical={false} />
           <XAxis


### PR DESCRIPTION
Replace max-h-72 with h-72 on ChartContainer so Safari can resolve an explicit height without relying on aspect-ratio, which it fails to compute on flex children constrained only by max-height.

Fixes #1789