### PR TITLE
Implement immutable billing period history

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -13,7 +13,7 @@ import type {
 } from "react-router";
 import { ServerRouter } from "react-router";
 
-import createQueue from "./modules/queues/helpers/createQueue";
+import createQueue, { QUEUES } from "./modules/queues/helpers/createQueue";
 import "./modules/storage/storage";
 
 const tracer = trace.getTracer("react-router");
@@ -79,7 +79,17 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
 const setupQueues = async () => {
   createQueue("tasks");
   createQueue("general");
-  createQueue("cron");
+  await createQueue("cron");
+
+  await QUEUES["cron"].upsertJobScheduler(
+    "billing-close-periods",
+    { pattern: "0 0 1 * *" },
+    {
+      name: "BILLING:CLOSE_PERIODS",
+      data: {},
+      opts: { attempts: 3, backoff: { type: "exponential", delay: 5000 } },
+    },
+  );
 };
 
 setTimeout(() => {

--- a/app/lib/schemas/billingPeriod.schema.ts
+++ b/app/lib/schemas/billingPeriod.schema.ts
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+
+const billingPeriodSchema = new mongoose.Schema({
+  team: { type: mongoose.Types.ObjectId, ref: "Team", required: true },
+  plan: { type: mongoose.Types.ObjectId, ref: "BillingPlan", required: true },
+  markupRate: { type: Number, required: true },
+  startAt: { type: Date, required: true },
+  endAt: { type: Date, required: true },
+  status: { type: String, enum: ["open", "closed"], default: "open" },
+  rawCost: { type: Number },
+  billedAmount: { type: Number },
+  closingBalance: { type: Number },
+  closedAt: { type: Date },
+});
+
+billingPeriodSchema.index({ team: 1, startAt: -1 });
+billingPeriodSchema.index({ team: 1, startAt: 1 }, { unique: true });
+billingPeriodSchema.index({ team: 1, status: 1 });
+
+export default billingPeriodSchema;

--- a/app/lib/schemas/teamBillingPlan.schema.ts
+++ b/app/lib/schemas/teamBillingPlan.schema.ts
@@ -3,9 +3,11 @@ import mongoose from "mongoose";
 const teamBillingPlanSchema = new mongoose.Schema({
   team: { type: mongoose.Types.ObjectId, ref: "Team", required: true },
   plan: { type: mongoose.Types.ObjectId, ref: "BillingPlan", required: true },
+  effectiveFrom: { type: Date, required: true },
   createdAt: { type: Date, default: Date.now },
 });
 
-teamBillingPlanSchema.index({ team: 1 }, { unique: true });
+teamBillingPlanSchema.index({ team: 1, effectiveFrom: -1 });
+teamBillingPlanSchema.index({ team: 1, effectiveFrom: 1 }, { unique: true });
 
 export default teamBillingPlanSchema;

--- a/app/migrations/20260327135814-backfill-billing-plan-effective-from.ts
+++ b/app/migrations/20260327135814-backfill-billing-plan-effective-from.ts
@@ -1,0 +1,57 @@
+import type { Db } from "mongodb";
+import type {
+  MigrationFile,
+  MigrationResult,
+} from "~/modules/migrations/types";
+
+export default {
+  id: "20260327135814-backfill-billing-plan-effective-from",
+  name: "Backfill Billing Plan Effective From",
+  description:
+    "Adds effectiveFrom to existing teamBillingPlan records that predate the billing period system",
+
+  async up(db: Db): Promise<MigrationResult> {
+    const collection = db.collection("teambillingplans");
+    const docs = await collection
+      .find({ effectiveFrom: { $exists: false } })
+      .toArray();
+
+    console.log(
+      `Found ${docs.length} teamBillingPlan records without effectiveFrom`,
+    );
+
+    let migrated = 0;
+    let failed = 0;
+
+    for (const doc of docs) {
+      try {
+        const createdAt =
+          doc.createdAt instanceof Date
+            ? doc.createdAt
+            : new Date(doc.createdAt ?? 0);
+        const effectiveFrom = new Date(
+          Date.UTC(createdAt.getUTCFullYear(), createdAt.getUTCMonth(), 1),
+        );
+
+        await collection.updateOne(
+          { _id: doc._id },
+          { $set: { effectiveFrom } },
+        );
+
+        console.log(
+          `Migrated teamBillingPlan ${doc._id}: effectiveFrom = ${effectiveFrom.toISOString()}`,
+        );
+        migrated++;
+      } catch (err) {
+        console.error(`Failed to migrate teamBillingPlan ${doc._id}:`, err);
+        failed++;
+      }
+    }
+
+    return {
+      success: failed === 0,
+      message: `Backfilled effectiveFrom on ${migrated} teamBillingPlan records${failed > 0 ? `, ${failed} failed` : ""}`,
+      stats: { migrated, failed },
+    };
+  },
+} satisfies MigrationFile;

--- a/app/migrations/20260327150303-drop-team-unique-index-from-team-billing-plan.ts
+++ b/app/migrations/20260327150303-drop-team-unique-index-from-team-billing-plan.ts
@@ -1,0 +1,47 @@
+import type { Db } from "mongodb";
+import type {
+  MigrationFile,
+  MigrationResult,
+} from "~/modules/migrations/types";
+
+export default {
+  id: "20260327150303-drop-team-unique-index-from-team-billing-plan",
+  name: "Drop Team Unique Index From TeamBillingPlan",
+  description:
+    "Drops the legacy single-field unique index on 'team' from teambillingplans, replaced by compound unique index on { team, effectiveFrom }",
+
+  async up(db: Db): Promise<MigrationResult> {
+    const collection = db.collection("teambillingplans");
+
+    const indexes = await collection.indexes();
+    console.log(
+      `Found ${indexes.length} indexes on teambillingplans:`,
+      indexes.map((i) => i.name),
+    );
+
+    const legacyIndex = indexes.find(
+      (i) =>
+        i.name === "team_1" &&
+        i.unique === true &&
+        !("effectiveFrom" in (i.key ?? {})),
+    );
+
+    if (!legacyIndex) {
+      console.log("Legacy team_1 unique index not found — skipping");
+      return {
+        success: true,
+        message: "No legacy index to drop",
+        stats: { migrated: 0, failed: 0 },
+      };
+    }
+
+    await collection.dropIndex("team_1");
+    console.log("Dropped legacy team_1 unique index from teambillingplans");
+
+    return {
+      success: true,
+      message: "Dropped legacy team_1 unique index",
+      stats: { migrated: 1, failed: 0 },
+    };
+  },
+} satisfies MigrationFile;

--- a/app/modules/app/helpers/getMonthYearString.ts
+++ b/app/modules/app/helpers/getMonthYearString.ts
@@ -1,0 +1,10 @@
+export default function getMonthYearString(
+  date: Date | string | null | undefined,
+): string {
+  if (!date) return "--";
+  return new Date(date).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/app/modules/billing/__tests__/billing.test.ts
+++ b/app/modules/billing/__tests__/billing.test.ts
@@ -1,8 +1,10 @@
-import { Types } from "mongoose";
+import mongoose, { Types } from "mongoose";
 import { beforeEach, describe, expect, it } from "vitest";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import makeDate from "../../../../test/helpers/makeDate";
 import { TeamBillingService } from "../billing";
+import { BillingPeriodService } from "../billingPeriod";
 import { BillingPlanService } from "../billingPlan";
 import { TeamBillingPlanService } from "../teamBillingPlan";
 import { TeamCreditService } from "../teamCredit";
@@ -54,60 +56,6 @@ describe("Billing", () => {
       const defaultPlan = await BillingPlanService.findDefault();
       expect(defaultPlan?.name).toBe("Standard");
       expect(defaultPlan?.isDefault).toBe(true);
-    });
-  });
-
-  describe("TeamBillingPlanService", () => {
-    it("assigns a plan to a team", async () => {
-      const plan = await BillingPlanService.create({
-        name: "Standard",
-        markupRate: 1.5,
-        isDefault: true,
-      });
-
-      const assignment = await TeamBillingPlanService.assignPlan(
-        teamId,
-        plan._id,
-      );
-      expect(assignment.team).toBe(teamId);
-      expect(assignment.plan).toBe(plan._id);
-    });
-
-    it("upserts on reassignment", async () => {
-      const plan1 = await BillingPlanService.create({
-        name: "Standard",
-        markupRate: 1.5,
-        isDefault: true,
-      });
-      const plan2 = await BillingPlanService.create({
-        name: "Premium",
-        markupRate: 2.0,
-        isDefault: false,
-      });
-
-      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
-      const updated = await TeamBillingPlanService.assignPlan(
-        teamId,
-        plan2._id,
-      );
-
-      expect(updated.plan).toBe(plan2._id);
-
-      const found = await TeamBillingPlanService.findByTeam(teamId);
-      expect(found?.plan).toBe(plan2._id);
-    });
-
-    it("returns effective plan for team", async () => {
-      const plan = await seedDefaultPlan();
-
-      const effective = await TeamBillingPlanService.getEffectivePlan(teamId);
-      expect(effective?.name).toBe(plan.name);
-      expect(effective?.markupRate).toBe(1.5);
-    });
-
-    it("returns null when no plan assigned", async () => {
-      const effective = await TeamBillingPlanService.getEffectivePlan(teamId);
-      expect(effective).toBeNull();
     });
   });
 
@@ -289,6 +237,260 @@ describe("Billing", () => {
     it("returns null summary when no plan assigned", async () => {
       const summary = await TeamBillingService.getBalanceSummary(teamId);
       expect(summary).toBeNull();
+    });
+  });
+
+  describe("TeamBillingService — period-aware balance", () => {
+    async function seedPlanBackdated(markupRate = 1.5) {
+      const plan = await BillingPlanService.create({
+        name: "Standard",
+        markupRate,
+        isDefault: true,
+      });
+      const TeamBillingPlanModel = mongoose.model("TeamBillingPlan");
+      await TeamBillingPlanModel.create({
+        team: new Types.ObjectId(teamId),
+        plan: plan._id,
+        effectiveFrom: new Date(0),
+      });
+      return plan;
+    }
+
+    async function insertCredit(amount: number, createdAt: Date) {
+      const TeamCreditModel = mongoose.model("TeamCredit");
+      await TeamCreditModel.create({
+        team: new Types.ObjectId(teamId),
+        amount,
+        addedBy: new Types.ObjectId(userId),
+        createdAt,
+      });
+    }
+
+    async function insertCost(cost: number, createdAt: Date) {
+      const LlmCostModel = mongoose.model("LlmCost");
+      await LlmCostModel.create({
+        team: new Types.ObjectId(teamId),
+        model: "claude-opus",
+        source: "annotation:per-session",
+        inputTokens: 100,
+        outputTokens: 50,
+        cost,
+        providerCost: cost * 0.8,
+        createdAt,
+      });
+    }
+
+    it("no closed periods: falls back to all-time aggregation (same as original)", async () => {
+      await seedPlanBackdated(1.5);
+
+      await TeamCreditService.create({
+        team: teamId,
+        amount: 100,
+        addedBy: userId,
+      });
+      await LlmCostService.create({
+        team: teamId,
+        model: "claude-opus",
+        source: "annotation:per-session",
+        inputTokens: 100,
+        outputTokens: 50,
+        cost: 10,
+        providerCost: 8,
+      });
+
+      // balance = 100 - (10 * 1.5) = 85
+      const balance = await TeamBillingService.getBalance(teamId);
+      expect(balance).toBe(85);
+    });
+
+    it("one closed period with no new activity: balance equals closingBalance", async () => {
+      await seedPlanBackdated(1.5);
+
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await insertCost(10, makeDate(2025, 1, 20));
+      await BillingPeriodService.closePeriod(period);
+
+      const balance = await TeamBillingService.getBalance(teamId);
+      // closingBalance = 100 - (10 * 1.5) = 85
+      expect(balance).toBe(85);
+    });
+
+    it("one closed period + new credit added after endAt", async () => {
+      await seedPlanBackdated(1.5);
+
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await BillingPeriodService.closePeriod(period);
+
+      // Credit added after period closed (Feb 2025)
+      await insertCredit(50, makeDate(2025, 2, 10));
+
+      const balance = await TeamBillingService.getBalance(teamId);
+      // 100 (closingBalance) + 50 (new credit) = 150
+      expect(balance).toBe(150);
+    });
+
+    it("one closed period + new cost after endAt", async () => {
+      await seedPlanBackdated(1.5);
+
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await BillingPeriodService.closePeriod(period);
+
+      // Cost in Feb 2025 (after period1 endAt)
+      await insertCost(20, makeDate(2025, 2, 10));
+
+      const balance = await TeamBillingService.getBalance(teamId);
+      // 100 (closingBalance) - (20 * 1.5) = 70
+      expect(balance).toBe(70);
+    });
+
+    it("multiple closed periods: only uses the last closingBalance", async () => {
+      await seedPlanBackdated(1.5);
+
+      const period1 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await insertCost(10, makeDate(2025, 1, 20));
+      await BillingPeriodService.closePeriod(period1);
+
+      const period2 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 2),
+      );
+      await insertCredit(50, makeDate(2025, 2, 15));
+      await BillingPeriodService.closePeriod(period2);
+
+      const balance = await TeamBillingService.getBalance(teamId);
+      // period1.closingBalance = 100 - 15 = 85
+      // period2.closingBalance = 85 + 50 - 0 = 135
+      expect(balance).toBe(135);
+    });
+
+    it("historical costs are billed at the rate locked in their period, not the current rate", async () => {
+      // Jan period: rate 1.5x. Cost $10 → billed $15. Balance = 100 - 15 = 85.
+      const plan1 = await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: true,
+      });
+      const TeamBillingPlanModel = mongoose.model("TeamBillingPlan");
+      await TeamBillingPlanModel.create({
+        team: new Types.ObjectId(teamId),
+        plan: plan1._id,
+        effectiveFrom: new Date(0),
+      });
+
+      const period1 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 10));
+      await insertCost(10, makeDate(2025, 1, 20));
+      await BillingPeriodService.closePeriod(period1);
+
+      // After period 1 close: 100 - (10 * 1.5) = 85
+      expect(await TeamBillingService.getBalance(teamId)).toBe(85);
+
+      // Plan changes to 2.0x from Feb 2025
+      const plan2 = await BillingPlanService.create({
+        name: "Premium",
+        markupRate: 2.0,
+        isDefault: false,
+      });
+      await TeamBillingPlanModel.create({
+        team: new Types.ObjectId(teamId),
+        plan: plan2._id,
+        effectiveFrom: makeDate(2025, 2),
+      });
+
+      // Feb period: rate 2.0x. Cost $5 → billed $10. closingBalance = 85 - 10 = 75.
+      const period2 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 2),
+      );
+      await insertCost(5, makeDate(2025, 2, 10));
+      await BillingPeriodService.closePeriod(period2);
+
+      // Old all-time impl: (10+5) * 2.0 = 30 → balance = 100 - 30 = 70 (WRONG)
+      // Correct period-aware result: 75
+      const balance = await TeamBillingService.getBalance(teamId);
+      expect(balance).toBe(75);
+    });
+
+    it("credits field equals closingBalance plus new credits when a period is closed", async () => {
+      await seedPlanBackdated(1.5);
+
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await insertCost(10, makeDate(2025, 1, 20));
+      await BillingPeriodService.closePeriod(period);
+      // closingBalance = 100 - (10 * 1.5) = 85
+
+      // New credit after period close
+      await insertCredit(40, makeDate(2025, 2, 5));
+
+      const summary = await TeamBillingService.getBalanceSummary(teamId);
+      expect(summary).not.toBeNull();
+      // credits = closingBalance + newCredits = 85 + 40 = 125
+      expect(summary!.credits).toBe(125);
+      expect(summary!.balance).toBe(125);
+    });
+
+    it("plan change after period close: live costs use the new plan rate", async () => {
+      const plan1 = await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: true,
+      });
+      const TeamBillingPlanModel = mongoose.model("TeamBillingPlan");
+      await TeamBillingPlanModel.create({
+        team: new Types.ObjectId(teamId),
+        plan: plan1._id,
+        effectiveFrom: new Date(0),
+      });
+
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await BillingPeriodService.closePeriod(period);
+      // closingBalance = 100
+
+      // New plan with 2x markup, effective Feb 2025
+      const plan2 = await BillingPlanService.create({
+        name: "Premium",
+        markupRate: 2.0,
+        isDefault: false,
+      });
+      await TeamBillingPlanModel.create({
+        team: new Types.ObjectId(teamId),
+        plan: plan2._id,
+        effectiveFrom: makeDate(2025, 2),
+      });
+
+      // Live cost in Feb 2025 (after period1.endAt)
+      await insertCost(10, makeDate(2025, 2, 10));
+
+      const balance = await TeamBillingService.getBalance(teamId);
+      // 100 (closingBalance) - (10 * 2.0) = 80
+      expect(balance).toBe(80);
     });
   });
 });

