### PR TITLE
Fix modal announcements and status messages (Issue #2028)

### DIFF
--- a/app/modules/sessions/components/runSessionViewer.tsx
+++ b/app/modules/sessions/components/runSessionViewer.tsx
@@ -190,11 +190,15 @@ export default function SessionViewer({
                 >
                   First annotation
                 </Button>
-                {hasSelectedAnnotation && (
-                  <div className="text-muted-foreground text-sm">
-                    {selectedUtteranceIndex + 1}/{annotatedUtteranceCount}
-                  </div>
-                )}
+                <div
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="text-muted-foreground text-sm"
+                >
+                  {hasSelectedAnnotation
+                    ? `${selectedUtteranceIndex + 1}/${annotatedUtteranceCount}`
+                    : ""}
+                </div>
                 <div className="flex gap-1">
                   <Button
                     variant="outline"

--- a/app/modules/teams/components/inviteUserToTeamDialog.tsx
+++ b/app/modules/teams/components/inviteUserToTeamDialog.tsx
@@ -100,6 +100,11 @@ export default function InviteUserToTeamDialog({
                 </div>
                 <Button
                   variant="ghost"
+                  aria-label={
+                    hasCopiedInviteLink
+                      ? "Invite link copied"
+                      : "Copy invite link"
+                  }
                   className="absolute top-0 right-1 z-10 cursor-pointer"
                   disabled={hasCopiedInviteLink}
                   onClick={onCopyInviteClicked}
@@ -108,11 +113,12 @@ export default function InviteUserToTeamDialog({
 
                   {!hasCopiedInviteLink && <CopyIcon />}
                 </Button>
-                {hasCopiedInviteLink && (
-                  <div className="text-sandpiper-success absolute right-4 -bottom-6 text-xs">
-                    Invite link copied!
-                  </div>
-                )}
+                <div
+                  role="status"
+                  className="text-sandpiper-success absolute right-4 -bottom-6 text-xs"
+                >
+                  {hasCopiedInviteLink ? "Invite link copied!" : ""}
+                </div>
                 <div className="text-muted-foreground mt-4 text-xs">
                   {`This invite link will expire in ${INVITE_LINK_TTL_DAYS} days.`}
                 </div>

--- a/app/modules/teams/components/teamsSelector.tsx
+++ b/app/modules/teams/components/teamsSelector.tsx
@@ -38,6 +38,7 @@ export default function TeamsSelector({
           variant="outline"
           role="combobox"
           aria-expanded={isOpen}
+          aria-haspopup="listbox"
           className="w-[200px] justify-between"
         >
           {selectedTeam

--- a/app/uikit/components/ui/dialog.tsx
+++ b/app/uikit/components/ui/dialog.tsx
@@ -48,15 +48,35 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onOpenAutoFocus,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
 }) {
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  const handleOpenAutoFocus = React.useCallback(
+    (event: Event) => {
+      if (onOpenAutoFocus) {
+        onOpenAutoFocus(event);
+        return;
+      }
+      event.preventDefault();
+      const title = contentRef.current?.querySelector<HTMLElement>(
+        '[data-slot="dialog-title"]',
+      );
+      title?.focus();
+    },
+    [onOpenAutoFocus],
+  );
+
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
+        ref={contentRef}
         data-slot="dialog-content"
+        onOpenAutoFocus={handleOpenAutoFocus}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
@@ -108,7 +128,11 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      tabIndex={-1}
+      className={cn(
+        "text-lg leading-none font-semibold outline-none",
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- Focus dialog title on open so VoiceOver announces the dialog name immediately instead of reading the close button
- Add `aria-haspopup="listbox"` to the teams combobox trigger to signal that a list will appear
- Replace conditional annotation counter with a persistent `aria-live` region so Next/Prev navigation is announced
- Add `role="status"` live region and dynamic `aria-label` on the invite link copy button so the copy confirmation is announced

Fixes #2028