### PR TITLE
Credits should only be assigned to first (personal) team on signup

### DIFF
--- a/app/modules/authentication/helpers/githubStrategy.ts
+++ b/app/modules/authentication/helpers/githubStrategy.ts
@@ -99,7 +99,8 @@ const githubStrategy = new GitHubStrategy<any>(
           newUser._id,
           { isPersonal: true },
         );
-        await TeamBillingService.setupNewTeam(team._id, newUser._id);
+        await TeamBillingService.setupTeamBilling(team._id);
+        await TeamBillingService.assignInitialCredits(team._id, newUser._id);
         trackServerEvent({ name: "user_registered", userId: newUser._id });
         return (await UserService.findById(newUser._id))!;
       } else {

--- a/app/modules/billing/__tests__/billing.test.ts
+++ b/app/modules/billing/__tests__/billing.test.ts
@@ -238,6 +238,78 @@ describe("Billing", () => {
       const summary = await TeamBillingService.getBalanceSummary(teamId);
       expect(summary).toBeNull();
     });
+
+    describe("setupTeamBilling", () => {
+      it("assigns the default billing plan to the team", async () => {
+        await BillingPlanService.create({
+          name: "Standard",
+          markupRate: 1.5,
+          isDefault: true,
+        });
+
+        await TeamBillingService.setupTeamBilling(teamId);
+
+        const assignment = await TeamBillingPlanService.findByTeam(teamId);
+        expect(assignment).not.toBeNull();
+      });
+
+      it("does not create any credits", async () => {
+        await BillingPlanService.create({
+          name: "Standard",
+          markupRate: 1.5,
+          isDefault: true,
+        });
+
+        await TeamBillingService.setupTeamBilling(teamId);
+
+        const credits = await TeamCreditService.sumByTeam(teamId);
+        expect(credits).toBe(0);
+      });
+
+      it("does nothing when no default plan exists", async () => {
+        await TeamBillingService.setupTeamBilling(teamId);
+
+        const assignment = await TeamBillingPlanService.findByTeam(teamId);
+        expect(assignment).toBeNull();
+      });
+    });
+
+    describe("assignInitialCredits", () => {
+      it("assigns 75 credits when billing is disabled", async () => {
+        const original = process.env.BILLING_ENABLED;
+        delete process.env.BILLING_ENABLED;
+
+        await TeamBillingService.assignInitialCredits(teamId, userId);
+
+        const credits = await TeamCreditService.sumByTeam(teamId);
+        expect(credits).toBe(75);
+
+        process.env.BILLING_ENABLED = original;
+      });
+
+      it("assigns 10 credits when billing is enabled", async () => {
+        const original = process.env.BILLING_ENABLED;
+        process.env.BILLING_ENABLED = "true";
+
+        await TeamBillingService.assignInitialCredits(teamId, userId);
+
+        const credits = await TeamCreditService.sumByTeam(teamId);
+        expect(credits).toBe(10);
+
+        process.env.BILLING_ENABLED = original;
+      });
+
+      it("records the credit with the correct note and addedBy", async () => {
+        delete process.env.BILLING_ENABLED;
+
+        await TeamBillingService.assignInitialCredits(teamId, userId);
+
+        const all = await TeamCreditService.findByTeam(teamId);
+        expect(all).toHaveLength(1);
+        expect(all[0].note).toBe("Initial credits");
+        expect(all[0].addedBy).toBe(userId);
+      });
+    });
   });
 
   describe("TeamBillingService — period-aware balance", () => {

--- a/app/modules/billing/teamBilling.ts
+++ b/app/modules/billing/teamBilling.ts
@@ -55,7 +55,7 @@ export class TeamBillingService {
     return summary?.balance ?? 0;
   }
 
-  static async setupNewTeam(teamId: string, userId: string): Promise<void> {
+  static async setupTeamBilling(teamId: string): Promise<void> {
     const defaultPlan = await BillingPlanService.findDefault();
     if (!defaultPlan) {
       console.warn(
@@ -63,17 +63,19 @@ export class TeamBillingService {
       );
       return;
     }
+    await TeamBillingPlanService.assignPlan(teamId, defaultPlan._id);
+  }
 
+  static async assignInitialCredits(
+    teamId: string,
+    userId: string,
+  ): Promise<void> {
     const initialCredits = isBillingEnabled() ? 10 : 75;
-
-    await Promise.all([
-      TeamBillingPlanService.assignPlan(teamId, defaultPlan._id),
-      TeamCreditService.create({
-        team: teamId,
-        amount: initialCredits,
-        addedBy: userId,
-        note: "Initial credits",
-      }),
-    ]);
+    await TeamCreditService.create({
+      team: teamId,
+      amount: initialCredits,
+      addedBy: userId,
+      note: "Initial credits",
+    });
   }
 }

--- a/app/modules/teams/__tests__/teams.route.test.ts
+++ b/app/modules/teams/__tests__/teams.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { BillingPlanService } from "~/modules/billing/billingPlan";
 import { TeamBillingPlanService } from "~/modules/billing/teamBillingPlan";
+import { TeamCreditService } from "~/modules/billing/teamCredit";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import loginUser from "../../../../test/helpers/loginUser";
@@ -140,6 +141,37 @@ describe("teams.route", () => {
       const teamId = response.data.data._id;
       const assignment = await TeamBillingPlanService.findByTeam(teamId);
       expect(assignment).toBeDefined();
+    });
+
+    it("does not assign credits to the new team", async () => {
+      await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: true,
+      });
+
+      const admin = await UserService.create({
+        username: "admin",
+        role: "SUPER_ADMIN",
+      });
+
+      const cookieHeader = await loginUser(admin._id);
+
+      const response = (await action({
+        request: new Request("http://localhost/teams", {
+          method: "POST",
+          headers: { cookie: cookieHeader },
+          body: JSON.stringify({
+            intent: "CREATE_TEAM",
+            payload: { name: "new team" },
+          }),
+        }),
+        params: {},
+      } as any)) as any;
+
+      const teamId = response.data.data._id;
+      const credits = await TeamCreditService.sumByTeam(teamId);
+      expect(credits).toBe(0);
     });
 
     it("creates a team without a plan if no default plan exists", async () => {

--- a/app/modules/teams/containers/teams.route.tsx
+++ b/app/modules/teams/containers/teams.route.tsx
@@ -90,7 +90,7 @@ export async function action({ request }: Route.ActionArgs) {
         );
       }
       const team = await TeamService.createForUser(name, user._id);
-      await TeamBillingService.setupNewTeam(team._id, user._id);
+      await TeamBillingService.setupTeamBilling(team._id);
       return data({
         success: true,
         intent: "CREATE_TEAM",


### PR DESCRIPTION
Split setupNewTeam into setupTeamBilling (plan assignment only) and assignInitialCredits (credits only). New teams created via the teams route get a billing plan but no credits. Credits are only assigned in the GitHub strategy when a new user's personal team is created.

Fixes #1854