### PR TITLE
Add handleError export to capture server exceptions in SigNoz

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -8,6 +8,7 @@ import { renderToPipeableStream } from "react-dom/server";
 import type {
   AppLoadContext,
   EntryContext,
+  HandleErrorFunction,
   unstable_ServerInstrumentation,
 } from "react-router";
 import { ServerRouter } from "react-router";
@@ -63,6 +64,17 @@ const otelServerInstrumentation: unstable_ServerInstrumentation = {
 };
 
 export const unstable_instrumentations = [otelServerInstrumentation];
+
+export const handleError: HandleErrorFunction = (error, { request }) => {
+  if (!request.signal.aborted) {
+    console.error(error);
+    const span = trace.getActiveSpan();
+    if (span) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+    }
+  }
+};
 
 const setupQueues = async () => {
   createQueue("tasks");


### PR DESCRIPTION
Fixes #1798

Exports `handleError` from `entry.server.tsx` — React Router's centralized hook for all caught errors. Records each exception on the active OTel span so it appears in SigNoz alongside the request trace.

Requires `OTEL_ENABLED=true` and `OTEL_EXPORTER_OTLP_ENDPOINT` to be set in the environment.