### PR TITLE
Display team balance on team list

### DIFF
--- a/app/modules/teams/__tests__/teams.route.test.ts
+++ b/app/modules/teams/__tests__/teams.route.test.ts
@@ -47,6 +47,65 @@ describe("teams.route", () => {
       expect(result.teams.data.map((t: any) => t._id)).toContain(team2._id);
     });
 
+    it("returns balances for each team when user is super admin", async () => {
+      const plan = await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1,
+        isDefault: true,
+      });
+
+      const admin = await UserService.create({
+        username: "admin",
+        role: "SUPER_ADMIN",
+        teams: [],
+      });
+
+      const team1 = await TeamService.create({ name: "team 1" });
+      const team2 = await TeamService.create({ name: "team 2" });
+
+      await TeamBillingPlanService.assignPlan(team1._id, plan._id);
+      await TeamBillingPlanService.assignPlan(team2._id, plan._id);
+      await TeamCreditService.create({
+        team: team1._id,
+        amount: 50,
+        addedBy: admin._id,
+      });
+
+      const cookieHeader = await loginUser(admin._id);
+
+      const result = (await loader({
+        request: new Request("http://localhost/teams", {
+          headers: { cookie: cookieHeader },
+        }),
+        params: {},
+      } as any)) as any;
+
+      expect(result.balances).toBeDefined();
+      expect(result.balances[team1._id]).toBe(50);
+      expect(result.balances[team2._id]).toBe(0);
+    });
+
+    it("returns empty balances for non-super admin", async () => {
+      const team1 = await TeamService.create({ name: "team 1" });
+
+      const user = await UserService.create({
+        username: "user1",
+        role: "USER",
+        teams: [{ team: team1._id, role: "ADMIN" }],
+      });
+
+      const cookieHeader = await loginUser(user._id);
+
+      const result = (await loader({
+        request: new Request("http://localhost/teams", {
+          headers: { cookie: cookieHeader },
+        }),
+        params: {},
+      } as any)) as any;
+
+      expect(result.balances).toEqual({});
+    });
+
     it("returns only user's teams for regular user", async () => {
       const team1 = await TeamService.create({ name: "team 1" });
       await TeamService.create({ name: "team 2" });

--- a/app/modules/teams/components/teams.tsx
+++ b/app/modules/teams/components/teams.tsx
@@ -14,6 +14,7 @@ import type { Team } from "../teams.types";
 interface TeamsProps {
   teams: Team[];
   user: User;
+  balances: Record<string, number>;
   breadcrumbs: Breadcrumb[];
   searchValue: string;
   currentPage: number;
@@ -32,6 +33,7 @@ interface TeamsProps {
 export default function Teams({
   teams,
   user,
+  balances,
   breadcrumbs,
   filtersValues,
   sortValue,
@@ -68,7 +70,9 @@ export default function Teams({
         totalPages={totalPages}
         emptyAttributes={getTeamsEmptyAttributes()}
         isSyncing={isSyncing}
-        getItemAttributes={getTeamsItemAttributes}
+        getItemAttributes={(item) =>
+          getTeamsItemAttributes(item, balances[item._id])
+        }
         getItemActions={(item) => getTeamsItemActions(item, user)}
         onActionClicked={onActionClicked}
         onItemActionClicked={onItemActionClicked}

--- a/app/modules/teams/containers/teams.route.tsx
+++ b/app/modules/teams/containers/teams.route.tsx
@@ -53,7 +53,19 @@ export async function loader({ request }: Route.LoaderArgs) {
     page: query.page,
   });
 
-  return { teams };
+  const balances: Record<string, number> =
+    userSession.role === "SUPER_ADMIN"
+      ? Object.fromEntries(
+          await Promise.all(
+            teams.data.map(async (team) => [
+              team._id,
+              await TeamBillingService.getBalance(team._id),
+            ]),
+          ),
+        )
+      : {};
+
+  return { teams, balances };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -126,7 +138,7 @@ export function HydrateFallback() {
 }
 
 export default function TeamsRoute({ loaderData }: Route.ComponentProps) {
-  const { teams } = loaderData;
+  const { teams, balances } = loaderData;
   const user = useContext(AuthenticationContext) as User;
   const fetcher = useFetcher();
   const navigate = useNavigate();
@@ -240,6 +252,7 @@ export default function TeamsRoute({ loaderData }: Route.ComponentProps) {
     <Teams
       teams={teams?.data}
       user={user}
+      balances={balances}
       breadcrumbs={breadcrumbs}
       searchValue={searchValue}
       currentPage={currentPage}

--- a/app/modules/teams/helpers/getTeamsItemAttributes.tsx
+++ b/app/modules/teams/helpers/getTeamsItemAttributes.tsx
@@ -1,15 +1,19 @@
 import getDateString from "~/modules/app/helpers/getDateString";
 import type { Team } from "../teams.types";
 
-export default function getTeamsItemAttributes(item: Team) {
+export default function getTeamsItemAttributes(
+  item: Team,
+  balance: number | undefined,
+) {
   return {
     id: item._id,
     title: item.name,
     to: `/teams/${item._id}/users`,
     meta: [
-      {
-        text: `Created at - ${getDateString(item.createdAt)}`,
-      },
+      { text: `Created at - ${getDateString(item.createdAt)}` },
+      ...(balance !== undefined
+        ? [{ text: `Balance: $${balance.toFixed(2)}` }]
+        : []),
     ],
   };
 }


### PR DESCRIPTION
## Summary

- Fetches balance for each team in the loader concurrently via `Promise.all`, gated to `SUPER_ADMIN` only to avoid unnecessary DB load for regular users
- Passes balances as a `Record<string, number>` map to the `Teams` component and into `getTeamsItemAttributes`
- Balance appears as a `Balance: $X.XX` meta item on each team row in the list

Fixes #1959