### PR TITLE
Fix missing auth checks in run, sessions, and runSetOverview actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -608,7 +608,30 @@ export const ProjectAuthorization = {
 Authorization checks are done in route loaders/actions:
 
 - **Loaders**: Use `redirect()` for auth failures
-- **Actions**: Return `data({ errors: {...} }, { status: 400/403/500 })` for errors
+- **Actions**: Use `redirect()` for auth/authorization failures; return `data({ errors: {...} }, { status: 400/403/500 })` for business logic errors
+
+**CRITICAL: Actions are not protected by the loader.** React Router loaders and actions are independent HTTP endpoints. A user can POST directly to a route without triggering the loader — so an action that relies on the loader's auth check has no auth at all. Every action must independently verify authentication (and authorization where the resource is team/user-scoped):
+
+```typescript
+// ✅ Action must check auth independently — never rely on the loader
+export async function action({ request, params }: Route.ActionArgs) {
+  const user = (await getSessionUser({ request })) as User;
+  if (!user) return redirect("/");
+
+  const project = await ProjectService.findById(params.projectId);
+  if (!project || !ProjectAuthorization.canView(user, project)) {
+    return redirect("/");
+  }
+
+  // ... rest of action
+}
+
+// ❌ This action has no auth — the loader's check doesn't protect it
+export async function action({ request, params }: Route.ActionArgs) {
+  const { intent } = await request.json(); // Anyone can call this
+  await RunService.deleteById(params.runId);
+}
+```
 
 ### Human Runs (`isHuman: true`)
 

--- a/app/modules/runSets/__tests__/runSetOverview.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetOverview.route.test.ts
@@ -13,7 +13,7 @@ import type { User } from "~/modules/users/users.types";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
 import loginUser from "../../../../test/helpers/loginUser";
-import { loader } from "../containers/runSetOverview.route";
+import { action, loader } from "../containers/runSetOverview.route";
 
 type LoaderResult = {
   runs: { data: Run[]; count: number; totalPages: number };
@@ -298,5 +298,80 @@ describe("runSetOverview.route loader", () => {
     const data = res as LoaderResult;
     expect(data.sessions.data).toHaveLength(1);
     expect(data.sessions.totalPages).toBe(1);
+  });
+});
+
+describe("runSetOverview.route action", () => {
+  let user: User;
+  let team: Team;
+  let project: Project;
+  let runSet: RunSet;
+  let run: Run;
+  let cookieHeader: string;
+
+  beforeEach(async () => {
+    await clearDocumentDB();
+
+    user = await UserService.create({ username: "test_user", teams: [] });
+    team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+    run = await createTestRun({
+      name: "Test Run",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      isRunning: false,
+      isComplete: false,
+    });
+    runSet = await RunSetService.create({
+      name: "Test Run Set",
+      project: project._id,
+      sessions: [],
+      runs: [run._id],
+      annotationType: "PER_UTTERANCE",
+    });
+    cookieHeader = await loginUser(user._id);
+  });
+
+  it("redirects to / when unauthenticated for REMOVE_RUN_FROM_RUN_SET", async () => {
+    const res = await action({
+      request: new Request("http://localhost/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          intent: "REMOVE_RUN_FROM_RUN_SET",
+          payload: { runId: run._id },
+        }),
+      }),
+      params: { projectId: project._id, runSetId: runSet._id },
+    } as any);
+
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).headers.get("Location")).toBe("/");
+  });
+
+  it("removes run from run set when authenticated", async () => {
+    const res = await action({
+      request: new Request("http://localhost/", {
+        method: "POST",
+        headers: { cookie: cookieHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          intent: "REMOVE_RUN_FROM_RUN_SET",
+          payload: { runId: run._id },
+        }),
+      }),
+      params: { projectId: project._id, runSetId: runSet._id },
+    } as any);
+
+    expect(res).not.toBeInstanceOf(Response);
+    expect((res as any).intent).toBe("REMOVE_RUN_FROM_RUN_SET");
+    const updated = await RunSetService.findById(runSet._id);
+    expect(updated?.runs).not.toContain(run._id);
   });
 });

