### PR TITLE
Centralize Mongoose model declarations in service files

### DIFF
--- a/app/modules/humanAnnotations/services/createHumanRun.server.ts
+++ b/app/modules/humanAnnotations/services/createHumanRun.server.ts
@@ -1,10 +1,7 @@
-import mongoose from "mongoose";
-import runSchema from "~/lib/schemas/run.schema";
 import type { AnnotationSchemaItem } from "~/modules/prompts/prompts.types";
+import { RunService } from "~/modules/runs/run";
 import type { Run, RunSession } from "~/modules/runs/runs.types";
 import { SessionService } from "~/modules/sessions/session";
-
-const RunModel = mongoose.models.Run || mongoose.model("Run", runSchema);
 
 interface CreateHumanRunProps {
   project: string;
@@ -35,7 +32,7 @@ export default async function createHumanRun({
     });
   }
 
-  const doc = await RunModel.create({
+  return RunService.createFromData({
     project,
     name,
     annotationType,
@@ -55,6 +52,4 @@ export default async function createHumanRun({
     isComplete: false,
     shouldRunVerification: false,
   });
-
-  return doc.toJSON({ flattenObjectIds: true });
 }

--- a/app/modules/llmCosts/llmCost.ts
+++ b/app/modules/llmCosts/llmCost.ts
@@ -11,7 +11,7 @@ import sumCostByModel from "./services/sumCostByModel.server";
 import sumCostBySource from "./services/sumCostBySource.server";
 import sumCostOverTime from "./services/sumCostOverTime.server";
 
-const LlmCostModel =
+export const LlmCostModel =
   mongoose.models.LlmCost || mongoose.model("LlmCost", llmCostSchema);
 
 export class LlmCostService {

--- a/app/modules/llmCosts/services/sumCostByModel.server.ts
+++ b/app/modules/llmCosts/services/sumCostByModel.server.ts
@@ -1,9 +1,6 @@
 import mongoose from "mongoose";
-import llmCostSchema from "~/lib/schemas/llmCost.schema";
+import { LlmCostModel } from "../llmCost";
 import type { CostByModel } from "../llmCosts.types";
-
-const LlmCostModel =
-  mongoose.models.LlmCost || mongoose.model("LlmCost", llmCostSchema);
 
 export default async function sumCostByModel(
   teamId: string,

--- a/app/modules/llmCosts/services/sumCostBySource.server.ts
+++ b/app/modules/llmCosts/services/sumCostBySource.server.ts
@@ -1,9 +1,6 @@
 import mongoose from "mongoose";
-import llmCostSchema from "~/lib/schemas/llmCost.schema";
+import { LlmCostModel } from "../llmCost";
 import type { CostBySource } from "../llmCosts.types";
-
-const LlmCostModel =
-  mongoose.models.LlmCost || mongoose.model("LlmCost", llmCostSchema);
 
 export default async function sumCostBySource(
   teamId: string,

--- a/app/modules/llmCosts/services/sumCostOverTime.server.ts
+++ b/app/modules/llmCosts/services/sumCostOverTime.server.ts
@@ -1,9 +1,6 @@
 import mongoose from "mongoose";
-import llmCostSchema from "~/lib/schemas/llmCost.schema";
+import { LlmCostModel } from "../llmCost";
 import type { CostOverTime, SpendGranularity } from "../llmCosts.types";
-
-const LlmCostModel =
-  mongoose.models.LlmCost || mongoose.model("LlmCost", llmCostSchema);
 
 function getStartDate(granularity: SpendGranularity): Date {
   const now = new Date();

--- a/app/modules/runs/run.ts
+++ b/app/modules/runs/run.ts
@@ -10,7 +10,7 @@ import createRunAnnotations from "./services/createRunAnnotations.server";
 import getAverageSecondsPerSession from "./services/getAverageSecondsPerSession.server";
 import paginateSessionsService from "./services/paginateSessions.server";
 
-const RunModel = mongoose.models.Run || mongoose.model("Run", runSchema);
+export const RunModel = mongoose.models.Run || mongoose.model("Run", runSchema);
 
 export class RunService {
   private static toRun(doc: any): Run {
@@ -97,6 +97,11 @@ export class RunService {
       isAdjudication: !!props.isAdjudication,
       adjudication: props.adjudication,
     });
+    return this.toRun(doc);
+  }
+
+  static async createFromData(data: Record<string, unknown>): Promise<Run> {
+    const doc = await RunModel.create(data);
     return this.toRun(doc);
   }
 

--- a/app/modules/runs/services/aggregateProgress.server.ts
+++ b/app/modules/runs/services/aggregateProgress.server.ts
@@ -1,7 +1,5 @@
 import mongoose from "mongoose";
-import runSchema from "~/lib/schemas/run.schema";
-
-const RunModel = mongoose.models.Run || mongoose.model("Run", runSchema);
+import { RunModel } from "../run";
 
 export interface AggregateProgressResult {
   completedRuns: number;

--- a/app/modules/runs/services/getAverageSecondsPerSession.server.ts
+++ b/app/modules/runs/services/getAverageSecondsPerSession.server.ts
@@ -1,6 +1,5 @@
 import mongoose from "mongoose";
-
-const RunModel = mongoose.models.Run;
+import { RunModel } from "../run";
 
 export default async function getAverageSecondsPerSession(
   projectId: string,


### PR DESCRIPTION
Export models from module facades (run.ts, llmCost.ts) and import them in service files instead of re-declaring inline. Add RunService.createFromData() for cross-module use by humanAnnotations.

Fixes #1780