### PR TITLE
Delete orphaned project data and prevent future orphans

### DIFF
--- a/app/migrations/20260403172820-delete-orphaned-project-data.ts
+++ b/app/migrations/20260403172820-delete-orphaned-project-data.ts
@@ -1,0 +1,51 @@
+import type { Db } from "mongodb";
+import type {
+  MigrationFile,
+  MigrationResult,
+} from "~/modules/migrations/types";
+
+const ORPHANED_COLLECTIONS = ["sessions", "runs", "runsets", "evaluations"];
+
+export default {
+  id: "20260403172820-delete-orphaned-project-data",
+  name: "Delete Orphaned Project Data",
+  description:
+    "Delete documents from sessions, runs, runsets, and evaluations whose project no longer exists",
+
+  async up(db: Db): Promise<MigrationResult> {
+    console.log("Starting Delete Orphaned Project Data migration...");
+
+    const projectIds = await db
+      .collection("projects")
+      .find({}, { projection: { _id: 1 } })
+      .map((p) => p._id)
+      .toArray();
+
+    console.log(`Found ${projectIds.length} existing projects`);
+
+    const stats: Record<string, number> = {};
+
+    for (const collection of ORPHANED_COLLECTIONS) {
+      const result = await db
+        .collection(collection)
+        .deleteMany({ project: { $exists: true, $nin: projectIds } });
+
+      stats[collection] = result.deletedCount;
+      console.log(
+        `  ${collection}: deleted ${result.deletedCount} orphaned documents`,
+      );
+    }
+
+    const totalDeleted = Object.values(stats).reduce((sum, n) => sum + n, 0);
+
+    console.log(
+      `\n✓ Migration complete: ${totalDeleted} orphaned documents deleted`,
+    );
+
+    return {
+      success: true,
+      message: `Deleted ${totalDeleted} orphaned documents`,
+      stats,
+    };
+  },
+} satisfies MigrationFile;

--- a/app/modules/evaluations/evaluation.ts
+++ b/app/modules/evaluations/evaluation.ts
@@ -119,4 +119,9 @@ export class EvaluationService {
     const doc = await EvaluationModel.findByIdAndDelete(id);
     return doc ? this.toEvaluation(doc) : null;
   }
+
+  static async deleteByProject(projectId: string): Promise<number> {
+    const result = await EvaluationModel.deleteMany({ project: projectId });
+    return result.deletedCount || 0;
+  }
 }

--- a/app/modules/runs/run.ts
+++ b/app/modules/runs/run.ts
@@ -151,6 +151,11 @@ export class RunService {
     return doc ? this.toRun(doc) : null;
   }
 
+  static async deleteByProject(projectId: string): Promise<number> {
+    const result = await RunModel.deleteMany({ project: projectId });
+    return result.deletedCount || 0;
+  }
+
   static async findOne(match: Record<string, any>): Promise<Run | null> {
     const docs = await this.find({ match });
     return docs[0] || null;

--- a/workers/general/deleteProjectData.ts
+++ b/workers/general/deleteProjectData.ts
@@ -1,5 +1,9 @@
 import type { Job } from "bullmq";
+import { EvaluationService } from "~/modules/evaluations/evaluation";
 import { FileService } from "~/modules/files/file";
+import { RunService } from "~/modules/runs/run";
+import { RunSetService } from "~/modules/runSets/runSet";
+import { SessionService } from "~/modules/sessions/session";
 import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
 import { getProjectStorageDir } from "~/modules/uploads/helpers/projectStorage";
 
@@ -11,10 +15,14 @@ export default async function deleteProjectData(job: Job) {
 
   const storage = getStorageAdapter();
 
-  // Delete all files
-  await FileService.deleteByProject(projectId);
+  await Promise.all([
+    FileService.deleteByProject(projectId),
+    SessionService.deleteByProject(projectId),
+    RunService.deleteByProject(projectId),
+    RunSetService.deleteByProject(projectId),
+    EvaluationService.deleteByProject(projectId),
+  ]);
 
-  // Delete entire project storage directory
   const projectStorageDir = getProjectStorageDir(projectId);
   await storage.removeDir({ sourcePath: projectStorageDir });
 


### PR DESCRIPTION
Add migration to clean up sessions, runs, run sets, and evaluations whose project no longer exists. Fix deleteProjectData worker to delete all related documents when a project is deleted, not just files.