### PR TITLE
Implement keyboard focus and accessibility fixes (#2027)

### DIFF
--- a/app/modules/authentication/containers/authentication.container.tsx
+++ b/app/modules/authentication/containers/authentication.container.tsx
@@ -1,4 +1,5 @@
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { SkipLink } from "@/components/ui/skipLink";
 import get from "lodash/get";
 import { LoaderPinwheel } from "lucide-react";
 import { useEffect, useRef, type ReactNode } from "react";
@@ -85,8 +86,18 @@ export default function AuthenticationContainer({
     <AuthenticationContext value={authentication}>
       <MaintenanceBanner />
       <SidebarProvider defaultOpen={true}>
+        <SkipLink href="#main-content" className="focus:top-4 focus:left-4">
+          Skip to main content
+        </SkipLink>
         <AppSidebar />
-        <SidebarInset>{children}</SidebarInset>
+        <SidebarInset
+          id="main-content"
+          tabIndex={-1}
+          aria-label="Main content"
+          className="focus-visible:outline-none"
+        >
+          {children}
+        </SidebarInset>
       </SidebarProvider>
     </AuthenticationContext>
   );

--- a/app/modules/dialogs/components/modal.tsx
+++ b/app/modules/dialogs/components/modal.tsx
@@ -1,4 +1,5 @@
 import { Dialog } from "@/components/ui/dialog";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import type { Modal } from "../dialogs.types";
 
 export default function Modal({
@@ -6,6 +7,26 @@ export default function Modal({
   component,
   onCloseModalClicked,
 }: Modal) {
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  // Capture the trigger element when the dialog opens. useLayoutEffect fires
+  // synchronously after the DOM commits but before Radix's useEffect moves
+  // focus into the dialog — so activeElement is still the trigger button.
+  // Radix can't handle this automatically because dialogs here are opened
+  // imperatively (no <DialogTrigger>), so it has no trigger ref.
+  useLayoutEffect(() => {
+    if (isOpen) {
+      returnFocusRef.current = document.activeElement as HTMLElement | null;
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen && returnFocusRef.current) {
+      returnFocusRef.current.focus();
+      returnFocusRef.current = null;
+    }
+  }, [isOpen]);
+
   return (
     <Dialog
       open={isOpen}
@@ -13,7 +34,7 @@ export default function Modal({
         if (!isOpen) onCloseModalClicked();
       }}
     >
-      {isOpen && component}
+      {component}
     </Dialog>
   );
 }

--- a/app/modules/projects/components/project.tsx
+++ b/app/modules/projects/components/project.tsx
@@ -93,7 +93,11 @@ export default function Project({
         </PageHeaderRight>
       </PageHeader>
       <div className="grid grid-cols-4 gap-8">
-        <Link to={`/projects/${project._id}/files`} replace className="h-full">
+        <Link
+          to={`/projects/${project._id}/files`}
+          replace
+          className="focus-visible:ring-ring h-full rounded-xl focus-visible:ring-2 focus-visible:outline-none"
+        >
           <Card
             className={clsx("h-full transition-all", {
               "border-accent-foreground": tabValue === "FILES",
@@ -123,7 +127,7 @@ export default function Project({
         <Link
           to={`/projects/${project._id}/sessions`}
           replace
-          className="h-full"
+          className="focus-visible:ring-ring h-full rounded-xl focus-visible:ring-2 focus-visible:outline-none"
         >
           <Card
             className={clsx("h-full transition-all", {
@@ -156,7 +160,11 @@ export default function Project({
             </CardContent>
           </Card>
         </Link>
-        <Link to={`/projects/${project._id}`} replace className="h-full">
+        <Link
+          to={`/projects/${project._id}`}
+          replace
+          className="focus-visible:ring-ring h-full rounded-xl focus-visible:ring-2 focus-visible:outline-none"
+        >
           <Card
             className={clsx("h-full transition-all", {
               "border-accent-foreground": tabValue === "RUNS",
@@ -185,7 +193,7 @@ export default function Project({
         <Link
           to={`/projects/${project._id}/run-sets`}
           replace
-          className="h-full"
+          className="focus-visible:ring-ring h-full rounded-xl focus-visible:ring-2 focus-visible:outline-none"
         >
           <Card
             className={clsx("h-full transition-all", {

--- a/app/modules/prompts/components/createPromptDialog.tsx
+++ b/app/modules/prompts/components/createPromptDialog.tsx
@@ -115,17 +115,15 @@ const CreatePromptDialog = ({
             Cancel
           </Button>
         </DialogClose>
-        <DialogClose asChild>
-          <Button
-            type="button"
-            disabled={isSubmitButtonDisabled}
-            onClick={() => {
-              onCreateNewPromptClicked({ name, team, annotationType });
-            }}
-          >
-            Create prompt
-          </Button>
-        </DialogClose>
+        <Button
+          type="button"
+          disabled={isSubmitButtonDisabled}
+          onClick={() => {
+            onCreateNewPromptClicked({ name, team, annotationType });
+          }}
+        >
+          Create prompt
+        </Button>
       </DialogFooter>
     </DialogContent>
   );

--- a/app/modules/prompts/components/promptSelector.tsx
+++ b/app/modules/prompts/components/promptSelector.tsx
@@ -29,6 +29,7 @@ import {
   ChevronsUpDownIcon,
   ViewIcon,
 } from "lucide-react";
+import { useState } from "react";
 import type { Prompt, PromptVersion } from "../prompts.types";
 
 export default function PromptSelector({
@@ -39,10 +40,7 @@ export default function PromptSelector({
   productionVersion,
   isLoadingPrompts,
   isLoadingPromptVersions,
-  isPromptsOpen,
-  isPromptVersionsOpen,
-  onTogglePromptPopover,
-  onTogglePromptVersionsPopover,
+  onPromptsPopoverOpened,
   onSelectedPromptChange,
   onSelectedPromptVersionChange,
 }: {
@@ -53,13 +51,13 @@ export default function PromptSelector({
   productionVersion: number;
   isLoadingPrompts: boolean;
   isLoadingPromptVersions: boolean;
-  isPromptsOpen: boolean;
-  isPromptVersionsOpen: boolean;
-  onTogglePromptPopover: (isPromptsOpen: boolean) => void;
-  onTogglePromptVersionsPopover: (isPromptVersionsOpen: boolean) => void;
+  onPromptsPopoverOpened: () => void;
   onSelectedPromptChange: (selectedPrompt: string) => void;
   onSelectedPromptVersionChange: (selectedPromptVersion: number) => void;
 }) {
+  const [isPromptsOpen, setIsPromptsOpen] = useState(false);
+  const [isPromptVersionsOpen, setIsPromptVersionsOpen] = useState(false);
+
   let selectedPromptVersionItem = null;
   if (selectedPromptVersion) {
     selectedPromptVersionItem = find(promptVersions, {
@@ -69,7 +67,13 @@ export default function PromptSelector({
 
   return (
     <div className="flex items-center">
-      <Popover open={isPromptsOpen} onOpenChange={onTogglePromptPopover}>
+      <Popover
+        open={isPromptsOpen}
+        onOpenChange={(open) => {
+          setIsPromptsOpen(open);
+          if (open) onPromptsPopoverOpened();
+        }}
+      >
         <PopoverTrigger asChild>
           <Button
             variant="outline"
@@ -105,7 +109,7 @@ export default function PromptSelector({
                     keywords={[prompt._id]}
                     onSelect={() => {
                       onSelectedPromptChange(prompt._id);
-                      onTogglePromptPopover(false);
+                      setIsPromptsOpen(false);
                     }}
                   >
                     <CheckIcon
@@ -128,7 +132,7 @@ export default function PromptSelector({
         <div className="ml-2">
           <Popover
             open={isPromptVersionsOpen}
-            onOpenChange={onTogglePromptVersionsPopover}
+            onOpenChange={setIsPromptVersionsOpen}
           >
             <PopoverTrigger asChild>
               <Button
@@ -181,7 +185,7 @@ export default function PromptSelector({
                         ]}
                         onSelect={() => {
                           onSelectedPromptVersionChange(promptVersion.version);
-                          onTogglePromptVersionsPopover(false);
+                          setIsPromptVersionsOpen(false);
                         }}
                       >
                         <CheckIcon

--- a/app/modules/prompts/containers/promptSelectorContainer.tsx
+++ b/app/modules/prompts/containers/promptSelectorContainer.tsx
@@ -27,8 +27,6 @@ export default function PromptSelectorContainer({
     inputTokens?: number,
   ) => void;
 }) {
-  const [isPromptsOpen, setIsPromptsOpen] = useState(false);
-  const [isPromptVersionsOpen, setIsPromptVersionsOpen] = useState(false);
   const [fetchedVersionsByPrompt, setFetchedVersionsByPrompt] = useState<
     Record<string, PromptVersion[]>
   >({});
@@ -36,13 +34,10 @@ export default function PromptSelectorContainer({
   const promptsFetcher = useFetcher();
   const promptVersionsFetcher = useFetcher();
 
-  const onTogglePromptPopover = (isPromptsOpen: boolean) => {
-    setIsPromptsOpen(isPromptsOpen);
-    if (isPromptsOpen) {
-      const params = new URLSearchParams();
-      params.set("annotationType", annotationType);
-      promptsFetcher.load(`/api/promptsList?${params.toString()}`);
-    }
+  const onPromptsPopoverOpened = () => {
+    const params = new URLSearchParams();
+    params.set("annotationType", annotationType);
+    promptsFetcher.load(`/api/promptsList?${params.toString()}`);
   };
 
   useEffect(() => {
@@ -58,10 +53,6 @@ export default function PromptSelectorContainer({
       );
     }
   }, [selectedPrompt]);
-
-  const onTogglePromptVersionsPopover = (isPromptsOpen: boolean) => {
-    setIsPromptVersionsOpen(isPromptsOpen);
-  };
 
   const onSelectedPromptChange = (selectedPrompt: string) => {
     const selectedPromptItem = find(promptsFetcher.data.prompts.data, {
@@ -136,10 +127,7 @@ export default function PromptSelectorContainer({
       productionVersion={productionVersion}
       isLoadingPrompts={promptsFetcher.state === "loading"}
       isLoadingPromptVersions={promptVersionsFetcher.state === "loading"}
-      isPromptsOpen={isPromptsOpen}
-      isPromptVersionsOpen={isPromptVersionsOpen}
-      onTogglePromptPopover={onTogglePromptPopover}
-      onTogglePromptVersionsPopover={onTogglePromptVersionsPopover}
+      onPromptsPopoverOpened={onPromptsPopoverOpened}
       onSelectedPromptChange={onSelectedPromptChange}
       onSelectedPromptVersionChange={onSelectedPromptVersionChange}
     />

--- a/app/modules/sessions/components/runSessionViewer.tsx
+++ b/app/modules/sessions/components/runSessionViewer.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { SkipLink } from "@/components/ui/skipLink";
 import find from "lodash/find";
 import map from "lodash/map";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -77,6 +78,9 @@ export default function SessionViewer({
 
   return (
     <div className="flex h-full flex-1">
+      <SkipLink href="#session-annotations-panel" className="focus:p-2">
+        Skip to annotations
+      </SkipLink>
       <div
         id="session-viewer-scroll-container"
         className="flex h-full w-3/5 min-w-0 flex-col overflow-y-scroll scroll-smooth border-r p-4"
@@ -111,7 +115,11 @@ export default function SessionViewer({
           );
         })}
       </div>
-      <div className="flex h-full w-2/5 min-w-0 flex-col pt-8">
+      <div
+        id="session-annotations-panel"
+        tabIndex={-1}
+        className="flex h-full w-2/5 min-w-0 flex-col pt-8"
+      >
         <div className="border-b px-4 pb-4">
           <SessionViewerDetails
             session={session}

--- a/app/uikit/components/ui/skipLink.tsx
+++ b/app/uikit/components/ui/skipLink.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+export function SkipLink({
+  href,
+  children,
+  className,
+}: {
+  href: string;
+  children: string;
+  className?: string;
+}) {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const target = document.querySelector(href) as HTMLElement | null;
+    target?.focus();
+  };
+
+  return (
+    <a
+      href={href}
+      onClick={handleClick}
+      className={cn(
+        "bg-background focus-visible:ring-ring sr-only fixed -top-full left-0 z-50 rounded px-4 py-2 text-sm focus:top-0 focus:left-0 focus-visible:ring-2 focus-visible:outline-none",
+        className,
+      )}
+    >
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

- Return focus to the trigger button after dialog close — dialogs opened via `addDialog()` have no `<DialogTrigger>`, so Radix can't auto-return focus; `useLayoutEffect` captures `activeElement` before Radix moves focus in
- Fix focus trap race in Notifications by always mounting dialog content (remove `{isOpen && component}` guard), aligning with the standard Radix pattern
- Remove `<DialogClose asChild>` from the Create Prompt submit button — dialog was closing before the server responded; it now closes via `addDialog(null)` in the route's success `useEffect`
- Add skip link to session viewer transcript pane so keyboard users can jump directly to the annotations panel (54.1)
- Add "Skip to main content" link as the first focusable element in the authenticated layout (57.1); `<SidebarInset>` gets `aria-label="Main content"` so screen readers announce the landmark on arrival
- Move prompt selector popover open state local to the component — eliminates the controlled-Popover focus-return problem (focus now returns natively on Escape) and removes 4 props from the container (57.2)
- Add `rounded-xl` and `focus-visible:ring` to project card `<Link>` wrappers so the focus ring follows the card's border radius

Fixes #2027