### PR TITLE
Fix jsdom tests failing to resolve optional @taskforcesh/bullmq-pro i…

### DIFF
--- a/test/mocks/bullmq-pro.ts
+++ b/test/mocks/bullmq-pro.ts
@@ -1,0 +1,4 @@
+import { FlowProducer, Queue } from "bullmq";
+
+export const FlowProducerPro = FlowProducer;
+export const QueuePro = Queue;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "url";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
@@ -23,4 +24,13 @@ export default defineConfig({
     },
   },
   plugins: [tsconfigPaths()],
+  resolve: {
+    alias: process.env.BULLMQ_PRO_TOKEN
+      ? {}
+      : {
+          "@taskforcesh/bullmq-pro": fileURLToPath(
+            new URL("./test/mocks/bullmq-pro.ts", import.meta.url),
+          ),
+        },
+  },
 });


### PR DESCRIPTION
When no BULLMQ_PRO_TOKEN is set, alias the package to a stub that re-exports from bullmq. This prevents Vite's client-side import analysis (used by jsdom test environments) from erroring on the uninstalled optional dependency.