### PR TITLE
Show remaining credits in run/run set creation

### DIFF
--- a/app/lib/schemas/run.schema.ts
+++ b/app/lib/schemas/run.schema.ts
@@ -54,6 +54,7 @@ export default new mongoose.Schema({
   hasErrored: { type: Boolean, default: false },
   isExporting: { type: Boolean, default: false },
   shouldRunVerification: { type: Boolean, default: false },
+  acknowledgedInsufficientCredits: { type: Boolean, default: false },
   startedAt: { type: Date },
   finishedAt: { type: Date },
   createdAt: { type: Date, default: Date.now },

--- a/app/modules/runSets/components/estimateSummary.tsx
+++ b/app/modules/runSets/components/estimateSummary.tsx
@@ -3,18 +3,22 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Clock, DollarSign } from "lucide-react";
+import { Clock, DollarSign, Wallet } from "lucide-react";
 import type { EstimationResult } from "~/modules/runSets/runSets.types";
 import { formatCost, formatTime } from "../helpers/formatEstimates";
 
 export default function EstimateSummary({
   estimation,
+  balance,
 }: {
   estimation: EstimationResult;
+  balance: number | null;
 }) {
   if (estimation.estimatedTimeSeconds === 0) {
     return null;
   }
+
+  const exceedsBalance = balance !== null && estimation.estimatedCost > balance;
 
   return (
     <div className="flex items-center gap-4">
@@ -49,6 +53,24 @@ export default function EstimateSummary({
           <p>Estimate based on avg 500 tokens/session</p>
         </TooltipContent>
       </Tooltip>
+
+      {balance !== null && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className={`flex cursor-help items-center gap-1 ${exceedsBalance ? "text-sandpiper-warning" : "text-sandpiper-info"}`}
+            >
+              <Wallet className="h-4 w-4" />
+              <span className="text-sm whitespace-nowrap">
+                ${formatCost(balance)} remaining
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Your team&apos;s remaining credits</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/app/modules/runSets/components/insufficientCreditsAlert.tsx
+++ b/app/modules/runSets/components/insufficientCreditsAlert.tsx
@@ -1,0 +1,43 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { AlertTriangle } from "lucide-react";
+import { useId } from "react";
+
+export default function InsufficientCreditsAlert({
+  exceedsBalance,
+  acknowledged,
+  onAcknowledgedChanged,
+}: {
+  exceedsBalance: boolean;
+  acknowledged: boolean;
+  onAcknowledgedChanged: (value: boolean) => void;
+}) {
+  const id = useId();
+
+  if (!exceedsBalance) return null;
+
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="h-4 w-4" />
+      <AlertDescription className="flex items-center justify-between gap-4">
+        <span>
+          Estimated cost exceeds your remaining credits. Runs may fail if
+          credits are exhausted.
+        </span>
+        <div className="flex shrink-0 items-center gap-2">
+          <Checkbox
+            id={id}
+            checked={acknowledged}
+            onCheckedChange={(checked) =>
+              onAcknowledgedChanged(Boolean(checked))
+            }
+          />
+          <Label htmlFor={id} className="text-sm font-normal whitespace-nowrap">
+            I understand and want to proceed
+          </Label>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/app/modules/runSets/components/runSetCreateRunsFooter.tsx
+++ b/app/modules/runSets/components/runSetCreateRunsFooter.tsx
@@ -2,8 +2,10 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { AlertTriangle, Info } from "lucide-react";
+import type { CreditAcknowledgment } from "../hooks/useCreditAcknowledgment";
 import type { EstimationResult, RunSet } from "../runSets.types";
 import EstimateSummary from "./estimateSummary";
+import InsufficientCreditsAlert from "./insufficientCreditsAlert";
 
 type FooterState = "ready" | "all_duplicates" | "empty";
 
@@ -14,6 +16,8 @@ interface RunSetCreateRunsFooterProps {
   newRunsCount: number;
   duplicateCount: number;
   estimation: EstimationResult;
+  balance: number;
+  creditAcknowledgment: CreditAcknowledgment;
   isLoading: boolean;
   isSubmitDisabled: boolean;
   onCancel: () => void;
@@ -27,6 +31,8 @@ export default function RunSetCreateRunsFooter({
   newRunsCount,
   duplicateCount,
   estimation,
+  balance,
+  creditAcknowledgment,
   isLoading,
   isSubmitDisabled,
   onCancel,
@@ -44,50 +50,56 @@ export default function RunSetCreateRunsFooter({
   const footerState = getFooterState();
 
   return (
-    <div className="bg-background sticky bottom-0 flex items-center gap-8 rounded-b-4xl border-t px-8 py-4">
-      <div className="flex-1">
-        {footerState === "ready" && (
-          <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
-            <div className="flex items-center justify-between gap-4">
-              <p className="text-foreground text-sm">
-                This will create <strong>{newRunsCount}</strong> new run(s) with{" "}
-                {selectedPromptsCount} prompt(s) × {selectedModelsCount}{" "}
-                model(s) across {runSet.sessions?.length || 0} session(s)
-                {duplicateCount > 0 && (
-                  <span className="text-sandpiper-warning">
-                    {" "}
-                    ({duplicateCount} duplicate combination(s) will be skipped)
-                  </span>
-                )}
-              </p>
-              <EstimateSummary estimation={estimation} />
-            </div>
+    <div className="bg-background sticky bottom-0 space-y-3 rounded-b-4xl border-t px-8 py-4">
+      {footerState === "ready" && (
+        <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-foreground text-sm">
+              This will create <strong>{newRunsCount}</strong> new run(s) with{" "}
+              {selectedPromptsCount} prompt(s) × {selectedModelsCount} model(s)
+              across {runSet.sessions?.length || 0} session(s)
+              {duplicateCount > 0 && (
+                <span className="text-sandpiper-warning">
+                  {" "}
+                  ({duplicateCount} duplicate combination(s) will be skipped)
+                </span>
+              )}
+            </p>
+            <EstimateSummary estimation={estimation} balance={balance} />
           </div>
-        )}
+        </div>
+      )}
 
-        {footerState === "all_duplicates" && (
-          <Alert variant="destructive">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertTitle>All combinations already exist</AlertTitle>
-            <AlertDescription>
-              All selected prompt+model combinations are already in this runSet.
-              Please select different prompts or models.
-            </AlertDescription>
-          </Alert>
-        )}
+      {footerState === "all_duplicates" && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>All combinations already exist</AlertTitle>
+          <AlertDescription>
+            All selected prompt+model combinations are already in this runSet.
+            Please select different prompts or models.
+          </AlertDescription>
+        </Alert>
+      )}
 
-        {footerState === "empty" && (
-          <Alert>
-            <Info className="h-4 w-4" />
-            <AlertTitle>Select prompts and models</AlertTitle>
-            <AlertDescription>
-              Choose at least one prompt and one model to create new runs.
-            </AlertDescription>
-          </Alert>
-        )}
-      </div>
+      {footerState === "empty" && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertTitle>Select prompts and models</AlertTitle>
+          <AlertDescription>
+            Choose at least one prompt and one model to create new runs.
+          </AlertDescription>
+        </Alert>
+      )}
 
-      <div className="flex gap-2">
+      {footerState === "ready" && (
+        <InsufficientCreditsAlert
+          exceedsBalance={creditAcknowledgment.exceedsBalance}
+          acknowledged={creditAcknowledgment.acknowledged}
+          onAcknowledgedChanged={creditAcknowledgment.setAcknowledged}
+        />
+      )}
+
+      <div className="flex justify-end gap-2">
         <Button variant="outline" onClick={onCancel}>
           Cancel
         </Button>

--- a/app/modules/runSets/components/runSetCreatorFooter.tsx
+++ b/app/modules/runSets/components/runSetCreatorFooter.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@/components/ui/button";
+import type { CreditAcknowledgment } from "~/modules/runSets/hooks/useCreditAcknowledgment";
 import type { EstimationResult } from "~/modules/runSets/runSets.types";
 import EstimateSummary from "./estimateSummary";
+import InsufficientCreditsAlert from "./insufficientCreditsAlert";
 import RunSetValidationAlert from "./runSetValidationAlert";
 
 export default function RunSetCreatorFooter({
@@ -8,6 +10,8 @@ export default function RunSetCreatorFooter({
   runsCount,
   selectedSessions,
   estimation,
+  balance,
+  creditAcknowledgment,
   isLoading,
   onCreateClicked,
 }: {
@@ -15,39 +19,51 @@ export default function RunSetCreatorFooter({
   runsCount: number;
   selectedSessions: string[];
   estimation: EstimationResult;
+  balance: number;
+  creditAcknowledgment: CreditAcknowledgment;
   isLoading: boolean;
   onCreateClicked: () => void;
 }) {
+  const hasValidationErrors =
+    !name.trim() || runsCount === 0 || selectedSessions.length === 0;
   const isSubmitDisabled =
     isLoading ||
-    !name.trim() ||
-    runsCount === 0 ||
-    selectedSessions.length === 0;
+    hasValidationErrors ||
+    (creditAcknowledgment.exceedsBalance && !creditAcknowledgment.acknowledged);
 
   return (
-    <div className="bg-background sticky bottom-0 flex items-center gap-8 rounded-b-4xl border-t px-8 py-4">
-      <div className="flex-1">
-        {isSubmitDisabled ? (
-          <RunSetValidationAlert
-            name={name}
-            runsCount={runsCount}
-            selectedSessions={selectedSessions}
-          />
-        ) : (
-          <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
-            <div className="flex items-center justify-between gap-4">
-              <p className="text-foreground text-sm">
-                This will create <strong>{runsCount}</strong> run(s) across{" "}
-                {selectedSessions.length} session(s)
-              </p>
-              <EstimateSummary estimation={estimation} />
-            </div>
+    <div className="bg-background sticky bottom-0 space-y-3 rounded-b-4xl border-t px-8 py-4">
+      {hasValidationErrors ? (
+        <RunSetValidationAlert
+          name={name}
+          runsCount={runsCount}
+          selectedSessions={selectedSessions}
+        />
+      ) : (
+        <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-foreground text-sm">
+              This will create <strong>{runsCount}</strong> run(s) across{" "}
+              {selectedSessions.length} session(s)
+            </p>
+            <EstimateSummary estimation={estimation} balance={balance} />
           </div>
-        )}
+        </div>
+      )}
+
+      {!hasValidationErrors && (
+        <InsufficientCreditsAlert
+          exceedsBalance={creditAcknowledgment.exceedsBalance}
+          acknowledged={creditAcknowledgment.acknowledged}
+          onAcknowledgedChanged={creditAcknowledgment.setAcknowledged}
+        />
+      )}
+
+      <div className="flex justify-end">
+        <Button size="lg" onClick={onCreateClicked} disabled={isSubmitDisabled}>
+          Create Run Set & Launch Runs
+        </Button>
       </div>
-      <Button size="lg" onClick={onCreateClicked} disabled={isSubmitDisabled}>
-        Create Run Set & Launch Runs
-      </Button>
     </div>
   );
 }

--- a/app/modules/runSets/containers/runSetCreate.route.tsx
+++ b/app/modules/runSets/containers/runSetCreate.route.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { getAvailableModels } from "~/modules/llm/modelRegistry";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import ProjectAuthorization from "~/modules/projects/authorization";
@@ -185,7 +186,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     }
   }
 
-  const [avgSecondsPerSession, outputToInputRatio, prefillSessions] =
+  const [avgSecondsPerSession, outputToInputRatio, prefillSessions, balance] =
     await Promise.all([
       RunService.getAverageSecondsPerSession(params.projectId),
       LlmCostService.getOutputToInputRatio(project.team as string),
@@ -195,6 +196,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             select: "_id inputTokens",
           })
         : Promise.resolve([]),
+      TeamBillingService.getBalance(project.team as string),
     ]);
 
   if (prefillData) {
@@ -205,7 +207,13 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     }));
   }
 
-  return { project, prefillData, avgSecondsPerSession, outputToInputRatio };
+  return {
+    project,
+    prefillData,
+    avgSecondsPerSession,
+    outputToInputRatio,
+    balance,
+  };
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -258,6 +266,8 @@ export async function action({ request, params }: Route.ActionArgs) {
         definitions,
         annotationType: annotationType as RunAnnotationType,
         shouldRunVerification: !!payload.shouldRunVerification,
+        acknowledgedInsufficientCredits:
+          !!payload.acknowledgedInsufficientCredits,
       });
 
       trackServerEvent({ name: "run_set_created", userId: user._id });
@@ -281,8 +291,13 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export default function RunSetCreateRoute() {
-  const { project, prefillData, avgSecondsPerSession, outputToInputRatio } =
-    useLoaderData<typeof loader>();
+  const {
+    project,
+    prefillData,
+    avgSecondsPerSession,
+    outputToInputRatio,
+    balance,
+  } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const fetcher = useFetcher();
 
@@ -337,6 +352,7 @@ export default function RunSetCreateRoute() {
         prefillData={prefillData}
         avgSecondsPerSession={avgSecondsPerSession}
         outputToInputRatio={outputToInputRatio}
+        balance={balance}
         onSubmit={handleSubmit}
         isLoading={fetcher.state !== "idle"}
         errors={(fetcher.data as any)?.errors || {}}

--- a/app/modules/runSets/containers/runSetCreateRuns.container.tsx
+++ b/app/modules/runSets/containers/runSetCreateRuns.container.tsx
@@ -13,6 +13,7 @@ import {
   buildUsedPromptModelSet,
   type PromptModelPair,
 } from "../helpers/getUsedPromptModels";
+import useCreditAcknowledgment from "../hooks/useCreditAcknowledgment";
 import type { PromptReference, RunSet } from "../runSets.types";
 
 interface RunSetCreateRunsContainerProps {
@@ -21,6 +22,7 @@ interface RunSetCreateRunsContainerProps {
   avgSecondsPerSession: number | null;
   outputToInputRatio: number | null;
   sessions: Array<{ inputTokens?: number }>;
+  balance: number;
   onSubmit: (requestBody: string) => void;
   onCancel: () => void;
   isLoading: boolean;
@@ -33,6 +35,7 @@ export default function RunSetCreateRunsContainer({
   avgSecondsPerSession,
   outputToInputRatio,
   sessions,
+  balance,
   onSubmit,
   onCancel,
   isLoading,
@@ -65,6 +68,11 @@ export default function RunSetCreateRunsContainer({
     outputToInputRatio,
   });
 
+  const creditAcknowledgment = useCreditAcknowledgment(
+    estimation.estimatedCost,
+    balance,
+  );
+
   const handleRemoveCard = (key: string) => {
     setRemovedKeys((prev) => new Set(prev).add(key));
   };
@@ -91,7 +99,8 @@ export default function RunSetCreateRunsContainer({
     isLoading ||
     selectedPrompts.length === 0 ||
     selectedModels.length === 0 ||
-    runDefinitions.length === 0;
+    runDefinitions.length === 0 ||
+    (creditAcknowledgment.exceedsBalance && !creditAcknowledgment.acknowledged);
 
   const handleCreateRuns = () => {
     const requestBody = JSON.stringify({
@@ -99,6 +108,7 @@ export default function RunSetCreateRunsContainer({
       payload: {
         definitions: runDefinitions,
         shouldRunVerification,
+        acknowledgedInsufficientCredits: creditAcknowledgment.acknowledged,
       },
     });
     onSubmit(requestBody);
@@ -149,6 +159,8 @@ export default function RunSetCreateRunsContainer({
         newRunsCount={runDefinitions.length}
         duplicateCount={duplicateDefinitions.length}
         estimation={estimation}
+        balance={balance}
+        creditAcknowledgment={creditAcknowledgment}
         isLoading={isLoading}
         isSubmitDisabled={isSubmitDisabled}
         onCancel={onCancel}

--- a/app/modules/runSets/containers/runSetCreateRuns.route.tsx
+++ b/app/modules/runSets/containers/runSetCreateRuns.route.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
@@ -51,7 +52,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const usedPromptModels = getUsedPromptModels(existingRuns);
 
-  const [avgSecondsPerSession, outputToInputRatio, sessions] =
+  const [avgSecondsPerSession, outputToInputRatio, sessions, balance] =
     await Promise.all([
       RunService.getAverageSecondsPerSession(params.projectId),
       LlmCostService.getOutputToInputRatio(project.team as string),
@@ -61,6 +62,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             select: "_id inputTokens",
           })
         : Promise.resolve([]),
+      TeamBillingService.getBalance(project.team as string),
     ]);
 
   return {
@@ -70,6 +72,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     avgSecondsPerSession,
     outputToInputRatio,
     sessions,
+    balance,
   };
 }
 
@@ -108,6 +111,8 @@ export async function action({ request, params }: Route.ActionArgs) {
         runSetId: params.runSetId,
         definitions,
         shouldRunVerification: !!payload.shouldRunVerification,
+        acknowledgedInsufficientCredits:
+          !!payload.acknowledgedInsufficientCredits,
       });
 
       if (!result.runSet) {
@@ -154,6 +159,7 @@ export default function RunSetCreateRunsRoute() {
     avgSecondsPerSession,
     outputToInputRatio,
     sessions,
+    balance,
   } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const fetcher = useFetcher();
@@ -219,6 +225,7 @@ export default function RunSetCreateRunsRoute() {
         avgSecondsPerSession={avgSecondsPerSession}
         outputToInputRatio={outputToInputRatio}
         sessions={sessions}
+        balance={balance}
         onSubmit={handleSubmit}
         onCancel={handleCancel}
         isLoading={fetcher.state !== "idle"}

--- a/app/modules/runSets/containers/runSetCreator.container.tsx
+++ b/app/modules/runSets/containers/runSetCreator.container.tsx
@@ -12,6 +12,7 @@ import RunSetCreatorVerificationToggle from "../components/runSetCreatorVerifica
 import RunSetRunPreview from "../components/runSetRunPreview";
 import buildDefinitionsFromSelection from "../helpers/buildDefinitionsFromSelection";
 import { calculateEstimates } from "../helpers/calculateEstimates";
+import useCreditAcknowledgment from "../hooks/useCreditAcknowledgment";
 import type { PrefillData, PromptReference } from "../runSets.types";
 
 function getDefaultName(prefillData?: PrefillData | null): string {
@@ -29,6 +30,7 @@ export default function RunSetCreatorContainer({
   prefillData,
   avgSecondsPerSession,
   outputToInputRatio,
+  balance,
   onSubmit,
   isLoading,
   errors,
@@ -36,6 +38,7 @@ export default function RunSetCreatorContainer({
   prefillData?: PrefillData | null;
   avgSecondsPerSession: number | null;
   outputToInputRatio: number | null;
+  balance: number;
   onSubmit: (requestBody: string) => void;
   isLoading: boolean;
   errors: Record<string, string>;
@@ -71,6 +74,11 @@ export default function RunSetCreatorContainer({
     avgSecondsPerSession,
     outputToInputRatio,
   });
+
+  const creditAcknowledgment = useCreditAcknowledgment(
+    estimation.estimatedCost,
+    balance,
+  );
 
   const handleAnnotationTypeChange = (type: string) => {
     setAnnotationType(type);
@@ -109,6 +117,7 @@ export default function RunSetCreatorContainer({
         definitions: runDefinitions,
         sessions: selectedSessions.map((s) => s._id),
         shouldRunVerification,
+        acknowledgedInsufficientCredits: creditAcknowledgment.acknowledged,
       },
     });
     onSubmit(requestBody);
@@ -166,6 +175,8 @@ export default function RunSetCreatorContainer({
         runsCount={runDefinitions.length}
         selectedSessions={selectedSessions.map((s) => s._id)}
         estimation={estimation}
+        balance={balance}
+        creditAcknowledgment={creditAcknowledgment}
         isLoading={isLoading}
         onCreateClicked={handleSubmit}
       />

--- a/app/modules/runSets/hooks/useCreditAcknowledgment.ts
+++ b/app/modules/runSets/hooks/useCreditAcknowledgment.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+export interface CreditAcknowledgment {
+  exceedsBalance: boolean;
+  acknowledged: boolean;
+  setAcknowledged: (value: boolean) => void;
+}
+
+export default function useCreditAcknowledgment(
+  estimatedCost: number,
+  balance: number,
+): CreditAcknowledgment {
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [prevEstimatedCost, setPrevEstimatedCost] = useState<number | null>(
+    null,
+  );
+
+  if (estimatedCost !== prevEstimatedCost) {
+    setPrevEstimatedCost(estimatedCost);
+    setAcknowledged(false);
+  }
+
+  return {
+    exceedsBalance: estimatedCost > balance,
+    acknowledged,
+    setAcknowledged,
+  };
+}

--- a/app/modules/runSets/runSet.ts
+++ b/app/modules/runSets/runSet.ts
@@ -129,6 +129,7 @@ export class RunSetService {
     definitions: RunDefinition[];
     annotationType: RunAnnotationType;
     shouldRunVerification?: boolean;
+    acknowledgedInsufficientCredits?: boolean;
   }): Promise<{ runSet: RunSet; errors: string[] }> {
     return createRunSetWithRuns(payload);
   }
@@ -202,6 +203,7 @@ export class RunSetService {
     runSetId: string;
     definitions: RunDefinition[];
     shouldRunVerification?: boolean;
+    acknowledgedInsufficientCredits?: boolean;
   }) {
     return createRunsForRunSetService(payload);
   }

--- a/app/modules/runSets/services/createRunSetWithRuns.server.ts
+++ b/app/modules/runSets/services/createRunSetWithRuns.server.ts
@@ -11,6 +11,7 @@ export interface CreateRunSetWithRunsPayload {
   definitions: RunDefinition[];
   annotationType: RunAnnotationType;
   shouldRunVerification?: boolean;
+  acknowledgedInsufficientCredits?: boolean;
 }
 
 export default async function createRunSetWithRuns(
@@ -44,6 +45,8 @@ export default async function createRunSetWithRuns(
         promptVersion: definition.prompt.version,
         modelCode: definition.modelCode,
         shouldRunVerification: !!payload.shouldRunVerification,
+        acknowledgedInsufficientCredits:
+          !!payload.acknowledgedInsufficientCredits,
       });
 
       generatedRunIds.push(newRun._id);

--- a/app/modules/runSets/services/createRunsForRunSet.server.ts
+++ b/app/modules/runSets/services/createRunsForRunSet.server.ts
@@ -12,6 +12,7 @@ export interface CreateRunsForRunSetPayload {
   runSetId: string;
   definitions: RunDefinition[];
   shouldRunVerification?: boolean;
+  acknowledgedInsufficientCredits?: boolean;
 }
 
 export interface CreateRunsForRunSetResult {
@@ -68,6 +69,8 @@ export default async function createRunsForRunSet(
         promptVersion: definition.prompt.version,
         modelCode: definition.modelCode,
         shouldRunVerification: !!payload.shouldRunVerification,
+        acknowledgedInsufficientCredits:
+          !!payload.acknowledgedInsufficientCredits,
       });
 
       generatedRunIds.push(newRun._id);

--- a/app/modules/runs/components/createRun.tsx
+++ b/app/modules/runs/components/createRun.tsx
@@ -12,6 +12,7 @@ export default function CreateRunComponent({
   duplicateWarnings = [],
   avgSecondsPerSession,
   outputToInputRatio,
+  balance,
 }: {
   breadcrumbs: Breadcrumb[];
   onStartRunClicked: (createRun: CreateRun) => void;
@@ -20,6 +21,7 @@ export default function CreateRunComponent({
   duplicateWarnings?: string[];
   avgSecondsPerSession: number | null;
   outputToInputRatio: number | null;
+  balance: number;
 }) {
   return (
     <div className="max-w-7xl p-8">
@@ -35,6 +37,7 @@ export default function CreateRunComponent({
         duplicateWarnings={duplicateWarnings}
         avgSecondsPerSession={avgSecondsPerSession}
         outputToInputRatio={outputToInputRatio}
+        balance={balance}
       />
     </div>
   );

--- a/app/modules/runs/components/runCreator.tsx
+++ b/app/modules/runs/components/runCreator.tsx
@@ -17,6 +17,8 @@ import AnnotationTypeSelectorContainer from "~/modules/prompts/containers/annoat
 import ModelSelectorContainer from "~/modules/prompts/containers/modelSelectorContainer";
 import PromptSelectorContainer from "~/modules/prompts/containers/promptSelectorContainer";
 import EstimateSummary from "~/modules/runSets/components/estimateSummary";
+import InsufficientCreditsAlert from "~/modules/runSets/components/insufficientCreditsAlert";
+import type { CreditAcknowledgment } from "~/modules/runSets/hooks/useCreditAcknowledgment";
 import type { EstimationResult } from "~/modules/runSets/runSets.types";
 import SessionSelectorContainer from "~/modules/sessions/containers/sessionSelectorContainer";
 import type { SessionData } from "~/modules/sessions/sessions.types";
@@ -31,6 +33,8 @@ export default function RunCreator({
   selectedModel,
   selectedSessions,
   estimation,
+  balance,
+  creditAcknowledgment,
   isSubmitting,
   isRunButtonDisabled,
   onRunNameChanged,
@@ -51,6 +55,8 @@ export default function RunCreator({
   selectedModel: string;
   selectedSessions: string[];
   estimation: EstimationResult;
+  balance: number;
+  creditAcknowledgment: CreditAcknowledgment;
   isSubmitting: boolean;
   isRunButtonDisabled: boolean;
   onRunNameChanged: (name: string) => void;
@@ -198,15 +204,22 @@ export default function RunCreator({
             selectedSessions={selectedSessions}
             onSelectedSessionsChanged={onSelectedSessionsChanged}
           />
-          <div className="mt-4 flex items-center justify-center gap-4">
-            <EstimateSummary estimation={estimation} />
-            <Button
-              size="sm"
-              disabled={isRunButtonDisabled}
-              onClick={onStartRunButtonClicked}
-            >
-              {isSubmitting ? "Starting run..." : "Start run"}
-            </Button>
+          <div className="mt-4 space-y-3">
+            <div className="flex items-center justify-center gap-4">
+              <EstimateSummary estimation={estimation} balance={balance} />
+              <Button
+                size="sm"
+                disabled={isRunButtonDisabled}
+                onClick={onStartRunButtonClicked}
+              >
+                {isSubmitting ? "Starting run..." : "Start run"}
+              </Button>
+            </div>
+            <InsufficientCreditsAlert
+              exceedsBalance={creditAcknowledgment.exceedsBalance}
+              acknowledged={creditAcknowledgment.acknowledged}
+              onAcknowledgedChanged={creditAcknowledgment.setAcknowledged}
+            />
           </div>
         </CardContent>
       </Card>

--- a/app/modules/runs/containers/createRun.route.tsx
+++ b/app/modules/runs/containers/createRun.route.tsx
@@ -6,6 +6,7 @@ import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.serve
 import useSubmitGuard from "~/modules/app/hooks/useSubmitGuard";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import { ProjectService } from "~/modules/projects/project";
 import createGeneralJob from "~/modules/queues/helpers/createGeneralJob";
@@ -41,10 +42,13 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const teamId =
     typeof project.team === "string" ? project.team : project.team._id;
-  const [avgSecondsPerSession, outputToInputRatio] = await Promise.all([
-    RunService.getAverageSecondsPerSession(params.projectId),
-    LlmCostService.getOutputToInputRatio(teamId),
-  ]);
+  const [avgSecondsPerSession, outputToInputRatio, balance] = await Promise.all(
+    [
+      RunService.getAverageSecondsPerSession(params.projectId),
+      LlmCostService.getOutputToInputRatio(teamId),
+      TeamBillingService.getBalance(teamId),
+    ],
+  );
 
   return {
     project,
@@ -52,6 +56,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     duplicateWarnings,
     avgSecondsPerSession,
     outputToInputRatio,
+    balance,
   };
 }
 
@@ -82,6 +87,8 @@ export async function action({ request, params }: Route.ActionArgs) {
         promptVersion: Number(promptVersion),
         modelCode: model,
         shouldRunVerification: !!payload.shouldRunVerification,
+        acknowledgedInsufficientCredits:
+          !!payload.acknowledgedInsufficientCredits,
       });
 
       await RunService.start(run);
@@ -106,6 +113,7 @@ export default function ProjectCreateRunRoute() {
     duplicateWarnings,
     avgSecondsPerSession,
     outputToInputRatio,
+    balance,
   } = useLoaderData();
   const fetcher = useFetcher();
   const navigate = useNavigate();
@@ -122,6 +130,7 @@ export default function ProjectCreateRunRoute() {
     selectedModel,
     selectedSessions,
     shouldRunVerification,
+    acknowledgedInsufficientCredits,
   }: CreateRunPayload) => {
     fetcher.submit(
       JSON.stringify({
@@ -134,6 +143,7 @@ export default function ProjectCreateRunRoute() {
           model: selectedModel,
           sessions: selectedSessions,
           shouldRunVerification,
+          acknowledgedInsufficientCredits,
         },
       }),
       { method: "POST", encType: "application/json" },
@@ -166,6 +176,7 @@ export default function ProjectCreateRunRoute() {
       duplicateWarnings={duplicateWarnings}
       avgSecondsPerSession={avgSecondsPerSession}
       outputToInputRatio={outputToInputRatio}
+      balance={balance}
     />
   );
 }

--- a/app/modules/runs/containers/runCreator.container.tsx
+++ b/app/modules/runs/containers/runCreator.container.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { getDefaultModelCode } from "~/modules/llm/modelRegistry";
 import type { CreateRun, Run } from "~/modules/runs/runs.types";
 import { calculateEstimates } from "~/modules/runSets/helpers/calculateEstimates";
+import useCreditAcknowledgment from "~/modules/runSets/hooks/useCreditAcknowledgment";
 import type { SessionData } from "~/modules/sessions/sessions.types";
 import RunCreator from "../components/runCreator";
 
@@ -12,6 +13,7 @@ interface RunCreatorContainerProps {
   duplicateWarnings?: string[];
   avgSecondsPerSession: number | null;
   outputToInputRatio: number | null;
+  balance: number;
 }
 
 export default function ProjectRunCreatorContainer({
@@ -21,6 +23,7 @@ export default function ProjectRunCreatorContainer({
   duplicateWarnings = [],
   avgSecondsPerSession,
   outputToInputRatio,
+  balance,
 }: RunCreatorContainerProps) {
   const [runName, setRunName] = useState(
     initialRun ? `${initialRun.name} (copy)` : "",
@@ -101,6 +104,11 @@ export default function ProjectRunCreatorContainer({
     ],
   );
 
+  const creditAcknowledgment = useCreditAcknowledgment(
+    estimation.estimatedCost,
+    balance,
+  );
+
   const onRunNameChangedHandler = (name: string) => {
     setRunName(name);
   };
@@ -114,14 +122,17 @@ export default function ProjectRunCreatorContainer({
       selectedModel,
       selectedSessions: selectedSessionIds,
       shouldRunVerification,
+      acknowledgedInsufficientCredits: creditAcknowledgment.acknowledged,
     });
   };
 
-  const isRunButtonDisabled = !(
-    selectedPrompt &&
-    selectedPromptVersion &&
-    selectedSessionIds.length > 0
-  );
+  const isRunButtonDisabled =
+    !(
+      selectedPrompt &&
+      selectedPromptVersion &&
+      selectedSessionIds.length > 0
+    ) ||
+    (creditAcknowledgment.exceedsBalance && !creditAcknowledgment.acknowledged);
 
   return (
     <RunCreator
@@ -133,6 +144,8 @@ export default function ProjectRunCreatorContainer({
       selectedModel={selectedModel}
       selectedSessions={selectedSessionIds}
       estimation={estimation}
+      balance={balance}
+      creditAcknowledgment={creditAcknowledgment}
       isSubmitting={isSubmitting}
       isRunButtonDisabled={isRunButtonDisabled || isSubmitting}
       onRunNameChanged={onRunNameChangedHandler}

--- a/app/modules/runs/run.ts
+++ b/app/modules/runs/run.ts
@@ -93,6 +93,7 @@ export class RunService {
       isRunning: false,
       isComplete: false,
       shouldRunVerification: !!props.shouldRunVerification,
+      acknowledgedInsufficientCredits: !!props.acknowledgedInsufficientCredits,
       isAdjudication: !!props.isAdjudication,
       adjudication: props.adjudication,
     });

--- a/app/modules/runs/runs.types.ts
+++ b/app/modules/runs/runs.types.ts
@@ -31,6 +31,7 @@ export interface Run {
   finishedAt: Date | string;
   isExporting: boolean;
   shouldRunVerification: boolean;
+  acknowledgedInsufficientCredits?: boolean;
 }
 
 export interface RunSession {
@@ -51,6 +52,7 @@ export interface CreateRun {
   selectedModel: string;
   selectedSessions: string[];
   shouldRunVerification: boolean;
+  acknowledgedInsufficientCredits?: boolean;
 }
 
 export interface CreateRunProps {
@@ -62,6 +64,7 @@ export interface CreateRunProps {
   promptVersion: number;
   modelCode: string;
   shouldRunVerification: boolean;
+  acknowledgedInsufficientCredits?: boolean;
   isAdjudication?: boolean;
   adjudication?: {
     sourceRuns: string[];


### PR DESCRIPTION
Display team balance alongside cost estimates when creating runs and run sets. When estimated cost exceeds remaining credits, show a warning alert with an acknowledgment checkbox that must be checked before proceeding. Track the acknowledgment as a flag on the run document.

Fixes #1863