### PR TITLE
Default invite role to Member and unify role selector

### DIFF
--- a/app/modules/teams/components/inviteUserToTeamDialog.tsx
+++ b/app/modules/teams/components/inviteUserToTeamDialog.tsx
@@ -57,9 +57,6 @@ export default function InviteUserToTeamDialog({
               <br />
               Adding a name will help you identify who you have sent this invite
               link to.
-              <br />
-              <br />
-              More roles will be added soon.
             </span>
           )}
         </DialogDescription>

--- a/app/modules/teams/containers/inviteUserToTeamDialogContainer.tsx
+++ b/app/modules/teams/containers/inviteUserToTeamDialogContainer.tsx
@@ -8,7 +8,7 @@ export default function InviteUserToTeamDialogContainer({
 }: {
   teamId: string;
 }) {
-  const [role, setRole] = useState("ADMIN");
+  const [role, setRole] = useState("MEMBER");
   const [name, setName] = useState("");
   const [hasCopiedInviteLink, setHasCopiedInviteLink] = useState(false);
   const [isGeneratingInviteLink, setIsGeneratingInviteLink] = useState(false);

--- a/app/modules/teams/helpers/getRoles.ts
+++ b/app/modules/teams/helpers/getRoles.ts
@@ -1,6 +1,10 @@
 export default () => {
   return [
     {
+      value: "MEMBER",
+      name: "Member",
+    },
+    {
       value: "ADMIN",
       name: "Admin",
     },

--- a/app/modules/teams/helpers/renderAddUserToTeamDialogItem.tsx
+++ b/app/modules/teams/helpers/renderAddUserToTeamDialogItem.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/select";
 import type { User } from "~/modules/users/users.types";
 import type { TeamRole } from "../teams.types";
+import getRoles from "./getRoles";
 
 export default function renderAddUserToTeamDialogItem(
   user: User,
@@ -17,6 +18,8 @@ export default function renderAddUserToTeamDialogItem(
 ) {
   const role = selectedUsers[user._id];
   const isChecked = role !== undefined;
+
+  const roles = getRoles();
 
   return (
     <div className="flex items-center gap-3 p-3">
@@ -43,8 +46,11 @@ export default function renderAddUserToTeamDialogItem(
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="MEMBER">Member</SelectItem>
-              <SelectItem value="ADMIN">Admin</SelectItem>
+              {roles.map((r) => (
+                <SelectItem key={r.value} value={r.value}>
+                  {r.name}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
Fixes #1840

- Change invite default role from ADMIN to MEMBER
- Add MEMBER option to getRoles() and use it as single source of truth for both the invite dialog and the add-user-to-team dialog
- Remove "More roles will be added soon" placeholder text