### PR TITLE
Update deprecated GHA actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ecs_build_image.yml
+++ b/.github/workflows/ecs_build_image.yml
@@ -68,10 +68,10 @@ jobs:
       image: ${{ steps.image.outputs.image }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.0.0
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1


### PR DESCRIPTION
- actions/checkout: v4 → v5
- aws-actions/configure-aws-credentials: v4 → v6.0.0