### PR TITLE
Fix run creation crash and align UX with RunSet creator

### DIFF
--- a/app/modules/runSets/components/estimateInfoBox.tsx
+++ b/app/modules/runSets/components/estimateInfoBox.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function EstimateInfoBox({ children }: { children: ReactNode }) {
+  return (
+    <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
+      {children}
+    </div>
+  );
+}

--- a/app/modules/runSets/components/runSetCreatorFooter.tsx
+++ b/app/modules/runSets/components/runSetCreatorFooter.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import type { CreditAcknowledgment } from "~/modules/runSets/hooks/useCreditAcknowledgment";
 import type { EstimationResult } from "~/modules/runSets/runSets.types";
+import EstimateInfoBox from "./estimateInfoBox";
 import EstimateSummary from "./estimateSummary";
 import InsufficientCreditsAlert from "./insufficientCreditsAlert";
 import RunSetValidationAlert from "./runSetValidationAlert";
@@ -40,7 +41,7 @@ export default function RunSetCreatorFooter({
           selectedSessions={selectedSessions}
         />
       ) : (
-        <div className="border-sandpiper-info/20 bg-sandpiper-info/5 rounded-lg border p-4">
+        <EstimateInfoBox>
           <div className="flex items-center justify-between gap-4">
             <p className="text-foreground text-sm">
               This will create <strong>{runsCount}</strong> run(s) across{" "}
@@ -48,7 +49,7 @@ export default function RunSetCreatorFooter({
             </p>
             <EstimateSummary estimation={estimation} balance={balance} />
           </div>
-        </div>
+        </EstimateInfoBox>
       )}
 
       {!hasValidationErrors && (

--- a/app/modules/runs/__tests__/createRun.route.test.ts
+++ b/app/modules/runs/__tests__/createRun.route.test.ts
@@ -6,7 +6,143 @@ import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import loginUser from "../../../../test/helpers/loginUser";
-import { loader } from "../containers/createRun.route";
+import { action, loader } from "../containers/createRun.route";
+
+describe("createRun.route action - CREATE_AND_START_RUN validation", () => {
+  let cookieHeader: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    await clearDocumentDB();
+
+    const user = await UserService.create({ username: "test_user", teams: [] });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+    projectId = project._id;
+    cookieHeader = await loginUser(user._id);
+  });
+
+  const makeRequest = (payload: object) =>
+    new Request("http://localhost/", {
+      method: "POST",
+      headers: { cookie: cookieHeader, "content-type": "application/json" },
+      body: JSON.stringify({ intent: "CREATE_AND_START_RUN", payload }),
+    });
+
+  it("returns 403 when user does not belong to the project team", async () => {
+    const otherUser = await UserService.create({
+      username: "other_user",
+      teams: [],
+    });
+    const otherCookie = await loginUser(otherUser._id);
+
+    const res = await action({
+      request: new Request("http://localhost/", {
+        method: "POST",
+        headers: { cookie: otherCookie, "content-type": "application/json" },
+        body: JSON.stringify({
+          intent: "CREATE_AND_START_RUN",
+          payload: {
+            name: "Valid Run Name",
+            annotationType: "PER_UTTERANCE",
+            prompt: new Types.ObjectId().toString(),
+            promptVersion: 1,
+            model: "gpt-4o",
+            sessions: [new Types.ObjectId().toString()],
+          },
+        }),
+      }),
+      params: { projectId },
+    } as any);
+
+    expect((res as any).data.errors.project).toBeDefined();
+  });
+
+  it("returns errors when name is missing", async () => {
+    const res = await action({
+      request: makeRequest({
+        annotationType: "PER_UTTERANCE",
+        prompt: new Types.ObjectId().toString(),
+        promptVersion: 1,
+        model: "gpt-4o",
+        sessions: [new Types.ObjectId().toString()],
+      }),
+      params: { projectId },
+    } as any);
+
+    expect((res as any).data.errors.name).toBeDefined();
+  });
+
+  it("returns errors when name is whitespace only", async () => {
+    const res = await action({
+      request: makeRequest({
+        name: "   ",
+        annotationType: "PER_UTTERANCE",
+        prompt: new Types.ObjectId().toString(),
+        promptVersion: 1,
+        model: "gpt-4o",
+        sessions: [new Types.ObjectId().toString()],
+      }),
+      params: { projectId },
+    } as any);
+
+    expect((res as any).data.errors.name).toBeDefined();
+  });
+
+  it("returns errors when name is shorter than 3 characters", async () => {
+    const res = await action({
+      request: makeRequest({
+        name: "ab",
+        annotationType: "PER_UTTERANCE",
+        prompt: new Types.ObjectId().toString(),
+        promptVersion: 1,
+        model: "gpt-4o",
+        sessions: [new Types.ObjectId().toString()],
+      }),
+      params: { projectId },
+    } as any);
+
+    expect((res as any).data.errors.name).toBeDefined();
+  });
+
+  it("returns errors when sessions are missing", async () => {
+    const res = await action({
+      request: makeRequest({
+        name: "Valid Run Name",
+        annotationType: "PER_UTTERANCE",
+        prompt: new Types.ObjectId().toString(),
+        promptVersion: 1,
+        model: "gpt-4o",
+        sessions: [],
+      }),
+      params: { projectId },
+    } as any);
+
+    expect((res as any).data.errors.sessions).toBeDefined();
+  });
+
+  it("returns errors when prompt is missing", async () => {
+    const res = await action({
+      request: makeRequest({
+        name: "Valid Run Name",
+        annotationType: "PER_UTTERANCE",
+        promptVersion: 1,
+        model: "gpt-4o",
+        sessions: [new Types.ObjectId().toString()],
+      }),
+      params: { projectId },
+    } as any);
+
+    expect((res as any).data.errors.prompt).toBeDefined();
+  });
+});
 
 describe("createRun.route loader", () => {
   beforeEach(async () => {

--- a/app/modules/runs/components/runCreator.tsx
+++ b/app/modules/runs/components/runCreator.tsx
@@ -11,18 +11,19 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Info } from "lucide-react";
-import { useState } from "react";
+
 import Flag from "~/modules/featureFlags/components/flag";
 import AnnotationTypeSelectorContainer from "~/modules/prompts/containers/annoationTypeSelectorContainer";
 import ModelSelectorContainer from "~/modules/prompts/containers/modelSelectorContainer";
 import PromptSelectorContainer from "~/modules/prompts/containers/promptSelectorContainer";
+import EstimateInfoBox from "~/modules/runSets/components/estimateInfoBox";
 import EstimateSummary from "~/modules/runSets/components/estimateSummary";
 import InsufficientCreditsAlert from "~/modules/runSets/components/insufficientCreditsAlert";
 import type { CreditAcknowledgment } from "~/modules/runSets/hooks/useCreditAcknowledgment";
 import type { EstimationResult } from "~/modules/runSets/runSets.types";
 import SessionSelectorContainer from "~/modules/sessions/containers/sessionSelectorContainer";
 import type { SessionData } from "~/modules/sessions/sessions.types";
-import RunNameAlert from "./runNameAlert";
+import RunValidationAlert from "./runValidationAlert";
 
 export default function RunCreator({
   duplicateWarnings = [],
@@ -72,15 +73,6 @@ export default function RunCreator({
   onShouldRunVerificationChanged: (value: boolean) => void;
   onStartRunButtonClicked: () => void;
 }) {
-  const [runNameTouched, setRunNameTouched] = useState(false);
-
-  const handleRunNameChange = (value: string) => {
-    if (!runNameTouched) {
-      setRunNameTouched(true);
-    }
-    onRunNameChanged(value);
-  };
-
   return (
     <div className="mx-0 w-full max-w-3xl pt-4 pb-8">
       {duplicateWarnings.length > 0 && (
@@ -111,11 +103,10 @@ export default function RunCreator({
               name="name"
               value={runName}
               autoComplete="off"
-              onChange={(e) => handleRunNameChange(e.target.value)}
+              onChange={(e) => onRunNameChanged(e.target.value)}
               className="w-96"
               autoFocus
             />
-            {runNameTouched && <RunNameAlert name={runName} />}
           </div>
         </CardContent>
       </Card>
@@ -205,21 +196,36 @@ export default function RunCreator({
             onSelectedSessionsChanged={onSelectedSessionsChanged}
           />
           <div className="mt-4 space-y-3">
-            <div className="flex items-center justify-center gap-4">
-              <EstimateSummary estimation={estimation} balance={balance} />
+            {runName.trim().length < 3 ||
+            !selectedPrompt ||
+            !selectedPromptVersion ||
+            selectedSessions.length === 0 ? (
+              <RunValidationAlert
+                runName={runName}
+                selectedPrompt={selectedPrompt}
+                selectedPromptVersion={selectedPromptVersion}
+                selectedSessions={selectedSessions}
+              />
+            ) : (
+              <EstimateInfoBox>
+                <div className="flex justify-end">
+                  <EstimateSummary estimation={estimation} balance={balance} />
+                </div>
+              </EstimateInfoBox>
+            )}
+            <InsufficientCreditsAlert
+              exceedsBalance={creditAcknowledgment.exceedsBalance}
+              acknowledged={creditAcknowledgment.acknowledged}
+              onAcknowledgedChanged={creditAcknowledgment.setAcknowledged}
+            />
+            <div className="flex justify-end">
               <Button
-                size="sm"
                 disabled={isRunButtonDisabled}
                 onClick={onStartRunButtonClicked}
               >
                 {isSubmitting ? "Starting run..." : "Start run"}
               </Button>
             </div>
-            <InsufficientCreditsAlert
-              exceedsBalance={creditAcknowledgment.exceedsBalance}
-              acknowledged={creditAcknowledgment.acknowledged}
-              onAcknowledgedChanged={creditAcknowledgment.setAcknowledged}
-            />
           </div>
         </CardContent>
       </Card>

--- a/app/modules/runs/components/runNameAlert.tsx
+++ b/app/modules/runs/components/runNameAlert.tsx
@@ -4,7 +4,7 @@ import { AlertCircleIcon, CheckCircle } from "lucide-react";
 const RunNameAlert = ({ name }: { name: string }) => {
   return (
     <>
-      {name.trim().length === 0 && (
+      {name.length === 0 && (
         <Alert variant="destructive">
           <AlertCircleIcon />
           <AlertDescription>Run name is required</AlertDescription>
@@ -22,7 +22,7 @@ const RunNameAlert = ({ name }: { name: string }) => {
         <Alert variant="destructive">
           <AlertCircleIcon />
           <AlertDescription>
-            Run name must be longer than 3 characters
+            Run name must be at least 3 characters
           </AlertDescription>
         </Alert>
       )}

--- a/app/modules/runs/components/runValidationAlert.tsx
+++ b/app/modules/runs/components/runValidationAlert.tsx
@@ -1,0 +1,40 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircleIcon } from "lucide-react";
+
+export default function RunValidationAlert({
+  runName,
+  selectedPrompt,
+  selectedPromptVersion,
+  selectedSessions,
+}: {
+  runName: string;
+  selectedPrompt: string | null;
+  selectedPromptVersion: number | null;
+  selectedSessions: string[];
+}) {
+  const missingFields: string[] = [];
+
+  if (runName.trim().length < 3) {
+    missingFields.push("Run name");
+  }
+  if (!selectedPrompt) {
+    missingFields.push("A prompt");
+  }
+  if (!selectedPromptVersion) {
+    missingFields.push("A prompt version");
+  }
+  if (selectedSessions.length === 0) {
+    missingFields.push("At least one session");
+  }
+
+  if (missingFields.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert variant="destructive">
+      <AlertCircleIcon />
+      <AlertDescription>Required: {missingFields.join(", ")}</AlertDescription>
+    </Alert>
+  );
+}

--- a/app/modules/runs/containers/createRun.route.tsx
+++ b/app/modules/runs/containers/createRun.route.tsx
@@ -1,6 +1,12 @@
 import map from "lodash/map";
 import { useEffect } from "react";
-import { redirect, useFetcher, useLoaderData, useNavigate } from "react-router";
+import {
+  data,
+  redirect,
+  useFetcher,
+  useLoaderData,
+  useNavigate,
+} from "react-router";
 import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import useSubmitGuard from "~/modules/app/hooks/useSubmitGuard";
@@ -8,6 +14,7 @@ import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
 import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
+import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import createGeneralJob from "~/modules/queues/helpers/createGeneralJob";
 import { RunService } from "~/modules/runs/run";
@@ -62,7 +69,16 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 export async function action({ request, params }: Route.ActionArgs) {
   const user = await getSessionUser({ request });
-  if (!user) throw new Error("Authentication required");
+  if (!user) return redirect("/");
+
+  const project = await ProjectService.findById(params.projectId);
+  if (!project) {
+    return data({ errors: { project: "Project not found" } }, { status: 404 });
+  }
+
+  if (!ProjectAuthorization.Runs.canManage(user, project)) {
+    return data({ errors: { project: "Access denied" } }, { status: 403 });
+  }
 
   const { intent, payload = {} } = await request.json();
 
@@ -71,11 +87,30 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   switch (intent) {
     case "CREATE_AND_START_RUN": {
-      if (typeof name !== "string") {
-        throw new Error("Run name is required and must be a string.");
+      const errors: Record<string, string> = {};
+
+      if (typeof name !== "string" || name.trim().length < 3) {
+        errors.name = "Run name must be at least 3 characters";
       }
+
       if (!["PER_UTTERANCE", "PER_SESSION"].includes(annotationType)) {
-        throw new Error("Invalid annotation type.");
+        errors.annotationType = "Invalid annotation type";
+      }
+
+      if (!prompt) {
+        errors.prompt = "A prompt is required";
+      }
+
+      if (!promptVersion) {
+        errors.promptVersion = "A prompt version is required";
+      }
+
+      if (!Array.isArray(sessions) || sessions.length === 0) {
+        errors.sessions = "At least one session is required";
+      }
+
+      if (Object.keys(errors).length > 0) {
+        return data({ errors }, { status: 400 });
       }
 
       const run = await RunService.create({
@@ -95,10 +130,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       trackServerEvent({ name: "run_created", userId: user._id });
       await createGeneralJob("TRACK_FIRST_RUN", { userId: user._id });
 
-      return {
-        intent: "CREATE_AND_START_RUN",
-        data: run,
-      };
+      return data({ intent: "CREATE_AND_START_RUN", data: run });
     }
     default: {
       return {};
@@ -114,7 +146,7 @@ export default function ProjectCreateRunRoute() {
     avgSecondsPerSession,
     outputToInputRatio,
     balance,
-  } = useLoaderData();
+  } = useLoaderData<typeof loader>();
   const fetcher = useFetcher();
   const navigate = useNavigate();
   const { isSubmitting, guard } = useSubmitGuard(
@@ -152,8 +184,15 @@ export default function ProjectCreateRunRoute() {
 
   useEffect(() => {
     if (fetcher.state !== "idle") return;
-    if (!fetcher.data || !("intent" in fetcher.data)) return;
-    if (fetcher.data.intent === "CREATE_AND_START_RUN") {
+    if (!fetcher.data) return;
+    if ("errors" in fetcher.data) {
+      toast.error(Object.values(fetcher.data.errors)[0] as string);
+      return;
+    }
+    if (
+      "intent" in fetcher.data &&
+      fetcher.data.intent === "CREATE_AND_START_RUN"
+    ) {
       toast.success("Run created and started");
       navigate(
         `/projects/${fetcher.data.data.project}/runs/${fetcher.data.data._id}`,

--- a/app/modules/runs/containers/runCreator.container.tsx
+++ b/app/modules/runs/containers/runCreator.container.tsx
@@ -109,10 +109,6 @@ export default function ProjectRunCreatorContainer({
     balance,
   );
 
-  const onRunNameChangedHandler = (name: string) => {
-    setRunName(name);
-  };
-
   const onStartRunButtonClicked = () => {
     onStartRunClicked({
       name: runName,
@@ -128,6 +124,7 @@ export default function ProjectRunCreatorContainer({
 
   const isRunButtonDisabled =
     !(
+      runName.trim().length >= 3 &&
       selectedPrompt &&
       selectedPromptVersion &&
       selectedSessionIds.length > 0
@@ -148,7 +145,7 @@ export default function ProjectRunCreatorContainer({
       creditAcknowledgment={creditAcknowledgment}
       isSubmitting={isSubmitting}
       isRunButtonDisabled={isRunButtonDisabled || isSubmitting}
-      onRunNameChanged={onRunNameChangedHandler}
+      onRunNameChanged={setRunName}
       onSelectedAnnotationTypeChanged={onSelectedAnnotationTypeChanged}
       onSelectedPromptChanged={onSelectedPromptChanged}
       onSelectedPromptVersionChanged={onSelectedPromptVersionChanged}


### PR DESCRIPTION
- Disable Start Run button when name is invalid, prompt/sessions missing
- Add RunValidationAlert near the button listing missing required fields; replaced by EstimateInfoBox with cost estimate when form is complete
- Server action now returns data({ errors }) instead of throwing on invalid input
- Add authorization check in action (ProjectAuthorization.Runs.canManage)
- Fix dead branch in RunNameAlert (name.length vs name.trim().length)
- Extract EstimateInfoBox shared component used by both Run and RunSet creators
- Use useLoaderData<typeof loader>() for proper typing
- Add action tests for all validation error cases

Fixes #1951