### PR TITLE
Store inputTokens on prompt versions for better cost estimates

### DIFF
--- a/app/lib/schemas/promptVersion.schema.ts
+++ b/app/lib/schemas/promptVersion.schema.ts
@@ -9,6 +9,7 @@ export default new mongoose.Schema({
   codebook: { type: mongoose.Types.ObjectId, ref: "Codebook" },
   codebookVersion: { type: mongoose.Types.ObjectId, ref: "CodebookVersion" },
   hasBeenSaved: { type: Boolean, default: false },
+  inputTokens: { type: Number },
   createdAt: { type: Date, default: Date.now },
   createdBy: { type: mongoose.Types.ObjectId, ref: "User" },
   updatedAt: { type: Date },

--- a/app/migrations/20260330102322-backfill-prompt-version-input-tokens.ts
+++ b/app/migrations/20260330102322-backfill-prompt-version-input-tokens.ts
@@ -1,0 +1,61 @@
+import type { Db } from "mongodb";
+import type {
+  MigrationFile,
+  MigrationResult,
+} from "~/modules/migrations/types";
+import tokenizePromptVersion from "~/modules/prompts/helpers/tokenizePromptVersion";
+
+export default {
+  id: "20260330102322-backfill-prompt-version-input-tokens",
+  name: "Backfill Prompt Version Input Tokens",
+  description:
+    "Tokenize saved prompt versions and store inputTokens for cost estimation",
+
+  async up(db: Db): Promise<MigrationResult> {
+    console.log("Starting Backfill Prompt Version Input Tokens migration...");
+
+    const versions = await db
+      .collection("promptversions")
+      .find(
+        { hasBeenSaved: true, inputTokens: { $exists: false } },
+        { projection: { _id: 1, userPrompt: 1, annotationSchema: 1 } },
+      )
+      .toArray();
+
+    console.log(`Found ${versions.length} prompt versions without inputTokens`);
+
+    let migrated = 0;
+    let failed = 0;
+
+    for (const version of versions) {
+      try {
+        const inputTokens = tokenizePromptVersion(
+          version.userPrompt ?? "",
+          version.annotationSchema ?? [],
+        );
+
+        await db
+          .collection("promptversions")
+          .updateOne({ _id: version._id }, { $set: { inputTokens } });
+
+        console.log(`  ✓ PromptVersion ${version._id}: ${inputTokens} tokens`);
+        migrated++;
+      } catch (error) {
+        console.error(
+          `  ❌ PromptVersion ${version._id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        failed++;
+      }
+    }
+
+    console.log(
+      `\n✓ Migration complete: ${migrated} backfilled, ${failed} failed`,
+    );
+
+    return {
+      success: failed === 0,
+      message: `Backfilled inputTokens for ${migrated} prompt versions (${failed} failed)`,
+      stats: { migrated, failed },
+    };
+  },
+} satisfies MigrationFile;

--- a/app/modules/prompts/containers/promptEditor.route.tsx
+++ b/app/modules/prompts/containers/promptEditor.route.tsx
@@ -12,6 +12,7 @@ import addDialog from "~/modules/dialogs/addDialog";
 import type { User } from "~/modules/users/users.types";
 import PromptAuthorization from "../authorization";
 import PromptEditor from "../components/promptEditor";
+import tokenizePromptVersion from "../helpers/tokenizePromptVersion";
 import { PromptService } from "../prompt";
 import { PromptVersionService } from "../promptVersion";
 import type { Route } from "./+types/promptEditor.route";
@@ -97,15 +98,18 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   switch (intent) {
-    case "UPDATE_PROMPT_VERSION":
+    case "UPDATE_PROMPT_VERSION": {
+      const inputTokens = tokenizePromptVersion(userPrompt, annotationSchema);
       await PromptVersionService.updateById(entityId, {
         name,
         userPrompt,
         annotationSchema,
         hasBeenSaved: true,
+        inputTokens,
         updatedAt: new Date().toISOString(),
       });
       return {};
+    }
     case "MAKE_PROMPT_VERSION_PRODUCTION":
       await PromptService.updateById(promptId, {
         productionVersion: Number(params.version),

--- a/app/modules/prompts/containers/promptSelectorContainer.tsx
+++ b/app/modules/prompts/containers/promptSelectorContainer.tsx
@@ -22,7 +22,10 @@ export default function PromptSelectorContainer({
     selectedPrompt: string,
     selectedPromptName?: string,
   ) => void;
-  onSelectedPromptVersionChanged: (selectedPromptVersion: number) => void;
+  onSelectedPromptVersionChanged: (
+    selectedPromptVersion: number,
+    inputTokens?: number,
+  ) => void;
 }) {
   const [isPromptsOpen, setIsPromptsOpen] = useState(false);
   const [isPromptVersionsOpen, setIsPromptVersionsOpen] = useState(false);
@@ -74,7 +77,10 @@ export default function PromptSelectorContainer({
   };
 
   const onSelectedPromptVersionChange = (selectedPromptVersion: number) => {
-    onSelectedPromptVersionChanged(selectedPromptVersion);
+    const version = promptVersions.find(
+      (v) => v.version === selectedPromptVersion,
+    );
+    onSelectedPromptVersionChanged(selectedPromptVersion, version?.inputTokens);
   };
 
   const prompts = get(promptsFetcher, "data.prompts.data", []);

--- a/app/modules/prompts/helpers/tokenizePromptVersion.ts
+++ b/app/modules/prompts/helpers/tokenizePromptVersion.ts
@@ -1,0 +1,22 @@
+import { encode } from "gpt-tokenizer";
+import buildAnnotationSchema from "~/modules/llm/helpers/buildAnnotationSchema";
+import type { AnnotationSchemaItem } from "../prompts.types";
+
+export default function tokenizePromptVersion(
+  userPrompt: string,
+  annotationSchema: AnnotationSchemaItem[],
+): number {
+  const annotationFields: Record<string, any> = {};
+  for (const item of annotationSchema) {
+    annotationFields[item.fieldKey] = item.value;
+  }
+  const llmAnnotationSchema = { annotations: [annotationFields] };
+  const responseSchema = buildAnnotationSchema(
+    llmAnnotationSchema,
+    annotationSchema,
+  );
+
+  return encode(
+    `${userPrompt}\n\n${JSON.stringify(llmAnnotationSchema)}\n\n${JSON.stringify(responseSchema)}`,
+  ).length;
+}

--- a/app/modules/prompts/prompts.types.ts
+++ b/app/modules/prompts/prompts.types.ts
@@ -23,6 +23,7 @@ export interface PromptVersion {
   codebook?: string;
   codebookVersion?: string;
   hasBeenSaved: boolean;
+  inputTokens?: number;
   updatedAt: string;
 }
 

--- a/app/modules/runSets/__tests__/calculateEstimates.test.ts
+++ b/app/modules/runSets/__tests__/calculateEstimates.test.ts
@@ -11,10 +11,16 @@ function makeDefinition(
   promptId: string,
   version: number,
   modelCode: string,
+  promptInputTokens?: number,
 ): RunDefinition {
   return {
     key: buildUsedPromptModelKey(promptId, version, modelCode),
-    prompt: { promptId, promptName: promptId, version },
+    prompt: {
+      promptId,
+      promptName: promptId,
+      version,
+      inputTokens: promptInputTokens,
+    },
     modelCode,
   };
 }
@@ -203,5 +209,78 @@ describe("calculateEstimates", () => {
     const withDefault = calculateEstimates(definitions, sessions);
 
     expect(withZero.estimatedCost).toBe(withDefault.estimatedCost);
+  });
+
+  it("adds promptInputTokens per session to input token count", () => {
+    const promptInputTokens = 500;
+    const definitions = [
+      makeDefinition("promptA", 1, allModels[0], promptInputTokens),
+    ];
+    const sessions = Array(10).fill({ inputTokens: 1000 });
+    const result = calculateEstimates(definitions, sessions);
+
+    const totalInputTokens = 10 * (1000 + promptInputTokens);
+    const expected =
+      calculateCost({
+        modelCode: allModels[0],
+        inputTokens: totalInputTokens,
+        outputTokens: totalInputTokens,
+      }) * COST_BUFFER_MULTIPLIER;
+    expect(result.estimatedCost).toBe(expected);
+  });
+
+  it("uses promptInputTokens with fallback session tokens", () => {
+    const promptInputTokens = 800;
+    const definitions = [
+      makeDefinition("promptA", 1, allModels[0], promptInputTokens),
+    ];
+    const result = calculateEstimates(definitions, Array(5).fill({}));
+
+    const totalInputTokens = 5 * (250 + promptInputTokens);
+    const expected =
+      calculateCost({
+        modelCode: allModels[0],
+        inputTokens: totalInputTokens,
+        outputTokens: totalInputTokens,
+      }) * COST_BUFFER_MULTIPLIER;
+    expect(result.estimatedCost).toBe(expected);
+  });
+
+  it("applies different promptInputTokens per definition", () => {
+    const definitions = [
+      makeDefinition("promptA", 1, allModels[0], 300),
+      makeDefinition("promptB", 1, allModels[0], 700),
+    ];
+    const sessions = Array(10).fill({ inputTokens: 1000 });
+    const result = calculateEstimates(definitions, sessions);
+
+    const inputA = 10 * (1000 + 300);
+    const inputB = 10 * (1000 + 700);
+    const expected =
+      (calculateCost({
+        modelCode: allModels[0],
+        inputTokens: inputA,
+        outputTokens: inputA,
+      }) +
+        calculateCost({
+          modelCode: allModels[0],
+          inputTokens: inputB,
+          outputTokens: inputB,
+        })) *
+      COST_BUFFER_MULTIPLIER;
+    expect(result.estimatedCost).toBe(expected);
+  });
+
+  it("treats missing promptInputTokens as zero", () => {
+    const withTokens = calculateEstimates(
+      [makeDefinition("promptA", 1, allModels[0], 0)],
+      Array(10).fill({ inputTokens: 1000 }),
+    );
+    const withoutTokens = calculateEstimates(
+      [makeDefinition("promptA", 1, allModels[0])],
+      Array(10).fill({ inputTokens: 1000 }),
+    );
+
+    expect(withTokens.estimatedCost).toBe(withoutTokens.estimatedCost);
   });
 });

--- a/app/modules/runSets/components/runSetCreatorPrompts.tsx
+++ b/app/modules/runSets/components/runSetCreatorPrompts.tsx
@@ -19,6 +19,9 @@ export default function RunSetPromptsField({
   const [tempPromptVersion, setTempPromptVersion] = useState<number | null>(
     null,
   );
+  const [tempPromptInputTokens, setTempPromptInputTokens] = useState<
+    number | undefined
+  >(undefined);
 
   const onAddPrompt = () => {
     if (!tempPromptId || !tempPromptName || tempPromptVersion == null) return;
@@ -27,6 +30,7 @@ export default function RunSetPromptsField({
       promptId: tempPromptId,
       promptName: tempPromptName,
       version: tempPromptVersion,
+      inputTokens: tempPromptInputTokens,
     };
 
     if (
@@ -40,6 +44,7 @@ export default function RunSetPromptsField({
     setTempPromptId(null);
     setTempPromptName(null);
     setTempPromptVersion(null);
+    setTempPromptInputTokens(undefined);
   };
 
   const onRemovePrompt = (promptId: string, version: number) => {
@@ -64,7 +69,10 @@ export default function RunSetPromptsField({
               setTempPromptId(id);
               setTempPromptName(name || null);
             }}
-            onSelectedPromptVersionChanged={setTempPromptVersion}
+            onSelectedPromptVersionChanged={(version, inputTokens) => {
+              setTempPromptVersion(version);
+              setTempPromptInputTokens(inputTokens);
+            }}
           />
           <Button
             type="button"

--- a/app/modules/runSets/helpers/calculateEstimates.ts
+++ b/app/modules/runSets/helpers/calculateEstimates.ts
@@ -14,38 +14,34 @@ interface CalculateEstimatesOptions {
 }
 
 export function calculateEstimates(
-  runDefinitions: Array<{ modelCode: string }>,
+  runDefinitions: Array<{
+    modelCode: string;
+    prompt?: { inputTokens?: number };
+  }>,
   selectedSessions: Array<{ inputTokens?: number }>,
   options?: CalculateEstimatesOptions,
 ): EstimationResult {
   const numSessions = selectedSessions.length;
   const verificationMultiplier = options?.shouldRunVerification ? 2 : 1;
 
-  const totalInputTokens = selectedSessions.reduce((sum, s) => {
+  const sessionInputTokens = selectedSessions.reduce((sum, s) => {
     return sum + (s.inputTokens ? s.inputTokens : AVG_TOKENS_PER_SESSION / 2);
   }, 0);
 
   const rawRatio = options?.outputToInputRatio;
   const ratio = rawRatio != null && rawRatio > 0 ? rawRatio : DEFAULT_RATIO;
-  const totalOutputTokens = totalInputTokens * ratio;
-
-  const definitionsByModel = new Map<string, number>();
-  for (const definition of runDefinitions) {
-    definitionsByModel.set(
-      definition.modelCode,
-      (definitionsByModel.get(definition.modelCode) || 0) + 1,
-    );
-  }
 
   let totalCost = 0;
-  for (const [modelCode, count] of definitionsByModel) {
+  for (const definition of runDefinitions) {
+    const promptTokens = definition.prompt?.inputTokens ?? 0;
+    const defInputTokens = sessionInputTokens + promptTokens * numSessions;
+    const defOutputTokens = defInputTokens * ratio;
     totalCost +=
-      count *
       verificationMultiplier *
       calculateCost({
-        modelCode,
-        inputTokens: totalInputTokens,
-        outputTokens: totalOutputTokens,
+        modelCode: definition.modelCode,
+        inputTokens: defInputTokens,
+        outputTokens: defOutputTokens,
       });
   }
 

--- a/app/modules/runSets/runSets.types.ts
+++ b/app/modules/runSets/runSets.types.ts
@@ -21,6 +21,7 @@ export interface PromptReference {
   promptId: string;
   promptName: string;
   version: number;
+  inputTokens?: number;
 }
 
 export interface PrefillData {

--- a/app/modules/runs/components/runCreator.tsx
+++ b/app/modules/runs/components/runCreator.tsx
@@ -56,7 +56,10 @@ export default function RunCreator({
   onRunNameChanged: (name: string) => void;
   onSelectedAnnotationTypeChanged: (selectedAnnotationType: string) => void;
   onSelectedPromptChanged: (selectedPrompt: string) => void;
-  onSelectedPromptVersionChanged: (selectedPromptVersion: number) => void;
+  onSelectedPromptVersionChanged: (
+    selectedPromptVersion: number,
+    inputTokens?: number,
+  ) => void;
   onSelectedModelChanged: (selectedModel: string) => void;
   onSelectedSessionsChanged: (sessions: SessionData[]) => void;
   shouldRunVerification: boolean;

--- a/app/modules/runs/containers/runCreator.container.tsx
+++ b/app/modules/runs/containers/runCreator.container.tsx
@@ -34,6 +34,9 @@ export default function ProjectRunCreatorContainer({
   const [selectedPromptVersion, setSelectedPromptVersion] = useState<
     number | null
   >(initialRun?.promptVersion || null);
+  const [selectedPromptInputTokens, setSelectedPromptInputTokens] = useState<
+    number | undefined
+  >(undefined);
   const [selectedModel, setSelectedModel] = useState(
     initialRun?.snapshot?.model?.code || getDefaultModelCode(),
   );
@@ -51,10 +54,15 @@ export default function ProjectRunCreatorContainer({
 
   const onSelectedPromptChanged = (selectedPrompt: string) => {
     setSelectedPrompt(selectedPrompt);
+    setSelectedPromptInputTokens(undefined);
   };
 
-  const onSelectedPromptVersionChanged = (selectedPromptVersion: number) => {
+  const onSelectedPromptVersionChanged = (
+    selectedPromptVersion: number,
+    inputTokens?: number,
+  ) => {
     setSelectedPromptVersion(selectedPromptVersion);
+    setSelectedPromptInputTokens(inputTokens);
   };
 
   const onSelectedModelChanged = (selectedModel: string) => {
@@ -69,17 +77,27 @@ export default function ProjectRunCreatorContainer({
 
   const estimation = useMemo(
     () =>
-      calculateEstimates([{ modelCode: selectedModel }], selectedSessions, {
-        shouldRunVerification,
-        avgSecondsPerSession,
-        outputToInputRatio,
-      }),
+      calculateEstimates(
+        [
+          {
+            modelCode: selectedModel,
+            prompt: { inputTokens: selectedPromptInputTokens },
+          },
+        ],
+        selectedSessions,
+        {
+          shouldRunVerification,
+          avgSecondsPerSession,
+          outputToInputRatio,
+        },
+      ),
     [
       selectedModel,
       selectedSessions,
       shouldRunVerification,
       avgSecondsPerSession,
       outputToInputRatio,
+      selectedPromptInputTokens,
     ],
   );
 


### PR DESCRIPTION
Fixes #1785

When a prompt version is saved, tokenize the rendered template (userPrompt + llmAnnotationSchema + responseSchema) and store inputTokens on the prompt version document.

Cost estimates now use `promptTokens + sessionTokens` per LLM call, giving much tighter estimates before any LlmCost data exists.

Includes a migration to backfill inputTokens on existing saved versions.