--- a/app/modules/runSets/containers/runSetOverview.route.tsx
+++ b/app/modules/runSets/containers/runSetOverview.route.tsx
@@ -95,6 +95,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
+  const user = await getSessionUser({ request });
+  if (!user) return redirect("/");
+
   const { intent, payload = {} } = await request.json();
 
   switch (intent) {

--- a/app/modules/runs/__tests__/run.route.test.ts
+++ b/app/modules/runs/__tests__/run.route.test.ts
@@ -209,6 +209,88 @@ describe("run.route action", () => {
     await clearDocumentDB();
   });
 
+  it("redirects to / when unauthenticated", async () => {
+    const owner = await UserService.create({ username: "owner", teams: [] });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(owner._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: owner._id,
+      team: team._id,
+    });
+    const run = await RunService.create({
+      project: project._id,
+      name: "Test Run",
+      sessions: [],
+      annotationType: "PER_UTTERANCE",
+      prompt: new Types.ObjectId().toString(),
+      promptVersion: 1,
+      modelCode: "gpt-4",
+      shouldRunVerification: false,
+    });
+
+    const res = await action({
+      request: new Request(
+        "http://localhost/projects/" + project._id + "/runs/" + run._id,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ intent: "DELETE_RUN", payload: {} }),
+        },
+      ),
+      params: { projectId: project._id, runId: run._id },
+    } as any);
+
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).headers.get("Location")).toBe("/");
+  });
+
+  it("redirects to / when user is not in project team", async () => {
+    const owner = await UserService.create({ username: "owner", teams: [] });
+    const team = await TeamService.create({ name: "Private Team" });
+    await UserService.updateById(owner._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const project = await ProjectService.create({
+      name: "Private Project",
+      createdBy: owner._id,
+      team: team._id,
+    });
+    const run = await RunService.create({
+      project: project._id,
+      name: "Private Run",
+      sessions: [],
+      annotationType: "PER_UTTERANCE",
+      prompt: new Types.ObjectId().toString(),
+      promptVersion: 1,
+      modelCode: "gpt-4",
+      shouldRunVerification: false,
+    });
+
+    const otherUser = await UserService.create({
+      username: "other_user",
+      teams: [],
+    });
+    const cookieHeader = await loginUser(otherUser._id);
+
+    const res = await action({
+      request: new Request(
+        "http://localhost/projects/" + project._id + "/runs/" + run._id,
+        {
+          method: "POST",
+          headers: { cookie: cookieHeader, "Content-Type": "application/json" },
+          body: JSON.stringify({ intent: "DELETE_RUN", payload: {} }),
+        },
+      ),
+      params: { projectId: project._id, runId: run._id },
+    } as any);
+
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).headers.get("Location")).toBe("/");
+  });
+
   it("GET_ALL_RUN_SETS returns all run sets containing the run", async () => {
     const user = await UserService.create({ username: "test_user", teams: [] });
     const team = await TeamService.create({ name: "Test Team" });
@@ -240,12 +322,14 @@ describe("run.route action", () => {
       annotationType: "PER_UTTERANCE",
     });
 
+    const cookieHeader = await loginUser(user._id);
+
     const res = await action({
       request: new Request(
         "http://localhost/projects/" + project._id + "/runs/" + run._id,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { cookie: cookieHeader, "Content-Type": "application/json" },
           body: JSON.stringify({ intent: "GET_ALL_RUN_SETS" }),
         },
       ),
@@ -281,12 +365,14 @@ describe("run.route action", () => {
       shouldRunVerification: false,
     });
 
+    const cookieHeader = await loginUser(user._id);
+
     const res = await action({
       request: new Request(
         "http://localhost/projects/" + project._id + "/runs/" + run._id,
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: { cookie: cookieHeader, "Content-Type": "application/json" },
           body: JSON.stringify({
             intent: "UPDATE_RUN",
             payload: { name: "New Name" },
@@ -327,12 +413,14 @@ describe("run.route action", () => {
       shouldRunVerification: false,
     });
 
+    const cookieHeader = await loginUser(user._id);
+
     const res = await action({
       request: new Request(
         "http://localhost/projects/" + project._id + "/runs/" + run._id,
         {
           method: "DELETE",
-          headers: { "Content-Type": "application/json" },
+          headers: { cookie: cookieHeader, "Content-Type": "application/json" },
           body: JSON.stringify({ intent: "DELETE_RUN", payload: {} }),
         },
       ),

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -13,9 +13,11 @@ import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromR
 import triggerDownload from "~/modules/app/helpers/triggerDownload";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
+import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
 import addDialog from "~/modules/dialogs/addDialog";
 import useHasFeatureFlag from "~/modules/featureFlags/hooks/useHasFeatureFlag";
+import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import exportRun from "~/modules/runs/helpers/exportRun";
 import { useCreateRunSetForRun } from "~/modules/runs/hooks/useCreateRunSetForRun";
@@ -94,6 +96,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
+  const user = await getSessionUser({ request });
+  if (!user) return redirect("/");
+
+  const project = await ProjectService.findById(params.projectId);
+  if (!project || !ProjectAuthorization.Runs.canManage(user, project)) {
+    return redirect("/");
+  }
+
   const { intent, payload = {} } = await request.json();
 
   const { exportType } = payload;

--- a/app/modules/sessions/__tests__/sessions.route.test.ts
+++ b/app/modules/sessions/__tests__/sessions.route.test.ts
@@ -6,7 +6,7 @@ import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import loginUser from "../../../../test/helpers/loginUser";
-import { loader } from "../containers/sessions.route";
+import { action, loader } from "../containers/sessions.route";
 
 describe("sessions.route loader", () => {
   beforeEach(async () => {
@@ -24,6 +24,29 @@ describe("sessions.route loader", () => {
         { headers: { cookie: cookieHeader } },
       ),
       params: { id: fakeProjectId },
+    } as any);
+
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).headers.get("Location")).toBe("/");
+  });
+
+  it("redirects to / when unauthenticated", async () => {
+    const user = await UserService.create({ username: "test_user" });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+
+    const res = await loader({
+      request: new Request(
+        "http://localhost/projects/" + project._id + "/sessions",
+      ),
+      params: { id: project._id.toString() },
     } as any);
 
     expect(res).toBeInstanceOf(Response);
@@ -56,5 +79,73 @@ describe("sessions.route loader", () => {
 
     expect(res).not.toBeInstanceOf(Response);
     expect((res as any).sessions).toBeDefined();
+  });
+});
+
+describe("sessions.route action", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  it("redirects to / when unauthenticated for RE_RUN", async () => {
+    const user = await UserService.create({ username: "owner", teams: [] });
+    const team = await TeamService.create({ name: "Test Team" });
+    await UserService.updateById(user._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const project = await ProjectService.create({
+      name: "Test Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+
+    const res = await action({
+      request: new Request(
+        "http://localhost/projects/" + project._id + "/sessions",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ intent: "RE_RUN" }),
+        },
+      ),
+      params: { id: project._id.toString() },
+    } as any);
+
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).headers.get("Location")).toBe("/");
+  });
+
+  it("redirects to / when user cannot view project for RE_RUN", async () => {
+    const owner = await UserService.create({ username: "owner", teams: [] });
+    const team = await TeamService.create({ name: "Private Team" });
+    await UserService.updateById(owner._id, {
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const project = await ProjectService.create({
+      name: "Private Project",
+      createdBy: owner._id,
+      team: team._id,
+    });
+
+    const otherUser = await UserService.create({
+      username: "other_user",
+      teams: [],
+    });
+    const cookieHeader = await loginUser(otherUser._id);
+
+    const res = await action({
+      request: new Request(
+        "http://localhost/projects/" + project._id + "/sessions",
+        {
+          method: "POST",
+          headers: { cookie: cookieHeader, "Content-Type": "application/json" },
+          body: JSON.stringify({ intent: "RE_RUN" }),
+        },
+      ),
+      params: { id: project._id.toString() },
+    } as any);
+
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).headers.get("Location")).toBe("/");
   });
 });

--- a/app/modules/sessions/containers/sessions.route.tsx
+++ b/app/modules/sessions/containers/sessions.route.tsx
@@ -51,6 +51,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
+  const user = (await getSessionUser({ request })) as User;
+  if (!user) return redirect("/");
+
+  const project = await ProjectService.findById(params.id);
+  if (!project || !ProjectAuthorization.canView(user, project)) {
+    return redirect("/");
+  }
+
   const { intent } = await request.json();
 
   switch (intent) {


### PR DESCRIPTION
## Summary

- `run.route.tsx` action had no auth — unauthenticated/cross-team users could stop, delete, export, or rename any run
- `sessions.route.tsx` action had no auth — unauthenticated users could trigger file conversion jobs on any project
- `runSetOverview.route.tsx` action had no auth — unauthenticated users could remove any run from any run set

Each action was relying on the loader's auth check, which does not protect actions (they are independent HTTP endpoints).

Closes #1967