--- a/app/modules/billing/__tests__/billingPeriod.test.ts
+++ b/app/modules/billing/__tests__/billingPeriod.test.ts
@@ -1,0 +1,513 @@
+import mongoose, { Types } from "mongoose";
+import { beforeEach, describe, expect, it } from "vitest";
+import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import makeDate from "../../../../test/helpers/makeDate";
+import { LlmCostService } from "../../llmCosts/llmCost";
+import { BillingPeriodService } from "../billingPeriod";
+import { BillingPlanService } from "../billingPlan";
+import { TeamBillingPlanService } from "../teamBillingPlan";
+import { TeamCreditService } from "../teamCredit";
+
+describe("BillingPeriodService", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  const teamId = new Types.ObjectId().toString();
+  const otherTeamId = new Types.ObjectId().toString();
+  const userId = new Types.ObjectId().toString();
+
+  async function seedPlan(markupRate = 1.5) {
+    const plan = await BillingPlanService.create({
+      name: "Standard",
+      markupRate,
+      isDefault: true,
+    });
+    // Backdate to epoch so the plan is effective for any historical period
+    const TeamBillingPlanModel = mongoose.model("TeamBillingPlan");
+    await TeamBillingPlanModel.create({
+      team: new Types.ObjectId(teamId),
+      plan: plan._id,
+      effectiveFrom: new Date(0),
+    });
+    return plan;
+  }
+
+  async function insertCredit(amount: number, createdAt: Date) {
+    const TeamCreditModel = mongoose.model("TeamCredit");
+    await TeamCreditModel.create({
+      team: new Types.ObjectId(teamId),
+      amount,
+      addedBy: new Types.ObjectId(userId),
+      createdAt,
+    });
+  }
+
+  async function insertCost(cost: number, createdAt: Date, forTeam = teamId) {
+    const LlmCostModel = mongoose.model("LlmCost");
+    await LlmCostModel.create({
+      team: new Types.ObjectId(forTeam),
+      model: "claude-opus",
+      source: "annotation:per-session",
+      inputTokens: 100,
+      outputTokens: 50,
+      cost,
+      providerCost: cost * 0.8,
+      createdAt,
+    });
+  }
+
+  describe("openPeriod", () => {
+    it("creates an open period with correct startAt and endAt", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 3),
+      );
+
+      expect(period.status).toBe("open");
+      expect(new Date(period.startAt).getTime()).toBe(
+        makeDate(2025, 3, 1).getTime(),
+      );
+      expect(new Date(period.endAt).getTime()).toBe(
+        makeDate(2025, 4, 1).getTime(),
+      );
+    });
+
+    it("normalises startAt to 1st of the month regardless of input day", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 3, 15),
+      );
+
+      expect(new Date(period.startAt).getTime()).toBe(
+        makeDate(2025, 3, 1).getTime(),
+      );
+    });
+
+    it("snapshots the markupRate from the plan at open time", async () => {
+      await seedPlan(2.0);
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 3),
+      );
+
+      expect(period.markupRate).toBe(2.0);
+    });
+
+    it("throws when no plan is assigned to the team", async () => {
+      await expect(
+        BillingPeriodService.openPeriod(teamId, makeDate(2025, 3)),
+      ).rejects.toThrow();
+    });
+
+    it("throws on duplicate open for the same team and month", async () => {
+      await seedPlan();
+      await BillingPeriodService.openPeriod(teamId, makeDate(2025, 3));
+
+      await expect(
+        BillingPeriodService.openPeriod(teamId, makeDate(2025, 3)),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("closePeriod", () => {
+    // For single-period tests that just need credits/costs in range, we open
+    // the CURRENT month so records created with Date.now() are within the window.
+
+    it("locks rawCost, billedAmount, and closingBalance on close", async () => {
+      await seedPlan(1.5);
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+
+      await TeamCreditService.create({
+        team: teamId,
+        amount: 100,
+        addedBy: userId,
+      });
+      await LlmCostService.create({
+        team: teamId,
+        model: "claude-opus",
+        source: "annotation:per-session",
+        inputTokens: 100,
+        outputTokens: 50,
+        cost: 10,
+        providerCost: 8,
+      });
+
+      const closed = await BillingPeriodService.closePeriod(period);
+
+      expect(closed.status).toBe("closed");
+      expect(closed.rawCost).toBe(10);
+      expect(closed.billedAmount).toBe(15);
+      expect(closed.closingBalance).toBe(85);
+      expect(closed.closedAt).toBeDefined();
+    });
+
+    it("first period with no costs: closingBalance equals all credits", async () => {
+      await seedPlan(1.5);
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+
+      await TeamCreditService.create({
+        team: teamId,
+        amount: 50,
+        addedBy: userId,
+      });
+      await TeamCreditService.create({
+        team: teamId,
+        amount: 30,
+        addedBy: userId,
+      });
+
+      const closed = await BillingPeriodService.closePeriod(period);
+
+      expect(closed.rawCost).toBe(0);
+      expect(closed.billedAmount).toBe(0);
+      expect(closed.closingBalance).toBe(80);
+    });
+
+    it("credits added after endAt are excluded from closingBalance", async () => {
+      await seedPlan(1.5);
+      // Period in Jan 2025 — endAt = 2025-02-01
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+
+      // In-window credit (Jan 15) — included
+      await insertCredit(50, makeDate(2025, 1, 15));
+      // Post-endAt credit (March, created with default Date.now()) — excluded
+      await TeamCreditService.create({
+        team: teamId,
+        amount: 200,
+        addedBy: userId,
+      });
+
+      const closed = await BillingPeriodService.closePeriod(period);
+
+      expect(closed.closingBalance).toBe(50);
+    });
+
+    it("costs before startAt are excluded from rawCost", async () => {
+      await seedPlan(1.5);
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+      const now = new Date();
+      const prevMonth = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15),
+      );
+
+      await insertCredit(100, now);
+      // Cost before period.startAt — excluded
+      await insertCost(999, prevMonth);
+
+      const closed = await BillingPeriodService.closePeriod(period);
+
+      expect(closed.rawCost).toBe(0);
+      expect(closed.closingBalance).toBe(100);
+    });
+
+    it("costs on or after endAt are excluded from rawCost", async () => {
+      await seedPlan(1.5);
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+      const now = new Date();
+      const nextMonth = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 15),
+      );
+
+      await insertCredit(100, now);
+      // Cost after endAt — excluded
+      await insertCost(999, nextMonth);
+
+      const closed = await BillingPeriodService.closePeriod(period);
+
+      expect(closed.rawCost).toBe(0);
+      expect(closed.closingBalance).toBe(100);
+    });
+
+    it("uses markupRate locked at open time, not the current plan rate", async () => {
+      const plan1 = await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: true,
+      });
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      // Open period — locks markupRate = 1.5
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+
+      // Change plan — takes effect next month, shouldn't affect this period
+      const plan2 = await BillingPlanService.create({
+        name: "Premium",
+        markupRate: 3.0,
+        isDefault: false,
+      });
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      await LlmCostService.create({
+        team: teamId,
+        model: "claude-opus",
+        source: "annotation:per-session",
+        inputTokens: 100,
+        outputTokens: 50,
+        cost: 10,
+        providerCost: 8,
+      });
+
+      const closed = await BillingPeriodService.closePeriod(period);
+
+      // Should use 1.5 (locked at open), not 3.0 (current plan)
+      expect(period.markupRate).toBe(1.5);
+      expect(closed.billedAmount).toBe(15);
+    });
+
+    it("builds closingBalance incrementally from the prior period", async () => {
+      await seedPlan(1.5);
+
+      // Period 1: Jan 2025
+      const period1 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await insertCost(10, makeDate(2025, 1, 20));
+      const closed1 = await BillingPeriodService.closePeriod(period1);
+      // closingBalance = 100 - (10 * 1.5) = 85
+      expect(closed1.closingBalance).toBe(85);
+
+      // Period 2: Feb 2025
+      const period2 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 2),
+      );
+      // Credit and cost explicitly in Feb window
+      await insertCredit(50, makeDate(2025, 2, 15));
+      await insertCost(20, makeDate(2025, 2, 20));
+      const closed2 = await BillingPeriodService.closePeriod(period2);
+      // closingBalance = 85 + 50 - (20 * 1.5) = 85 + 50 - 30 = 105
+      expect(closed2.rawCost).toBe(20);
+      expect(closed2.billedAmount).toBe(30);
+      expect(closed2.closingBalance).toBe(105);
+    });
+
+    it("credits in prior periods are not double-counted in later periods", async () => {
+      await seedPlan(1.5);
+
+      const period1 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      // Credit in Jan only
+      await insertCredit(100, makeDate(2025, 1, 15));
+      await BillingPeriodService.closePeriod(period1);
+
+      const period2 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 2),
+      );
+      // No new credits in Feb
+      const closed2 = await BillingPeriodService.closePeriod(period2);
+
+      // Feb gets no new credits (the Jan credit was already counted in period1)
+      expect(closed2.closingBalance).toBe(100);
+    });
+
+    it("closedAt reflects the time close ran, not the period endAt", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+      const before = Date.now();
+      const closed = await BillingPeriodService.closePeriod(period);
+      const after = Date.now();
+
+      const closedAtMs = new Date(closed.closedAt!).getTime();
+      expect(closedAtMs).toBeGreaterThanOrEqual(before);
+      expect(closedAtMs).toBeLessThanOrEqual(after);
+      expect(closedAtMs).not.toBe(new Date(period.endAt).getTime());
+    });
+
+    it("throws when trying to close an already-closed period", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+      await BillingPeriodService.closePeriod(period);
+
+      await expect(BillingPeriodService.closePeriod(period)).rejects.toThrow();
+    });
+
+    it("excludes costs from other teams", async () => {
+      await seedPlan(1.5);
+      const period = await BillingPeriodService.openPeriod(teamId, new Date());
+
+      await TeamCreditService.create({
+        team: teamId,
+        amount: 100,
+        addedBy: userId,
+      });
+      await LlmCostService.create({
+        team: otherTeamId,
+        model: "claude-opus",
+        source: "annotation:per-session",
+        inputTokens: 100,
+        outputTokens: 50,
+        cost: 999,
+        providerCost: 800,
+      });
+
+      const closed = await BillingPeriodService.closePeriod(period);
+
+      expect(closed.rawCost).toBe(0);
+      expect(closed.closingBalance).toBe(100);
+    });
+  });
+
+  describe("getCurrentPeriod", () => {
+    it("returns null when no periods exist", async () => {
+      const result = await BillingPeriodService.getCurrentPeriod(teamId);
+      expect(result).toBeNull();
+    });
+
+    it("returns the open period", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+
+      const result = await BillingPeriodService.getCurrentPeriod(teamId);
+      expect(result?._id).toBe(period._id);
+      expect(result?.status).toBe("open");
+    });
+
+    it("returns null when only a closed period exists", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await BillingPeriodService.closePeriod(period);
+
+      const result = await BillingPeriodService.getCurrentPeriod(teamId);
+      expect(result).toBeNull();
+    });
+
+    it("returns the open period when a closed one also exists", async () => {
+      await seedPlan();
+      const period1 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await BillingPeriodService.closePeriod(period1);
+      const period2 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 2),
+      );
+
+      const result = await BillingPeriodService.getCurrentPeriod(teamId);
+      expect(result?._id).toBe(period2._id);
+    });
+  });
+
+  describe("getLastClosedPeriod", () => {
+    it("returns null when no periods exist", async () => {
+      const result = await BillingPeriodService.getLastClosedPeriod(teamId);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when only an open period exists", async () => {
+      await seedPlan();
+      await BillingPeriodService.openPeriod(teamId, makeDate(2025, 1));
+
+      const result = await BillingPeriodService.getLastClosedPeriod(teamId);
+      expect(result).toBeNull();
+    });
+
+    it("returns the closed period", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await BillingPeriodService.closePeriod(period);
+
+      const result = await BillingPeriodService.getLastClosedPeriod(teamId);
+      expect(result?._id).toBe(period._id);
+    });
+
+    it("returns the most recently closed when multiple exist", async () => {
+      await seedPlan();
+      const period1 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      await BillingPeriodService.closePeriod(period1);
+      const period2 = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 2),
+      );
+      await BillingPeriodService.closePeriod(period2);
+
+      const result = await BillingPeriodService.getLastClosedPeriod(teamId);
+      expect(result?._id).toBe(period2._id);
+    });
+  });
+
+  describe("findStaleOpenPeriods", () => {
+    it("includes a period whose endAt equals asOf exactly", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      // endAt for Jan 2025 is Feb 1 00:00:00.000 UTC
+      const asOf = makeDate(2025, 2, 1);
+
+      const stale = await BillingPeriodService.findStaleOpenPeriods(asOf);
+      expect(stale.some((p) => p._id === period._id)).toBe(true);
+    });
+
+    it("excludes a period whose endAt is one millisecond in the future", async () => {
+      await seedPlan();
+      const period = await BillingPeriodService.openPeriod(
+        teamId,
+        makeDate(2025, 1),
+      );
+      // One millisecond before Feb 1 00:00:00.000 UTC
+      const asOf = new Date(makeDate(2025, 2, 1).getTime() - 1);
+
+      const stale = await BillingPeriodService.findStaleOpenPeriods(asOf);
+      expect(stale.some((p) => p._id === period._id)).toBe(false);
+    });
+  });
+
+  describe("findOrOpenCurrentPeriod", () => {
+    it("returns existing open period without creating a duplicate", async () => {
+      await seedPlan();
+      const existing = await BillingPeriodService.openPeriod(
+        teamId,
+        new Date(),
+      );
+
+      const result = await BillingPeriodService.findOrOpenCurrentPeriod(
+        teamId,
+        new Date(),
+      );
+      expect(result?._id).toBe(existing._id);
+    });
+
+    it("opens a new period when none exists and plan is assigned", async () => {
+      await seedPlan();
+
+      const result = await BillingPeriodService.findOrOpenCurrentPeriod(
+        teamId,
+        new Date(),
+      );
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe("open");
+    });
+
+    it("returns null when no plan is assigned", async () => {
+      const result = await BillingPeriodService.findOrOpenCurrentPeriod(
+        teamId,
+        new Date(),
+      );
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/app/modules/billing/__tests__/teamBilling.route.test.ts
+++ b/app/modules/billing/__tests__/teamBilling.route.test.ts
@@ -164,8 +164,14 @@ describe("teamBilling.route action", () => {
 
       expect(result.success).toBe(true);
 
-      const assignment = await TeamBillingPlanService.findByTeam(team._id);
-      expect(assignment!.plan).toBe(plan2._id);
+      // Reassignment is scheduled for next month — current plan stays plan1
+      const current = await TeamBillingPlanService.findByTeam(team._id);
+      expect(current!.plan).toBe(plan1._id);
+      // plan2 is pending for next month
+      const pending = await TeamBillingPlanService.getPendingPlanChange(
+        team._id,
+      );
+      expect(pending!.plan.name).toBe("Premium");
     });
 
     it("denies non-super-admin from assigning a plan", async () => {

--- a/app/modules/billing/__tests__/teamBillingPlan.test.ts
+++ b/app/modules/billing/__tests__/teamBillingPlan.test.ts
@@ -1,0 +1,178 @@
+import mongoose, { Types } from "mongoose";
+import { beforeEach, describe, expect, it } from "vitest";
+import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import { BillingPlanService } from "../billingPlan";
+import { TeamBillingPlanService } from "../teamBillingPlan";
+
+describe("TeamBillingPlanService", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  const teamId = new Types.ObjectId().toString();
+
+  async function createPlan(name = "Standard", markupRate = 1.5) {
+    return BillingPlanService.create({ name, markupRate, isDefault: false });
+  }
+
+  function startOfMonth(date: Date = new Date()): Date {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+  }
+
+  function startOfNextMonth(date: Date = new Date()): Date {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1));
+  }
+
+  describe("assignPlan", () => {
+    it("first assignment has effectiveFrom at start of current month", async () => {
+      const plan = await createPlan();
+      const assignment = await TeamBillingPlanService.assignPlan(
+        teamId,
+        plan._id,
+      );
+
+      expect(new Date(assignment.effectiveFrom).getTime()).toBe(
+        startOfMonth().getTime(),
+      );
+      expect(assignment.team).toBe(teamId);
+      expect(assignment.plan).toBe(plan._id);
+    });
+
+    it("reassignment has effectiveFrom at start of next month", async () => {
+      const plan1 = await createPlan("Standard");
+      const plan2 = await createPlan("Premium", 2.0);
+
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      const second = await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      expect(new Date(second.effectiveFrom).getTime()).toBe(
+        startOfNextMonth().getTime(),
+      );
+      expect(second.plan).toBe(plan2._id);
+    });
+
+    it("reassignment does not remove the current active assignment", async () => {
+      const plan1 = await createPlan("Standard");
+      const plan2 = await createPlan("Premium", 2.0);
+
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      const effective = await TeamBillingPlanService.getEffectivePlan(teamId);
+      expect(effective?.name).toBe("Standard");
+    });
+
+    it("re-assigning the same pending plan does not create a duplicate record", async () => {
+      const plan1 = await createPlan("Standard");
+      const plan2 = await createPlan("Premium", 2.0);
+
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+      // Assign plan2 again to the same next-month slot — should upsert, not insert
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      const TeamBillingPlanModel = mongoose.model("TeamBillingPlan");
+      const count = await TeamBillingPlanModel.countDocuments({
+        team: new Types.ObjectId(teamId),
+      });
+      expect(count).toBe(2);
+    });
+
+    it("replaces an existing pending change scheduled for the same month", async () => {
+      const plan1 = await createPlan("Standard");
+      const plan2 = await createPlan("Premium", 2.0);
+      const plan3 = await createPlan("Enterprise", 3.0);
+
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan3._id);
+
+      const pending = await TeamBillingPlanService.getPendingPlanChange(teamId);
+      expect(pending?.plan.name).toBe("Enterprise");
+    });
+  });
+
+  describe("getEffectivePlan", () => {
+    it("returns null when no records exist", async () => {
+      const result = await TeamBillingPlanService.getEffectivePlan(teamId);
+      expect(result).toBeNull();
+    });
+
+    it("returns the assigned plan", async () => {
+      const plan = await createPlan();
+      await TeamBillingPlanService.assignPlan(teamId, plan._id);
+
+      const result = await TeamBillingPlanService.getEffectivePlan(teamId);
+      expect(result?.name).toBe("Standard");
+      expect(result?.markupRate).toBe(1.5);
+    });
+
+    it("returns null when queried before the effectiveFrom date", async () => {
+      const plan = await createPlan();
+      await TeamBillingPlanService.assignPlan(teamId, plan._id);
+
+      const now = new Date();
+      const beforeCurrentMonth = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1),
+      );
+
+      const result = await TeamBillingPlanService.getEffectivePlan(
+        teamId,
+        beforeCurrentMonth,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns the plan active at a historical date, not the current plan", async () => {
+      const plan1 = await createPlan("Standard");
+      const plan2 = await createPlan("Premium", 2.0);
+
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      const result = await TeamBillingPlanService.getEffectivePlan(
+        teamId,
+        new Date(),
+      );
+      expect(result?.name).toBe("Standard");
+    });
+
+    it("does not return a pending future plan as the current plan", async () => {
+      const plan1 = await createPlan("Standard");
+      const plan2 = await createPlan("Premium", 2.0);
+
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      const current = await TeamBillingPlanService.getEffectivePlan(teamId);
+      expect(current?.name).toBe("Standard");
+    });
+  });
+
+  describe("getPendingPlanChange", () => {
+    it("returns null when no records exist", async () => {
+      const result = await TeamBillingPlanService.getPendingPlanChange(teamId);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when only a current assignment exists", async () => {
+      const plan = await createPlan();
+      await TeamBillingPlanService.assignPlan(teamId, plan._id);
+
+      const result = await TeamBillingPlanService.getPendingPlanChange(teamId);
+      expect(result).toBeNull();
+    });
+
+    it("returns the pending plan change", async () => {
+      const plan1 = await createPlan("Standard");
+      const plan2 = await createPlan("Premium", 2.0);
+
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      const pending = await TeamBillingPlanService.getPendingPlanChange(teamId);
+      expect(pending?.plan.name).toBe("Premium");
+      expect(pending?.effectiveFrom).toBeDefined();
+    });
+  });
+});

--- a/app/modules/billing/billing.ts
+++ b/app/modules/billing/billing.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import type { BalanceSummary } from "./billing.types";
-import { BillingPlanService } from "./billingPlan";
+import { BillingPeriodService } from "./billingPeriod";
 import { TeamBillingPlanService } from "./teamBillingPlan";
 import { TeamCreditService } from "./teamCredit";
 
@@ -9,20 +9,38 @@ export class TeamBillingService {
   static async getBalanceSummary(
     teamId: string,
   ): Promise<BalanceSummary | null> {
-    const [credits, costs, assignment] = await Promise.all([
+    const [plan, lastClosed] = await Promise.all([
+      TeamBillingPlanService.getEffectivePlan(teamId),
+      BillingPeriodService.getLastClosedPeriod(teamId),
+    ]);
+    if (!plan) return null;
+
+    let credits: number;
+    let costs: number;
+
+    if (lastClosed) {
+      const since = new Date(lastClosed.endAt);
+      [credits, costs] = await Promise.all([
+        TeamCreditService.sumByTeamSince(teamId, since),
+        LlmCostService.sumCostByTeamSince(teamId, since),
+      ]);
+      const base = lastClosed.closingBalance ?? 0;
+      const markedUpCosts = new Decimal(costs)
+        .times(plan.markupRate)
+        .toNumber();
+      const balance = new Decimal(base)
+        .plus(credits)
+        .minus(markedUpCosts)
+        .toNumber();
+
+      return { balance, credits: base + credits, costs, markedUpCosts, plan };
+    }
+
+    // No closed periods yet — fall back to all-time aggregation
+    [credits, costs] = await Promise.all([
       TeamCreditService.sumByTeam(teamId),
       LlmCostService.sumCostByTeam(teamId),
-      TeamBillingPlanService.findByTeam(teamId),
     ]);
-
-    if (!assignment) return null;
-
-    const planId =
-      typeof assignment.plan === "string"
-        ? assignment.plan
-        : assignment.plan._id;
-    const plan = await BillingPlanService.findById(planId);
-    if (!plan) return null;
 
     const markedUpCosts = new Decimal(costs).times(plan.markupRate).toNumber();
     const balance = new Decimal(credits).minus(markedUpCosts).toNumber();

--- a/app/modules/billing/billing.types.ts
+++ b/app/modules/billing/billing.types.ts
@@ -10,7 +10,22 @@ export interface TeamBillingPlan {
   _id: string;
   team: string;
   plan: string | BillingPlan;
+  effectiveFrom: Date | string;
   createdAt: Date | string;
+}
+
+export interface BillingPeriod {
+  _id: string;
+  team: string;
+  plan: string;
+  markupRate: number;
+  startAt: Date | string;
+  endAt: Date | string;
+  status: "open" | "closed";
+  rawCost?: number;
+  billedAmount?: number;
+  closingBalance?: number;
+  closedAt?: Date | string;
 }
 
 export interface TeamCredit {
@@ -20,6 +35,11 @@ export interface TeamCredit {
   addedBy: string;
   note?: string;
   createdAt: Date | string;
+}
+
+export interface PendingPlanChange {
+  plan: BillingPlan;
+  effectiveFrom: Date | string;
 }
 
 export interface BalanceSummary {

--- a/app/modules/billing/billingPeriod.ts
+++ b/app/modules/billing/billingPeriod.ts
@@ -1,0 +1,197 @@
+import Decimal from "decimal.js";
+import mongoose from "mongoose";
+import billingPeriodSchema from "~/lib/schemas/billingPeriod.schema";
+import llmCostSchema from "~/lib/schemas/llmCost.schema";
+import teamCreditSchema from "~/lib/schemas/teamCredit.schema";
+import type { BillingPeriod } from "./billing.types";
+import { startOfMonth, startOfNextMonth } from "./helpers/periodDates";
+import { TeamBillingPlanService } from "./teamBillingPlan";
+
+class NoPlanError extends Error {
+  constructor(teamId: string, asOf: Date) {
+    super(
+      `No billing plan assigned to team ${teamId} at ${asOf.toISOString()}`,
+    );
+    this.name = "NoPlanError";
+  }
+}
+
+const BillingPeriodModel =
+  mongoose.models.BillingPeriod ||
+  mongoose.model("BillingPeriod", billingPeriodSchema);
+
+const TeamCreditModel =
+  mongoose.models.TeamCredit || mongoose.model("TeamCredit", teamCreditSchema);
+
+const LlmCostModel =
+  mongoose.models.LlmCost || mongoose.model("LlmCost", llmCostSchema);
+
+export class BillingPeriodService {
+  private static toBillingPeriod(doc: any): BillingPeriod {
+    return doc.toJSON({ flattenObjectIds: true });
+  }
+
+  static async openPeriod(
+    teamId: string,
+    monthDate: Date,
+  ): Promise<BillingPeriod> {
+    const startAt = startOfMonth(monthDate);
+    const endAt = startOfNextMonth(monthDate);
+
+    const plan = await TeamBillingPlanService.getEffectivePlan(teamId, startAt);
+    if (!plan) {
+      throw new NoPlanError(teamId, startAt);
+    }
+
+    const existing = await BillingPeriodModel.findOne({
+      team: teamId,
+      startAt,
+    });
+    if (existing) {
+      throw new Error(
+        `A billing period already exists for team ${teamId} starting ${startAt.toISOString()}`,
+      );
+    }
+
+    const doc = await BillingPeriodModel.create({
+      team: teamId,
+      plan: plan._id,
+      markupRate: plan.markupRate,
+      startAt,
+      endAt,
+      status: "open",
+    });
+    return this.toBillingPeriod(doc);
+  }
+
+  static async closePeriod(period: BillingPeriod): Promise<BillingPeriod> {
+    const teamObjId = new mongoose.Types.ObjectId(period.team);
+    const startAt = new Date(period.startAt);
+    const endAt = new Date(period.endAt);
+
+    const prevClosed = await BillingPeriodModel.findOne({
+      team: teamObjId,
+      status: "closed",
+      endAt: { $lte: startAt },
+    }).sort({ endAt: -1 });
+
+    const creditLowerBound = prevClosed
+      ? new Date(prevClosed.endAt)
+      : new Date(0);
+
+    const [costResult, creditResult] = await Promise.all([
+      LlmCostModel.aggregate([
+        {
+          $match: {
+            team: teamObjId,
+            createdAt: { $gte: startAt, $lt: endAt },
+          },
+        },
+        { $group: { _id: null, total: { $sum: "$cost" } } },
+      ]),
+      TeamCreditModel.aggregate([
+        {
+          $match: {
+            team: teamObjId,
+            createdAt: { $gte: creditLowerBound, $lt: endAt },
+          },
+        },
+        { $group: { _id: null, total: { $sum: "$amount" } } },
+      ]),
+    ]);
+
+    const rawCost = costResult[0]?.total ?? 0;
+    const newCredits = creditResult[0]?.total ?? 0;
+    const prevClosingBalance = prevClosed?.closingBalance ?? 0;
+
+    const billedAmount = new Decimal(rawCost)
+      .times(period.markupRate)
+      .toNumber();
+    const closingBalance = new Decimal(prevClosingBalance)
+      .plus(newCredits)
+      .minus(billedAmount)
+      .toNumber();
+
+    const updated = await BillingPeriodModel.findOneAndUpdate(
+      { _id: period._id, status: "open" },
+      {
+        $set: {
+          status: "closed",
+          rawCost,
+          billedAmount,
+          closingBalance,
+          closedAt: new Date(),
+        },
+      },
+      { new: true },
+    );
+
+    if (!updated) {
+      throw new Error(
+        `Period ${period._id} is already closed or does not exist`,
+      );
+    }
+
+    return this.toBillingPeriod(updated);
+  }
+
+  static async getCurrentPeriod(teamId: string): Promise<BillingPeriod | null> {
+    const doc = await BillingPeriodModel.findOne({
+      team: teamId,
+      status: "open",
+    });
+    return doc ? this.toBillingPeriod(doc) : null;
+  }
+
+  static async getLastClosedPeriod(
+    teamId: string,
+  ): Promise<BillingPeriod | null> {
+    const doc = await BillingPeriodModel.findOne({
+      team: teamId,
+      status: "closed",
+    }).sort({ endAt: -1 });
+    return doc ? this.toBillingPeriod(doc) : null;
+  }
+
+  static async findClosedByTeam(
+    teamId: string,
+    limit = 24,
+  ): Promise<BillingPeriod[]> {
+    const docs = await BillingPeriodModel.find({
+      team: teamId,
+      status: "closed",
+    })
+      .sort({ startAt: -1 })
+      .limit(limit);
+    return docs.map((doc) => this.toBillingPeriod(doc));
+  }
+
+  static async findStaleOpenPeriods(
+    asOf: Date = new Date(),
+  ): Promise<BillingPeriod[]> {
+    const docs = await BillingPeriodModel.find({
+      status: "open",
+      endAt: { $lte: asOf },
+    }).sort({ team: 1, startAt: 1 });
+    return docs.map((doc) => this.toBillingPeriod(doc));
+  }
+
+  static async findOrOpenCurrentPeriod(
+    teamId: string,
+    date: Date = new Date(),
+  ): Promise<BillingPeriod | null> {
+    const existing = await this.getCurrentPeriod(teamId);
+    if (existing) return existing;
+
+    try {
+      return await this.openPeriod(teamId, date);
+    } catch (err) {
+      if (err instanceof NoPlanError) return null;
+      // Another process opened the period concurrently — return whatever is there now
+      if (err instanceof Error && (err as any).code === 11000) {
+        return this.getCurrentPeriod(teamId);
+      }
+      throw err;
+    }
+  }
+}

--- a/app/modules/billing/helpers/periodDates.ts
+++ b/app/modules/billing/helpers/periodDates.ts
@@ -1,0 +1,7 @@
+export function startOfMonth(date: Date = new Date()): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+export function startOfNextMonth(date: Date = new Date()): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1));
+}

--- a/app/modules/billing/teamBillingPlan.ts
+++ b/app/modules/billing/teamBillingPlan.ts
@@ -1,7 +1,12 @@
 import mongoose from "mongoose";
 import teamBillingPlanSchema from "~/lib/schemas/teamBillingPlan.schema";
-import type { BillingPlan, TeamBillingPlan } from "./billing.types";
+import type {
+  BillingPlan,
+  PendingPlanChange,
+  TeamBillingPlan,
+} from "./billing.types";
 import { BillingPlanService } from "./billingPlan";
+import { startOfMonth, startOfNextMonth } from "./helpers/periodDates";
 
 const TeamBillingPlanModel =
   mongoose.models.TeamBillingPlan ||
@@ -12,8 +17,22 @@ export class TeamBillingPlanService {
     return doc.toJSON({ flattenObjectIds: true });
   }
 
+  private static async resolvePlan(
+    assignment: TeamBillingPlan,
+  ): Promise<BillingPlan | null> {
+    const planId =
+      typeof assignment.plan === "string"
+        ? assignment.plan
+        : assignment.plan._id;
+    return BillingPlanService.findById(planId);
+  }
+
   static async findByTeam(teamId: string): Promise<TeamBillingPlan | null> {
-    const doc = await TeamBillingPlanModel.findOne({ team: teamId });
+    const now = new Date();
+    const doc = await TeamBillingPlanModel.findOne({
+      team: teamId,
+      effectiveFrom: { $lte: now },
+    }).sort({ effectiveFrom: -1 });
     return doc ? this.toTeamBillingPlan(doc) : null;
   }
 
@@ -21,22 +40,64 @@ export class TeamBillingPlanService {
     teamId: string,
     planId: string,
   ): Promise<TeamBillingPlan> {
+    const now = new Date();
+    const hasActiveAssignment = await TeamBillingPlanModel.exists({
+      team: teamId,
+      effectiveFrom: { $lte: now },
+    });
+
+    const effectiveFrom = hasActiveAssignment
+      ? startOfNextMonth(now)
+      : startOfMonth(now);
+
     const doc = await TeamBillingPlanModel.findOneAndUpdate(
-      { team: teamId },
-      { team: teamId, plan: planId },
+      { team: teamId, effectiveFrom },
+      { $set: { plan: planId } },
       { upsert: true, new: true },
     );
     return this.toTeamBillingPlan(doc);
   }
 
-  static async getEffectivePlan(teamId: string): Promise<BillingPlan | null> {
-    const assignment = await this.findByTeam(teamId);
-    if (!assignment) return null;
+  static async getEffectivePlan(
+    teamId: string,
+    asOf: Date = new Date(),
+  ): Promise<BillingPlan | null> {
+    const doc = await TeamBillingPlanModel.findOne({
+      team: teamId,
+      effectiveFrom: { $lte: asOf },
+    }).sort({ effectiveFrom: -1 });
 
-    const planId =
-      typeof assignment.plan === "string"
-        ? assignment.plan
-        : assignment.plan._id;
-    return BillingPlanService.findById(planId);
+    if (!doc) return null;
+    return this.resolvePlan(this.toTeamBillingPlan(doc));
+  }
+
+  static async findAllActiveTeamIds(
+    asOf: Date = new Date(),
+  ): Promise<string[]> {
+    const ids = await TeamBillingPlanModel.distinct("team", {
+      effectiveFrom: { $lte: asOf },
+    });
+    return ids.map((id: any) => id.toString());
+  }
+
+  static async findTeamsWithAnyPlan(): Promise<string[]> {
+    const ids = await TeamBillingPlanModel.distinct("team");
+    return ids.map((id: any) => id.toString());
+  }
+
+  static async getPendingPlanChange(
+    teamId: string,
+  ): Promise<PendingPlanChange | null> {
+    const now = new Date();
+    const doc = await TeamBillingPlanModel.findOne({
+      team: teamId,
+      effectiveFrom: { $gt: now },
+    });
+
+    if (!doc) return null;
+    const assignment = this.toTeamBillingPlan(doc);
+    const plan = await this.resolvePlan(assignment);
+    if (!plan) return null;
+    return { plan, effectiveFrom: assignment.effectiveFrom };
   }
 }

--- a/app/modules/billing/teamCredit.ts
+++ b/app/modules/billing/teamCredit.ts
@@ -60,6 +60,19 @@ export class TeamCreditService {
     return result[0]?.total ?? 0;
   }
 
+  static async sumByTeamSince(teamId: string, since: Date): Promise<number> {
+    const result = await TeamCreditModel.aggregate([
+      {
+        $match: {
+          team: new mongoose.Types.ObjectId(teamId),
+          createdAt: { $gte: since },
+        },
+      },
+      { $group: { _id: null, total: { $sum: "$amount" } } },
+    ]);
+    return result[0]?.total ?? 0;
+  }
+
   static async paginate({
     match,
     sort,

--- a/app/modules/llmCosts/llmCost.ts
+++ b/app/modules/llmCosts/llmCost.ts
@@ -46,6 +46,22 @@ export class LlmCostService {
     return result[0]?.total ?? 0;
   }
 
+  static async sumCostByTeamSince(
+    teamId: string,
+    since: Date,
+  ): Promise<number> {
+    const result = await LlmCostModel.aggregate([
+      {
+        $match: {
+          team: new mongoose.Types.ObjectId(teamId),
+          createdAt: { $gte: since },
+        },
+      },
+      { $group: { _id: null, total: { $sum: "$cost" } } },
+    ]);
+    return result[0]?.total ?? 0;
+  }
+
   static async sumCostByModel(teamId: string): Promise<CostByModel[]> {
     return sumCostByModel(teamId);
   }

--- a/app/modules/queues/helpers/isQueuePro.ts
+++ b/app/modules/queues/helpers/isQueuePro.ts
@@ -1,5 +1,5 @@
 // Returns true if the queue instance is a QueuePro with group methods
- 
+
 export default function isQueuePro(queue: any): boolean {
   return typeof queue?.getGroups === "function";
 }

--- a/app/modules/teams/components/billingOverview.tsx
+++ b/app/modules/teams/components/billingOverview.tsx
@@ -6,16 +6,21 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { AlertCircle, Plus } from "lucide-react";
+import { AlertCircle, Clock, Plus } from "lucide-react";
 import { useContext } from "react";
+import getMonthYearString from "~/modules/app/helpers/getMonthYearString";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
 import BillingAuthorization from "~/modules/billing/authorization";
-import type { BalanceSummary } from "~/modules/billing/billing.types";
+import type {
+  BalanceSummary,
+  PendingPlanChange,
+} from "~/modules/billing/billing.types";
 import type { Team } from "~/modules/teams/teams.types";
 import type { User } from "~/modules/users/users.types";
 
 interface BillingOverviewProps {
   balanceSummary: BalanceSummary;
+  pendingPlanChange: PendingPlanChange | null;
   team: Team;
   isSubmitting: boolean;
   onAddCreditsClicked: () => void;
@@ -24,6 +29,7 @@ interface BillingOverviewProps {
 
 export default function BillingOverview({
   balanceSummary,
+  pendingPlanChange,
   team,
   isSubmitting,
   onAddCreditsClicked,
@@ -33,7 +39,7 @@ export default function BillingOverview({
   const canAddCredits = BillingAuthorization.canAddCredits(user, team);
   const canAssignPlan = BillingAuthorization.canAssignPlan(user);
   const isLowBalance = balanceSummary.balance < 1 && balanceSummary.balance > 0;
-  const isNegativeBalance = balanceSummary.balance <= 0;
+  const isNegativeBalance = balanceSummary.balance < 0;
 
   return (
     <>
@@ -98,6 +104,13 @@ export default function BillingOverview({
             <CardDescription>
               {((balanceSummary.plan.markupRate - 1) * 100).toFixed(0)}% markup
             </CardDescription>
+            {pendingPlanChange && (
+              <CardDescription className="flex items-center gap-1 text-yellow-600">
+                <Clock className="h-3 w-3" />
+                Changing to {pendingPlanChange.plan.name} on{" "}
+                {getMonthYearString(pendingPlanChange.effectiveFrom)}
+              </CardDescription>
+            )}
             {canAssignPlan && (
               <Button
                 size="sm"

--- a/app/modules/teams/components/billingPeriodHistory.tsx
+++ b/app/modules/teams/components/billingPeriodHistory.tsx
@@ -1,0 +1,77 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import getDateString from "~/modules/app/helpers/getDateString";
+import getMonthYearString from "~/modules/app/helpers/getMonthYearString";
+import type { BillingPeriod } from "~/modules/billing/billing.types";
+
+interface BillingPeriodHistoryProps {
+  periods: BillingPeriod[];
+}
+
+export default function BillingPeriodHistory({
+  periods,
+}: BillingPeriodHistoryProps) {
+  if (periods.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Billing Period History</CardTitle>
+        <CardDescription>
+          Closed billing periods and their locked balances
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Period</TableHead>
+              <TableHead className="text-right">Usage</TableHead>
+              <TableHead className="text-right">Billed</TableHead>
+              <TableHead className="text-right">Closing Balance</TableHead>
+              <TableHead className="text-right">Closed On</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {periods.map((period) => (
+              <TableRow key={period._id}>
+                <TableCell className="font-medium">
+                  {getMonthYearString(period.startAt)}
+                </TableCell>
+                <TableCell className="text-right">
+                  ${(period.rawCost ?? 0).toFixed(2)}
+                </TableCell>
+                <TableCell className="text-right">
+                  ${(period.billedAmount ?? 0).toFixed(2)}
+                </TableCell>
+                <TableCell
+                  className={`text-right font-medium ${
+                    (period.closingBalance ?? 0) < 0 ? "text-destructive" : ""
+                  }`}
+                >
+                  ${(period.closingBalance ?? 0).toFixed(2)}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-right">
+                  {getDateString(period.closedAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/modules/teams/components/teamBilling.tsx
+++ b/app/modules/teams/components/teamBilling.tsx
@@ -5,6 +5,8 @@ import { AuthenticationContext } from "~/modules/authentication/authentication.c
 import BillingAuthorization from "~/modules/billing/authorization";
 import type {
   BalanceSummary,
+  BillingPeriod,
+  PendingPlanChange,
   TeamCredit,
 } from "~/modules/billing/billing.types";
 import type {
@@ -15,6 +17,7 @@ import type {
 import type { Team } from "~/modules/teams/teams.types";
 import type { User } from "~/modules/users/users.types";
 import BillingOverview from "./billingOverview";
+import BillingPeriodHistory from "./billingPeriodHistory";
 import BillingSettings from "./billingSettings";
 import CreditHistory from "./creditHistory";
 import SpendAnalytics from "./spendAnalytics";
@@ -38,6 +41,8 @@ interface SpendAnalyticsData {
 
 interface TeamBillingProps {
   balanceSummary: BalanceSummary | null;
+  pendingPlanChange: PendingPlanChange | null;
+  closedPeriods: BillingPeriod[];
   team: Team;
   credits: PaginatedCredits;
   billingUserInfo: BillingUserInfo | null;
@@ -57,6 +62,8 @@ interface TeamBillingProps {
 
 export default function TeamBilling({
   balanceSummary,
+  pendingPlanChange,
+  closedPeriods,
   team,
   credits,
   billingUserInfo,
@@ -104,6 +111,7 @@ export default function TeamBilling({
     <div className="space-y-6">
       <BillingOverview
         balanceSummary={balanceSummary}
+        pendingPlanChange={pendingPlanChange}
         team={team}
         isSubmitting={isSubmitting}
         onAddCreditsClicked={onAddCreditsClicked}
@@ -117,6 +125,8 @@ export default function TeamBilling({
         granularity={spendGranularity}
         onGranularityChanged={onSpendGranularityChanged}
       />
+
+      <BillingPeriodHistory periods={closedPeriods} />
 
       <div className="grid gap-6 lg:grid-cols-2">
         <CreditHistory

--- a/app/modules/teams/containers/teamBilling.route.tsx
+++ b/app/modules/teams/containers/teamBilling.route.tsx
@@ -14,6 +14,7 @@ import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import BillingAuthorization from "~/modules/billing/authorization";
 import { TeamBillingService } from "~/modules/billing/billing";
+import { BillingPeriodService } from "~/modules/billing/billingPeriod";
 import { BillingPlanService } from "~/modules/billing/billingPlan";
 import AddCreditsDialog from "~/modules/billing/components/addCreditsDialog";
 import AssignBillingPlanDialog from "~/modules/billing/components/assignBillingPlanDialog";
@@ -74,17 +75,25 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const isSuperAdmin = BillingAuthorization.canAssignPlan(user);
 
-  const [balanceSummary, credits, billingUserInfo, billingPlans] =
-    await Promise.all([
-      TeamBillingService.getBalanceSummary(params.id),
-      TeamCreditService.paginate(creditsQuery),
-      team.billingUser
-        ? UserService.findById(team.billingUser).then((u) =>
-            u ? { _id: u._id, username: u.username } : null,
-          )
-        : Promise.resolve(null),
-      isSuperAdmin ? BillingPlanService.find() : Promise.resolve([]),
-    ]);
+  const [
+    balanceSummary,
+    credits,
+    billingUserInfo,
+    billingPlans,
+    pendingPlanChange,
+    closedPeriods,
+  ] = await Promise.all([
+    TeamBillingService.getBalanceSummary(params.id),
+    TeamCreditService.paginate(creditsQuery),
+    team.billingUser
+      ? UserService.findById(team.billingUser).then((u) =>
+          u ? { _id: u._id, username: u.username } : null,
+        )
+      : Promise.resolve(null),
+    isSuperAdmin ? BillingPlanService.find() : Promise.resolve([]),
+    TeamBillingPlanService.getPendingPlanChange(params.id),
+    BillingPeriodService.findClosedByTeam(params.id),
+  ]);
 
   const emptySpendAnalytics = {
     byModel: [],
@@ -99,6 +108,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       credits,
       billingUserInfo,
       billingPlans,
+      pendingPlanChange,
+      closedPeriods,
       spendAnalytics: emptySpendAnalytics,
     };
   }
@@ -137,6 +148,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     credits,
     billingUserInfo,
     billingPlans,
+    pendingPlanChange,
+    closedPeriods,
     spendAnalytics,
   };
 }
@@ -222,6 +235,8 @@ export default function TeamBillingRoute() {
     credits,
     billingUserInfo,
     billingPlans,
+    pendingPlanChange,
+    closedPeriods,
     spendAnalytics,
   } = useLoaderData<typeof loader>();
   const fetcher = useFetcher();
@@ -316,6 +331,8 @@ export default function TeamBillingRoute() {
   return (
     <TeamBilling
       balanceSummary={balanceSummary}
+      pendingPlanChange={pendingPlanChange}
+      closedPeriods={closedPeriods}
       team={team}
       credits={credits}
       billingUserInfo={billingUserInfo}

--- a/app/modules/teams/team.ts
+++ b/app/modules/teams/team.ts
@@ -95,4 +95,9 @@ export class TeamService {
     const doc = await TeamModel.findByIdAndDelete(id).exec();
     return doc ? this.toTeam(doc) : null;
   }
+
+  static async findAllIds(): Promise<string[]> {
+    const ids = await TeamModel.distinct("_id");
+    return ids.map((id: any) => id.toString());
+  }
 }

--- a/e2e/billing.setup.ts
+++ b/e2e/billing.setup.ts
@@ -1,0 +1,80 @@
+import { test as setup } from "@playwright/test";
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+
+dotenv.config({ path: "../.env" });
+
+setup("setup billing", async () => {
+  const githubId = parseInt(process.env.SUPER_ADMIN_GITHUB_ID as string);
+  if (!githubId) {
+    throw new Error("SUPER_ADMIN_GITHUB_ID environment variable is required.");
+  }
+
+  const {
+    DOCUMENT_DB_CONNECTION_STRING,
+    DOCUMENT_DB_USERNAME,
+    DOCUMENT_DB_PASSWORD,
+  } = process.env;
+  if (
+    !DOCUMENT_DB_CONNECTION_STRING ||
+    !DOCUMENT_DB_USERNAME ||
+    !DOCUMENT_DB_PASSWORD
+  ) {
+    throw new Error("Database connection environment variables are required.");
+  }
+
+  const connectionString = `mongodb://${encodeURIComponent(DOCUMENT_DB_USERNAME)}:${encodeURIComponent(DOCUMENT_DB_PASSWORD)}@${DOCUMENT_DB_CONNECTION_STRING}`;
+  await mongoose.connect(connectionString, { connectTimeoutMS: 10000 });
+
+  await mongoose.connection
+    .collection("featureflags")
+    .updateOne(
+      { name: "HAS_BILLING" },
+      { $setOnInsert: { name: "HAS_BILLING", createdAt: new Date() } },
+      { upsert: true },
+    );
+
+  await mongoose.connection
+    .collection("users")
+    .updateOne({ githubId }, { $addToSet: { featureFlags: "HAS_BILLING" } });
+
+  const existingPlan = await mongoose.connection
+    .collection("billingplans")
+    .findOne({ name: "Standard" });
+
+  let planId: mongoose.Types.ObjectId;
+  if (existingPlan) {
+    planId = existingPlan._id as mongoose.Types.ObjectId;
+  } else {
+    const result = await mongoose.connection
+      .collection("billingplans")
+      .insertOne({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: false,
+        createdAt: new Date(),
+      });
+    planId = result.insertedId;
+  }
+
+  const team = await mongoose.connection
+    .collection("teams")
+    .findOne({ name: "Research Team Alpha" });
+  if (!team) {
+    throw new Error("Team 'Research Team Alpha' not found.");
+  }
+
+  await mongoose.connection.collection("teambillingplans").updateOne(
+    { team: team._id },
+    {
+      $set: {
+        plan: planId,
+        effectiveFrom: new Date(0),
+        createdAt: new Date(),
+      },
+    },
+    { upsert: true },
+  );
+
+  await mongoose.disconnect();
+});

--- a/e2e/billing.spec.ts
+++ b/e2e/billing.spec.ts
@@ -1,0 +1,84 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+async function navigateToBilling(page: Page) {
+  await page.goto("/");
+  await page.getByRole("link", { name: "Teams", exact: true }).first().click();
+  await page
+    .getByRole("link")
+    .filter({ hasText: "Research Team Alpha" })
+    .click();
+  await page.getByRole("tab", { name: "Billing" }).click();
+  await expect(page).toHaveURL(/\/teams\/[a-f0-9]+\/billing$/);
+}
+
+test.describe("Billing", () => {
+  test("should navigate to billing page", async ({ page }) => {
+    await navigateToBilling(page);
+    await expect(page.getByText("Balance").first()).toBeVisible();
+  });
+
+  test("should display billing overview cards", async ({ page }) => {
+    await navigateToBilling(page);
+    await expect(page.getByText("Balance").first()).toBeVisible();
+    await expect(page.getByText("Credits Added")).toBeVisible();
+    await expect(page.getByText("Usage (with markup)")).toBeVisible();
+    await expect(page.getByText("Plan").first()).toBeVisible();
+  });
+
+  test("should show Standard plan with markup rate", async ({ page }) => {
+    await navigateToBilling(page);
+    await expect(page.getByText("Standard")).toBeVisible();
+    await expect(page.getByText("50% markup")).toBeVisible();
+  });
+
+  test("should show Add credits button for super admin", async ({ page }) => {
+    await navigateToBilling(page);
+    await expect(
+      page.getByRole("button", { name: "Add credits" }),
+    ).toBeVisible();
+  });
+
+  test("should open add credits dialog", async ({ page }) => {
+    await navigateToBilling(page);
+    await page.getByRole("button", { name: "Add credits" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Add credits" }),
+    ).toBeVisible();
+    await expect(page.locator("#credit-amount")).toBeVisible();
+    await expect(page.locator("#credit-note")).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("should add credits successfully", async ({ page }) => {
+    await navigateToBilling(page);
+    await page.getByRole("button", { name: "Add credits" }).click();
+    await page.locator("#credit-amount").fill("50");
+    await page.locator("#credit-note").fill("E2E Test Credit");
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Add credits" })
+      .click();
+    await expect(page.getByText("Credits added")).toBeVisible();
+  });
+
+  test("should display credit history after adding credits", async ({
+    page,
+  }) => {
+    await navigateToBilling(page);
+    await expect(page.getByText("Credit history")).toBeVisible();
+    await expect(page.getByText("E2E Test Credit")).toBeVisible();
+  });
+
+  test("should display spend analytics section", async ({ page }) => {
+    await navigateToBilling(page);
+    await expect(page.getByText("Spend analytics")).toBeVisible();
+  });
+
+  test("should display billing settings section", async ({ page }) => {
+    await navigateToBilling(page);
+    await expect(page.getByText("Billing settings")).toBeVisible();
+    await expect(page.getByText("Billing user").first()).toBeVisible();
+  });
+});

--- a/test/helpers/makeDate.ts
+++ b/test/helpers/makeDate.ts
@@ -1,0 +1,3 @@
+export default function makeDate(year: number, month: number, day = 1): Date {
+  return new Date(Date.UTC(year, month - 1, day));
+}

--- a/workers/general/__tests__/closeBillingPeriods.test.ts
+++ b/workers/general/__tests__/closeBillingPeriods.test.ts
@@ -1,0 +1,271 @@
+import mongoose, { Types } from "mongoose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BillingPeriodService } from "~/modules/billing/billingPeriod";
+import { BillingPlanService } from "~/modules/billing/billingPlan";
+import { TeamBillingPlanService } from "~/modules/billing/teamBillingPlan";
+import { TeamCreditService } from "~/modules/billing/teamCredit";
+import { LlmCostService } from "~/modules/llmCosts/llmCost";
+import { TeamService } from "~/modules/teams/team";
+import clearDocumentDB from "../../../test/helpers/clearDocumentDB";
+import makeDate from "../../../test/helpers/makeDate";
+import closeBillingPeriods from "../closeBillingPeriods";
+
+// Importing these services registers their Mongoose schemas as a side effect,
+// which is required because the worker imports them indirectly via billing modules.
+void LlmCostService;
+void TeamCreditService;
+
+describe("closeBillingPeriods worker", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const teamId = new Types.ObjectId().toString();
+  const otherTeamId = new Types.ObjectId().toString();
+
+  async function seedPlan(team: string, markupRate = 1.5) {
+    const plan = await BillingPlanService.create({
+      name: "Standard",
+      markupRate,
+      isDefault: true,
+    });
+    const TeamBillingPlanModel = mongoose.model("TeamBillingPlan");
+    await TeamBillingPlanModel.create({
+      team: new Types.ObjectId(team),
+      plan: plan._id,
+      effectiveFrom: new Date(0),
+    });
+    return plan;
+  }
+
+  it("closes all stale open periods (endAt <= now)", async () => {
+    await seedPlan(teamId);
+
+    // Jan 2025 period — endAt = Feb 1 2025 (well in the past)
+    const period = await BillingPeriodService.openPeriod(
+      teamId,
+      makeDate(2025, 1),
+    );
+    expect(period.status).toBe("open");
+
+    const result = await closeBillingPeriods({ data: {} } as any);
+
+    expect(result.status).toBe("OK");
+    expect(result.stats.closed).toBe(1);
+
+    const last = await BillingPeriodService.getLastClosedPeriod(teamId);
+    expect(last).not.toBeNull();
+    expect(last!.status).toBe("closed");
+    expect(last!.closedAt).toBeDefined();
+  });
+
+  it("does not close an open period whose endAt is in the future (current month)", async () => {
+    await seedPlan(teamId);
+
+    // Current month period — endAt is next month, in the future
+    await BillingPeriodService.openPeriod(teamId, new Date());
+
+    const result = await closeBillingPeriods({ data: {} } as any);
+
+    expect(result.stats.closed).toBe(0);
+    const current = await BillingPeriodService.getCurrentPeriod(teamId);
+    expect(current).not.toBeNull();
+    expect(current!.status).toBe("open");
+  });
+
+  it("opens a new period for the current month after closing the stale one", async () => {
+    await seedPlan(teamId);
+
+    await BillingPeriodService.openPeriod(teamId, makeDate(2025, 1));
+
+    await closeBillingPeriods({ data: {} } as any);
+
+    const after = await BillingPeriodService.getCurrentPeriod(teamId);
+    expect(after).not.toBeNull();
+    expect(after!.status).toBe("open");
+    // The new period should be for the current month, not the stale Jan 2025 one
+    const expectedStartAt = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1),
+    );
+    expect(new Date(after!.startAt).getTime()).toBe(expectedStartAt.getTime());
+  });
+
+  it("does not open a period for a team with no billing plan", async () => {
+    // No plan seeded for teamId
+    const result = await closeBillingPeriods({ data: {} } as any);
+
+    expect(result.status).toBe("OK");
+    const current = await BillingPeriodService.getCurrentPeriod(teamId);
+    expect(current).toBeNull();
+  });
+
+  it("does not create a duplicate if a current-month period already exists", async () => {
+    await seedPlan(teamId);
+
+    // Open current month manually before the job runs
+    await BillingPeriodService.openPeriod(teamId, new Date());
+
+    const result = await closeBillingPeriods({ data: {} } as any);
+    expect(result.status).toBe("OK");
+
+    // Should not throw or create a duplicate
+    const BillingPeriodModel = mongoose.model("BillingPeriod");
+    const count = await BillingPeriodModel.countDocuments({
+      team: new Types.ObjectId(teamId),
+      status: "open",
+    });
+    expect(count).toBe(1);
+  });
+
+  it("is idempotent: running twice produces the same state", async () => {
+    await seedPlan(teamId);
+    await BillingPeriodService.openPeriod(teamId, makeDate(2025, 1));
+
+    await closeBillingPeriods({ data: {} } as any);
+    const result2 = await closeBillingPeriods({ data: {} } as any);
+
+    expect(result2.status).toBe("OK");
+    // Second run: nothing stale to close, current period already exists so 0 newly opened
+    expect(result2.stats.closed).toBe(0);
+    expect(result2.stats.opened).toBe(0);
+  });
+
+  it("handles multiple teams independently", async () => {
+    await seedPlan(teamId);
+    await seedPlan(otherTeamId);
+
+    await BillingPeriodService.openPeriod(teamId, makeDate(2025, 1));
+    await BillingPeriodService.openPeriod(otherTeamId, makeDate(2025, 2));
+
+    const result = await closeBillingPeriods({ data: {} } as any);
+
+    expect(result.stats.closed).toBe(2);
+
+    const team1Closed = await BillingPeriodService.getLastClosedPeriod(teamId);
+    const team2Closed =
+      await BillingPeriodService.getLastClosedPeriod(otherTeamId);
+    expect(team1Closed!.status).toBe("closed");
+    expect(team2Closed!.status).toBe("closed");
+  });
+
+  it("closes multiple stale periods for the same team in chronological order", async () => {
+    await seedPlan(teamId);
+
+    const p1 = await BillingPeriodService.openPeriod(teamId, makeDate(2025, 1));
+    await BillingPeriodService.closePeriod(p1);
+
+    const p2 = await BillingPeriodService.openPeriod(teamId, makeDate(2025, 2));
+    await BillingPeriodService.closePeriod(p2);
+
+    // Manually create a stale open period bypassing service validation
+    const BillingPeriodModel = mongoose.model("BillingPeriod");
+    const plan = await mongoose
+      .model("BillingPlan")
+      .findOne({ name: "Standard" });
+    await BillingPeriodModel.create({
+      team: new Types.ObjectId(teamId),
+      plan: plan!._id,
+      markupRate: 1.5,
+      startAt: makeDate(2025, 3),
+      endAt: makeDate(2025, 4),
+      status: "open",
+    });
+
+    const result = await closeBillingPeriods({ data: {} } as any);
+    expect(result.stats.closed).toBe(1);
+
+    const last = await BillingPeriodService.getLastClosedPeriod(teamId);
+    expect(new Date(last!.startAt).getUTCMonth()).toBe(2); // March (0-indexed)
+  });
+
+  it("returns PARTIAL status when a period fails to close", async () => {
+    await seedPlan(teamId);
+    await seedPlan(otherTeamId);
+
+    await BillingPeriodService.openPeriod(teamId, makeDate(2025, 1));
+    await BillingPeriodService.openPeriod(otherTeamId, makeDate(2025, 1));
+
+    const original =
+      BillingPeriodService.closePeriod.bind(BillingPeriodService);
+    let calls = 0;
+    vi.spyOn(BillingPeriodService, "closePeriod").mockImplementation(
+      async (...args) => {
+        calls++;
+        if (calls === 1) throw new Error("Simulated failure");
+        return original(...args);
+      },
+    );
+
+    const result = await closeBillingPeriods({ data: {} } as any);
+
+    expect(result.status).toBe("PARTIAL");
+    expect(result.stats.closeFailed).toBe(1);
+    expect(result.stats.closed).toBe(1);
+  });
+
+  describe("planless team fallback", () => {
+    it("assigns default plan to a team with no billing plan", async () => {
+      await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: true,
+      });
+      const team = await TeamService.create({ name: "Planless Team" });
+
+      const before = await TeamBillingPlanService.getEffectivePlan(team._id);
+      expect(before).toBeNull();
+
+      const result = await closeBillingPeriods({ data: {} } as any);
+      expect(result.stats.assigned).toBe(1);
+
+      const after = await TeamBillingPlanService.getEffectivePlan(team._id);
+      expect(after).not.toBeNull();
+      expect(after!.name).toBe("Standard");
+    });
+
+    it("does not reassign a plan to teams that already have one", async () => {
+      await seedPlan(teamId);
+
+      const result = await closeBillingPeriods({ data: {} } as any);
+      expect(result.stats.assigned).toBe(0);
+    });
+
+    it("does nothing when no default plan exists", async () => {
+      await BillingPlanService.create({
+        name: "Custom",
+        markupRate: 2.0,
+        isDefault: false,
+      });
+      const team = await TeamService.create({ name: "Planless Team" });
+
+      const result = await closeBillingPeriods({ data: {} } as any);
+      expect(result.stats.assigned).toBe(0);
+
+      const plan = await TeamBillingPlanService.getEffectivePlan(team._id);
+      expect(plan).toBeNull();
+    });
+
+    it("does not count teams with only a future pending plan as planless", async () => {
+      const plan1 = await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: true,
+      });
+      const plan2 = await BillingPlanService.create({
+        name: "Premium",
+        markupRate: 2.0,
+        isDefault: false,
+      });
+      // Assign plan1 now, then schedule plan2 for next month
+      await TeamBillingPlanService.assignPlan(teamId, plan1._id);
+      await TeamBillingPlanService.assignPlan(teamId, plan2._id);
+
+      const result = await closeBillingPeriods({ data: {} } as any);
+      expect(result.stats.assigned).toBe(0);
+    });
+  });
+});

--- a/workers/general/closeBillingPeriods.ts
+++ b/workers/general/closeBillingPeriods.ts
@@ -1,0 +1,102 @@
+import { BillingPeriodService } from "app/modules/billing/billingPeriod";
+import { BillingPlanService } from "app/modules/billing/billingPlan";
+import { TeamBillingPlanService } from "app/modules/billing/teamBillingPlan";
+import { TeamService } from "app/modules/teams/team";
+import type { Job } from "bullmq";
+
+export default async function closeBillingPeriods(_job: Job) {
+  const now = new Date();
+
+  // 1. Close stale open periods in parallel
+  const stale = await BillingPeriodService.findStaleOpenPeriods(now);
+
+  // Warn if any team has more than one stale period — costs in skipped months may be unbilled
+  const staleCountByTeam = new Map<string, number>();
+  for (const p of stale) {
+    staleCountByTeam.set(p.team, (staleCountByTeam.get(p.team) ?? 0) + 1);
+  }
+  for (const [tid, count] of staleCountByTeam) {
+    if (count > 1) {
+      console.warn(
+        `[closeBillingPeriods] Team ${tid} has ${count} stale periods — costs in skipped months may not be billed`,
+      );
+    }
+  }
+
+  const closeResults = await Promise.allSettled(
+    stale.map(async (period) => {
+      const closed = await BillingPeriodService.closePeriod(period);
+      console.log(
+        `[closeBillingPeriods] Closed period ${period._id} for team ${period.team} (endAt: ${new Date(period.endAt).toISOString()})`,
+      );
+      return closed;
+    }),
+  );
+
+  let closed = 0;
+  let closeFailed = 0;
+  for (const result of closeResults) {
+    if (result.status === "fulfilled") {
+      closed++;
+    } else {
+      closeFailed++;
+      console.error(
+        `[closeBillingPeriods] Failed to close a period:`,
+        result.reason,
+      );
+    }
+  }
+
+  // 2. Open current-month period for all teams with an active plan.
+  //    Track only genuinely new opens (not teams that already had a current period).
+  const activeTeamIds = await TeamBillingPlanService.findAllActiveTeamIds(now);
+  const openResults = await Promise.all(
+    activeTeamIds.map(async (teamId) => {
+      const hadCurrent = await BillingPeriodService.getCurrentPeriod(teamId);
+      if (hadCurrent) return false;
+      const period = await BillingPeriodService.findOrOpenCurrentPeriod(
+        teamId,
+        now,
+      );
+      return period !== null;
+    }),
+  );
+  const opened = openResults.filter(Boolean).length;
+
+  // 3. Assign default plan to any team that has none (recovery fallback)
+  const allTeamIds = await TeamService.findAllIds();
+  const teamsWithPlan = new Set(
+    await TeamBillingPlanService.findTeamsWithAnyPlan(),
+  );
+  const planlessTeamIds = allTeamIds.filter((id) => !teamsWithPlan.has(id));
+  let assigned = 0;
+
+  if (planlessTeamIds.length > 0) {
+    const defaultPlan = await BillingPlanService.findDefault();
+    if (defaultPlan) {
+      await Promise.all(
+        planlessTeamIds.map(async (teamId) => {
+          await TeamBillingPlanService.assignPlan(teamId, defaultPlan._id);
+          console.log(
+            `[closeBillingPeriods] Assigned default plan to planless team ${teamId}`,
+          );
+          assigned++;
+        }),
+      );
+    } else {
+      console.warn(
+        `[closeBillingPeriods] ${planlessTeamIds.length} planless team(s) found but no default plan exists`,
+      );
+    }
+  }
+
+  console.log(
+    `[closeBillingPeriods] Done: closed=${closed} opened=${opened} assigned=${assigned} closeFailed=${closeFailed}`,
+  );
+
+  return {
+    status: closeFailed > 0 ? "PARTIAL" : "OK",
+    message: `Closed ${closed} periods, opened ${opened} new periods, assigned plan to ${assigned} planless teams${closeFailed > 0 ? `, ${closeFailed} failed to close` : ""}`,
+    stats: { closed, closeFailed, opened, assigned },
+  };
+}

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -13,3 +13,4 @@ createWorker(
   `${global.root}/runners/tasks.ts`,
 );
 createWorker({ name: "general" }, `${global.root}/runners/general.ts`);
+createWorker({ name: "cron" }, `${global.root}/runners/cron.ts`);

--- a/workers/runners/cron.ts
+++ b/workers/runners/cron.ts
@@ -1,0 +1,28 @@
+import { initializeDatabase } from "app/lib/database";
+import "app/modules/storage/storage";
+import type { Job } from "bullmq";
+import closeBillingPeriods from "../general/closeBillingPeriods";
+
+console.log("[cron] Initializing database connection...");
+const _dbStart = Date.now();
+await initializeDatabase();
+console.log(`[cron] Database ready (${Date.now() - _dbStart}ms)`);
+
+export default async (job: Job) => {
+  try {
+    switch (job.name) {
+      case "BILLING:CLOSE_PERIODS": {
+        return closeBillingPeriods(job);
+      }
+      default: {
+        return {
+          status: "ERRORED",
+          message: `Missing handler for ${job.name}`,
+        };
+      }
+    }
+  } catch (error) {
+    console.error(error);
+    throw new Error("Cron worker failed", { cause: error });
+  }
+};


### PR DESCRIPTION
Adds month-anchored billing periods that lock rawCost, billedAmount, and closingBalance at month end. Balance calculation now uses the last closed period's closingBalance as a base plus a small live aggregation, so plan rate changes can never retroactively alter historical balances.

- BillingPeriod schema + service (open, close, findStale, findOrOpen)
- TeamBillingPlan gains effectiveFrom so reassignments take effect next month
- TeamBillingService.getBalanceSummary updated to period-aware calculation
- sumByTeamSince / sumCostByTeamSince added to TeamCreditService / LlmCostService
- BILLING:CLOSE_PERIODS cron job (monthly, 3-attempt retry with backoff)
- Billing page shows pending plan change notice and closed-period history table
- Backfill migration for existing TeamBillingPlan records
- 70+ new tests across billing, period, plan, and cron worker

Fixes #1799