### PR TITLE
Display user info on admin list and add detail dialog

### DIFF
--- a/app/modules/users/components/userDetailDialog.tsx
+++ b/app/modules/users/components/userDetailDialog.tsx
@@ -1,0 +1,128 @@
+import {
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import getDateString from "~/modules/app/helpers/getDateString";
+import type { User } from "../users.types";
+
+const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <div className="grid grid-cols-[140px_1fr] gap-2 text-sm">
+    <span className="text-muted-foreground">{label}</span>
+    <span>{value ?? "—"}</span>
+  </div>
+);
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <div className="grid gap-2">
+    <h3 className="text-sm font-semibold">{title}</h3>
+    {children}
+  </div>
+);
+
+const UserDetailDialog = ({
+  user,
+  teamsByIds,
+}: {
+  user: User;
+  teamsByIds: Record<string, string>;
+}) => {
+  return (
+    <DialogContent className="flex max-h-[90vh] max-w-lg flex-col">
+      <DialogHeader>
+        <DialogTitle>User Details</DialogTitle>
+        <DialogDescription>{user.username}</DialogDescription>
+      </DialogHeader>
+
+      <div className="grid gap-6 overflow-y-auto py-2">
+        <Section title="Basic Info">
+          <Field label="Username" value={user.username} />
+          <Field label="Name" value={user.name || "—"} />
+          <Field label="Email" value={user.email} />
+          <Field label="Role" value={user.role || "USER"} />
+        </Section>
+
+        {(user.orcidId || user.githubId) && (
+          <Section title="Authentication">
+            {user.orcidId && <Field label="ORCID ID" value={user.orcidId} />}
+            {user.githubId ? (
+              <Field label="GitHub ID" value={String(user.githubId)} />
+            ) : null}
+          </Section>
+        )}
+
+        <Section title="Registration">
+          <Field label="Registered" value={user.isRegistered ? "Yes" : "No"} />
+          <Field
+            label="Invited at"
+            value={getDateString(user.invitedAt, "—")}
+          />
+          <Field
+            label="Registered at"
+            value={getDateString(user.registeredAt, "—")}
+          />
+        </Section>
+
+        <Section title="Questionnaire">
+          <Field label="Institution" value={user.institution || "—"} />
+          <Field label="Role" value={user.userRole || "—"} />
+          <Field
+            label="Use cases"
+            value={
+              user.useCases && user.useCases.length > 0
+                ? user.useCases.join(", ")
+                : "—"
+            }
+          />
+          <Field
+            label="Scholarship interest"
+            value={
+              user.scholarshipInterest === undefined
+                ? "—"
+                : user.scholarshipInterest
+                  ? "Yes"
+                  : "No"
+            }
+          />
+          <Field
+            label="Terms accepted"
+            value={getDateString(user.termsAcceptedAt, "—")}
+          />
+          <Field
+            label="Onboarding complete"
+            value={
+              user.onboardingComplete === undefined
+                ? "—"
+                : user.onboardingComplete
+                  ? "Yes"
+                  : "No"
+            }
+          />
+        </Section>
+
+        <Section title="Teams">
+          {user.teams && user.teams.length > 0 ? (
+            user.teams.map((t) => (
+              <Field
+                key={t.team}
+                label={t.role}
+                value={teamsByIds[t.team] ?? t.team}
+              />
+            ))
+          ) : (
+            <span className="text-muted-foreground text-sm">No teams</span>
+          )}
+        </Section>
+      </div>
+    </DialogContent>
+  );
+};
+
+export default UserDetailDialog;

--- a/app/modules/users/containers/adminUsers.route.tsx
+++ b/app/modules/users/containers/adminUsers.route.tsx
@@ -8,9 +8,11 @@ import { AuditService } from "~/modules/audits/audit";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import { userIsSuperAdmin } from "~/modules/authorization/helpers/superAdmin";
 import addDialog from "~/modules/dialogs/addDialog";
+import { TeamService } from "~/modules/teams/team";
 import UserManagementAuthorization from "../authorization";
 import AdminUsers from "../components/adminUsers";
 import EditUserDialog from "../components/editUserDialog";
+import UserDetailDialog from "../components/userDetailDialog";
 import { UserService } from "../user";
 import type { User } from "../users.types";
 import AssignSuperAdminDialogContainer from "./assignSuperAdminDialogContainer";
@@ -35,11 +37,19 @@ export async function loader({ request }: Route.LoaderArgs) {
   const query = buildQueryFromParams({
     match: {},
     queryParams,
-    searchableFields: ["username", "email", "name"],
+    searchableFields: ["username", "email", "name", "institution"],
     sortableFields: ["username", "name", "createdAt"],
   });
 
   const users = await UserService.paginate(query);
+
+  const teamIds = [
+    ...new Set(users.data.flatMap((u: User) => u.teams.map((t) => t.team))),
+  ];
+  const teams = await TeamService.find({ match: { _id: { $in: teamIds } } });
+  const teamsByIds: Record<string, string> = Object.fromEntries(
+    teams.map((t) => [t._id, t.name]),
+  );
 
   const auditQueryParams = getQueryParamsFromRequest(
     request,
@@ -69,6 +79,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     users,
     audits,
     currentUser: user,
+    teamsByIds,
   };
 }
 
@@ -258,7 +269,7 @@ export async function action({ request }: Route.ActionArgs) {
 export default function UserManagementRoute({
   loaderData,
 }: Route.ComponentProps) {
-  const { users, audits, currentUser } = loaderData;
+  const { users, audits, currentUser, teamsByIds } = loaderData;
   const fetcher = useFetcher();
 
   const {
@@ -361,7 +372,9 @@ export default function UserManagementRoute({
     const targetUser = users.data.find((u: User) => u._id === id);
     if (!targetUser) return;
 
-    if (action === "EDIT") {
+    if (action === "VIEW") {
+      addDialog(<UserDetailDialog user={targetUser} teamsByIds={teamsByIds} />);
+    } else if (action === "EDIT") {
       openEditUserDialog(targetUser);
     } else if (action === "ASSIGN_SUPER_ADMIN") {
       addDialog(

--- a/app/modules/users/helpers/getUserManagementItemActions.tsx
+++ b/app/modules/users/helpers/getUserManagementItemActions.tsx
@@ -6,7 +6,9 @@ export default function getUserManagementItemActions(
   item: User,
   currentUser: User,
 ): CollectionItemAction[] {
-  const actions: CollectionItemAction[] = [];
+  const actions: CollectionItemAction[] = [
+    { action: "VIEW", text: "View Details" },
+  ];
 
   if (UserManagementAuthorization.canUpdate(currentUser)) {
     actions.push({

--- a/app/modules/users/helpers/getUserManagementItemAttributes.tsx
+++ b/app/modules/users/helpers/getUserManagementItemAttributes.tsx
@@ -10,6 +10,7 @@ export default function getUserManagementItemAttributes(item: User) {
       {
         text: item.role || "USER",
       },
+      ...(item.institution ? [{ text: item.institution }] : []),
       {
         text: `Created ${getDateString(item.createdAt)}`,
       },


### PR DESCRIPTION
## Summary

- Institution now appears in each user's list item meta (when present) and is included in search
- New "View Details" action opens a read-only dialog with full user info: basic info, authentication (ORCID/GitHub), registration dates, questionnaire answers, and team memberships with names
- Loader batch-fetches team names for the current page so the dialog can show team names instead of raw IDs

Fixes #1958