### PR TITLE
Style breadcrumb ancestor links as muted to highlight current page

### DIFF
--- a/app/modules/app/components/breadcrumbs.tsx
+++ b/app/modules/app/components/breadcrumbs.tsx
@@ -59,7 +59,7 @@ function BreadcrumbElement({ breadcrumb }: { breadcrumb: BreadcrumbType }) {
     );
   }
   return (
-    <BreadcrumbPage className="text-xl font-extrabold tracking-tight text-balance">
+    <BreadcrumbPage className="text-primary text-xl tracking-tight text-balance">
       {content}
     </BreadcrumbPage>
   );

--- a/app/modules/projects/containers/project.route.tsx
+++ b/app/modules/projects/containers/project.route.tsx
@@ -194,7 +194,7 @@ export default function ProjectRoute({ loaderData }: Route.ComponentProps) {
 
   const breadcrumbs = [
     { text: "Projects", link: "/projects" },
-    { text: project.name },
+    { text: project.name, link: `/projects/${project._id}` },
     { text: startCase(get(matches, "2.id", "").toLowerCase()) },
   ];
 


### PR DESCRIPTION
Two fixes:

- **Project name now has a link** — previously both the project name and the active tab rendered as `BreadcrumbPage` (same style), making it impossible to tell which was current. Now only the last item (the active tab) is unstyled as the current page.
- **Active breadcrumb uses `text-primary`** — gives the current page item a clear color accent instead of relying on the subtle foreground vs muted-foreground contrast.

Fixes #1408