### PR TITLE
A11y: Accessible labels for icon-only buttons and session page title

### DIFF
--- a/app/modules/prompts/components/promptSelector.tsx
+++ b/app/modules/prompts/components/promptSelector.tsx
@@ -221,7 +221,7 @@ export default function PromptSelector({
         <div className="ml-2">
           <Sheet>
             <SheetTrigger asChild>
-              <Button size="icon" variant="secondary">
+              <Button size="icon" variant="secondary" aria-label="View prompt">
                 <ViewIcon />
               </Button>
             </SheetTrigger>

--- a/app/modules/runs/containers/runSessions.route.tsx
+++ b/app/modules/runs/containers/runSessions.route.tsx
@@ -11,6 +11,10 @@ import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
 import RunSessions from "../components/runSessions";
 import type { Route } from "./+types/runSessions.route";
 
+export const meta: Route.MetaFunction = () => [
+  { title: "Session - Sandpiper" },
+];
+
 export async function loader({ request, params }: Route.LoaderArgs) {
   const authenticationTeams = await getSessionUserTeams({ request });
   const teamIds = map(authenticationTeams, "team");

--- a/app/modules/sessions/components/runSessionViewer.tsx
+++ b/app/modules/sessions/components/runSessionViewer.tsx
@@ -191,6 +191,7 @@ export default function SessionViewer({
                   <Button
                     variant="outline"
                     size="sm"
+                    aria-label="Previous annotation"
                     onClick={onPreviousAnnotationClicked}
                     disabled={
                       !hasSelectedAnnotation || selectedUtteranceIndex == 0
@@ -201,6 +202,7 @@ export default function SessionViewer({
                   <Button
                     variant="outline"
                     size="sm"
+                    aria-label="Next annotation"
                     onClick={onNextAnnotationClicked}
                     disabled={
                       hasSelectedAnnotation &&

--- a/app/modules/sessions/components/runSessionViewerAnnotation.tsx
+++ b/app/modules/sessions/components/runSessionViewerAnnotation.tsx
@@ -83,6 +83,8 @@ export default function SessionViewerAnnotation({
             <Button
               variant="outline"
               size="icon"
+              aria-label="Downvote annotation"
+              aria-pressed={annotation.markedAs === "DOWN_VOTED"}
               disabled={isVoting}
               onClick={onDownVoteClicked}
               className={clsx({
@@ -100,6 +102,8 @@ export default function SessionViewerAnnotation({
             <Button
               variant="outline"
               size="icon"
+              aria-label="Upvote annotation"
+              aria-pressed={annotation.markedAs === "UP_VOTED"}
               disabled={isVoting}
               onClick={onUpVoteClicked}
               className={clsx({
@@ -129,6 +133,7 @@ export default function SessionViewerAnnotation({
           <Button
             variant="outline"
             size="icon"
+            aria-label="Save reason"
             disabled={isSavingReason || !hasUnsavedChanges}
             onClick={() => onSaveVotingReason(reason)}
             className="shrink-0"

--- a/app/uikit/components/ui/sort.tsx
+++ b/app/uikit/components/ui/sort.tsx
@@ -24,7 +24,12 @@ const Sort = ({ sortOptions, sortValue, onSortValueChanged }: SortProps) => {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Sort"
+          className="relative"
+        >
           <ArrowDownUp />
         </Button>
       </PopoverTrigger>

--- a/app/uikit/components/ui/sortItem.tsx
+++ b/app/uikit/components/ui/sortItem.tsx
@@ -26,10 +26,16 @@ const SortItem = ({
           }
         }}
       >
-        <ToggleGroupItem value={item.value}>
+        <ToggleGroupItem
+          value={item.value}
+          aria-label={`Sort by ${item.text} ascending`}
+        >
           <ArrowDownWideNarrow />
         </ToggleGroupItem>
-        <ToggleGroupItem value={`-${item.value}`}>
+        <ToggleGroupItem
+          value={`-${item.value}`}
+          aria-label={`Sort by ${item.text} descending`}
+        >
           <ArrowUpWideNarrow />
         </ToggleGroupItem>
       </ToggleGroup>


### PR DESCRIPTION
Closes #2025. Part of #1355.

## Changes

- `aria-label="Previous annotation"` / `aria-label="Next annotation"` on annotation nav buttons
- `aria-label="Downvote annotation"` + `aria-pressed` on downvote button (state was color-only)
- `aria-label="Upvote annotation"` + `aria-pressed` on upvote button (state was color-only)
- `aria-label="Save reason"` on the check icon button in the voting reason form
- `aria-label="Sort"` on the sort popover trigger
- `aria-label="Sort by {field} ascending/descending"` on sort direction toggles
- `aria-label="View prompt"` on the prompt sheet trigger in Create Run
- `meta` export with `title: "Session - Sandpiper"` on the run session viewer route