### PR TITLE
Fix accessibility issues: nested main, sidebar landmark, button-in-anchor, help links

### DIFF
--- a/app/modules/app/components/appSidebar.tsx
+++ b/app/modules/app/components/appSidebar.tsx
@@ -59,7 +59,11 @@ export default function AppSidebar() {
   };
 
   return (
-    <Sidebar variant="inset">
+    <Sidebar
+      variant="inset"
+      role="navigation"
+      aria-label="Application navigation"
+    >
       <SidebarHeader className="p-4">
         <Link to={"/"}>
           <img
@@ -242,6 +246,7 @@ export default function AppSidebar() {
                     <SidebarMenuButton
                       size="lg"
                       className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                      aria-label={`User menu for ${user.name || user.username}`}
                     >
                       <div className="grid flex-1 text-left text-sm leading-tight">
                         <span className="truncate font-medium">

--- a/app/modules/app/components/sidebarHelpDropdown.tsx
+++ b/app/modules/app/components/sidebarHelpDropdown.tsx
@@ -33,7 +33,7 @@ export default function SideBarHelpDropdown() {
           <DropdownMenuItem onClick={() => setDocsOpen(true)}>
             Read the Documentation
           </DropdownMenuItem>
-          <DropdownMenuItem>
+          <DropdownMenuItem asChild>
             <a
               href="https://github.com/orgs/National-Tutoring-Observatory/discussions"
               target="_blank"
@@ -42,7 +42,7 @@ export default function SideBarHelpDropdown() {
               Ask a Question
             </a>
           </DropdownMenuItem>
-          <DropdownMenuItem>
+          <DropdownMenuItem asChild>
             <a
               href="https://github.com/National-Tutoring-Observatory/sandpiper/issues/new/choose"
               target="_blank"
@@ -51,7 +51,7 @@ export default function SideBarHelpDropdown() {
               Report a Bug or Request a Feature
             </a>
           </DropdownMenuItem>
-          <DropdownMenuItem>
+          <DropdownMenuItem asChild>
             <a
               href="https://github.com/National-Tutoring-Observatory/sandpiper/issues"
               target="_blank"

--- a/app/modules/authentication/containers/authentication.container.tsx
+++ b/app/modules/authentication/containers/authentication.container.tsx
@@ -86,9 +86,7 @@ export default function AuthenticationContainer({
       <MaintenanceBanner />
       <SidebarProvider defaultOpen={true}>
         <AppSidebar />
-        <SidebarInset>
-          <main>{children}</main>
-        </SidebarInset>
+        <SidebarInset>{children}</SidebarInset>
       </SidebarProvider>
     </AuthenticationContext>
   );

--- a/app/uikit/components/ui/collection.tsx
+++ b/app/uikit/components/ui/collection.tsx
@@ -8,7 +8,9 @@ import type {
   CollectionItemAction,
   CollectionItemAttributes,
 } from "./collectionItemContent";
-import CollectionItemContent from "./collectionItemContent";
+import CollectionItemContent, {
+  CollectionItemActions,
+} from "./collectionItemContent";
 import type { FiltersProps } from "./filters";
 import { Item, ItemGroup, ItemSeparator } from "./item";
 import type { PaginationProps } from "./pagination";
@@ -120,24 +122,38 @@ const Collection = ({
           return (
             <React.Fragment key={id}>
               <Item
-                asChild
                 variant={itemsLayout === "card" ? "outline" : undefined}
-                className={clsx({ "opacity-50": isDisabled })}
+                className={clsx(
+                  { "opacity-50": isDisabled },
+                  "has-[:focus-visible]:border-ring has-[:focus-visible]:ring-ring/50 has-[:focus-visible]:ring-[3px]",
+                )}
               >
                 {to && !isDisabled ? (
-                  <Link to={to} className="rounded-none">
-                    {(renderItem && renderItem(item)) || (
-                      <CollectionItemContent
+                  <>
+                    <Link
+                      to={to}
+                      className="flex min-w-0 flex-1 items-center gap-4 rounded-none outline-none"
+                    >
+                      {(renderItem && renderItem(item)) || (
+                        <CollectionItemContent
+                          id={id}
+                          title={title}
+                          description={description}
+                          meta={meta}
+                          actions={[]}
+                          isDisabled={isDisabled}
+                        />
+                      )}
+                    </Link>
+                    {!renderItem && (
+                      <CollectionItemActions
                         id={id}
-                        title={title}
-                        description={description}
-                        meta={meta}
                         actions={itemActions}
-                        isDisabled={isDisabled}
+                        isDisabled={!!isDisabled}
                         onItemActionClicked={onItemActionClicked}
                       />
                     )}
-                  </Link>
+                  </>
                 ) : (
                   <div
                     className={clsx("rounded-none", {

--- a/app/uikit/components/ui/collectionItemContent.tsx
+++ b/app/uikit/components/ui/collectionItemContent.tsx
@@ -50,6 +50,72 @@ type CollectionItemProps = {
   }) => void;
 };
 
+const CollectionItemActions = ({
+  id,
+  actions,
+  isDisabled,
+  onItemActionClicked,
+}: Pick<
+  CollectionItemProps,
+  "id" | "actions" | "isDisabled" | "onItemActionClicked"
+>) => {
+  if (actions.length === 0) return null;
+  return (
+    <ItemActions>
+      {(actions.length > 1 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild disabled={isDisabled}>
+            <Button
+              variant="ghost"
+              className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
+              size="icon"
+            >
+              <EllipsisVertical />
+              <span className="sr-only">Open menu</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-fit">
+            {map(actions, (action, index) => {
+              return (
+                <React.Fragment key={action.action}>
+                  <DropdownMenuItem
+                    variant={action.variant}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      event.preventDefault();
+                      if (onItemActionClicked) {
+                        onItemActionClicked({ id, action: action.action });
+                      }
+                    }}
+                  >
+                    {action.icon ? action.icon : null}
+                    {action.text}
+                  </DropdownMenuItem>
+                  {index !== actions.length - 1 && <DropdownMenuSeparator />}
+                </React.Fragment>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )) || (
+        <Button
+          variant="ghost"
+          onClick={(event) => {
+            event.stopPropagation();
+            event.preventDefault();
+            if (onItemActionClicked) {
+              onItemActionClicked({ id, action: actions[0].action });
+            }
+          }}
+        >
+          {actions[0].icon ? actions[0].icon : null}
+          {actions[0].text}
+        </Button>
+      )}
+    </ItemActions>
+  );
+};
+
 const CollectionItemContent = ({
   id,
   title,
@@ -78,61 +144,14 @@ const CollectionItemContent = ({
         })}
       </div>
     </ItemContent>
-    {actions.length > 0 && (
-      <ItemActions>
-        {(actions.length > 1 && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild disabled={isDisabled}>
-              <Button
-                variant="ghost"
-                className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
-                size="icon"
-              >
-                <EllipsisVertical />
-                <span className="sr-only">Open menu</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-fit">
-              {map(actions, (action, index) => {
-                return (
-                  <React.Fragment key={action.action}>
-                    <DropdownMenuItem
-                      variant={action.variant}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        if (onItemActionClicked) {
-                          onItemActionClicked({ id, action: action.action });
-                        }
-                      }}
-                    >
-                      {action.icon ? action.icon : null}
-                      {action.text}
-                    </DropdownMenuItem>
-                    {index !== actions.length - 1 && <DropdownMenuSeparator />}
-                  </React.Fragment>
-                );
-              })}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )) || (
-          <Button
-            variant="ghost"
-            onClick={(event) => {
-              event.stopPropagation();
-              event.preventDefault();
-              if (onItemActionClicked) {
-                onItemActionClicked({ id, action: actions[0].action });
-              }
-            }}
-          >
-            {actions[0].icon ? actions[0].icon : null}
-            {actions[0].text}
-          </Button>
-        )}
-      </ItemActions>
-    )}
+    <CollectionItemActions
+      id={id}
+      actions={actions}
+      isDisabled={isDisabled}
+      onItemActionClicked={onItemActionClicked}
+    />
   </>
 );
 
+export { CollectionItemActions };
 export default CollectionItemContent;


### PR DESCRIPTION
Fixes #2026

## Summary

- **Nested `<main>`**: Removed redundant `<main>` wrapper in `authentication.container.tsx` — `SidebarInset` already renders as `<main>`, so the inner one created an invalid nested landmark
- **Sidebar navigation landmark**: Added `role="navigation" aria-label="Application navigation"` to the sidebar in `appSidebar.tsx` so VoiceOver's landmark rotor can find it; also added `aria-label` to the user menu trigger button
- **Button nested inside `<a>`**: Extracted `CollectionItemActions` from `CollectionItemContent` so the actions button renders as a sibling of the row `<Link>`, not inside the `<a>` tag — invalid HTML that caused VoiceOver to skip the button; focus ring restored via `has-[:focus-visible]` on the row wrapper
- **Help popup links not activatable with Enter**: Added `asChild` to the three external-link `DropdownMenuItem`s so the `<a>` becomes the actual menuitem element and receives keyboard events directly