### PR TITLE
2051 phase 2 standardize route contracts and typing

### DIFF
--- a/app/modules/annotations/containers/annotations.route.tsx
+++ b/app/modules/annotations/containers/annotations.route.tsx
@@ -1,6 +1,5 @@
 import fse from "fs-extra";
-import { redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
@@ -26,10 +25,7 @@ function updateAnnotationVote(
 export async function action({ request, params }: Route.ActionArgs) {
   const payload = await request.json();
 
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const run = await RunService.findById(params.runId);
 

--- a/app/modules/authentication/__tests__/requireAuth.test.ts
+++ b/app/modules/authentication/__tests__/requireAuth.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { UserService } from "~/modules/users/user";
+import sessionStorage from "../../../../sessionStorage";
+import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import loginUser from "../../../../test/helpers/loginUser";
+import requireAuth from "../helpers/requireAuth";
+
+beforeEach(async () => {
+  await clearDocumentDB();
+});
+
+describe("requireAuth", () => {
+  describe("unauthenticated", () => {
+    it("throws a redirect to /signup", async () => {
+      const req = new Request("http://localhost/projects/123");
+      await expect(requireAuth({ request: req })).rejects.toBeInstanceOf(
+        Response,
+      );
+    });
+
+    it("redirects to /signup with no query string", async () => {
+      const req = new Request("http://localhost/projects/123");
+      let thrown: Response | undefined;
+      try {
+        await requireAuth({ request: req });
+      } catch (e) {
+        thrown = e as Response;
+      }
+      expect(thrown?.status).toBe(302);
+      expect(thrown?.headers.get("Location")).toBe("/signup");
+    });
+
+    it("stores the pathname in the session as returnTo", async () => {
+      const req = new Request("http://localhost/projects/123");
+      let thrown: Response | undefined;
+      try {
+        await requireAuth({ request: req });
+      } catch (e) {
+        thrown = e as Response;
+      }
+      const cookie = thrown?.headers.get("Set-Cookie") ?? "";
+      const session = await sessionStorage.getSession(cookie);
+      expect(session.get("returnTo")).toBe("/projects/123");
+    });
+
+    it("stores pathname and query string in the session", async () => {
+      const req = new Request(
+        "http://localhost/projects/123?searchValue=hello",
+      );
+      let thrown: Response | undefined;
+      try {
+        await requireAuth({ request: req });
+      } catch (e) {
+        thrown = e as Response;
+      }
+      const cookie = thrown?.headers.get("Set-Cookie") ?? "";
+      const session = await sessionStorage.getSession(cookie);
+      expect(session.get("returnTo")).toBe("/projects/123?searchValue=hello");
+    });
+
+    it("does not store the host in returnTo", async () => {
+      const req = new Request("http://evil.com/projects/123");
+      let thrown: Response | undefined;
+      try {
+        await requireAuth({ request: req });
+      } catch (e) {
+        thrown = e as Response;
+      }
+      const cookie = thrown?.headers.get("Set-Cookie") ?? "";
+      const session = await sessionStorage.getSession(cookie);
+      const returnTo = session.get("returnTo") as string;
+      expect(returnTo.startsWith("/")).toBe(true);
+      expect(returnTo).not.toContain("evil.com");
+    });
+  });
+
+  describe("authenticated", () => {
+    it("returns the user", async () => {
+      const user = await UserService.create({ username: "test_user" });
+      const cookieHeader = await loginUser(user._id);
+      const req = new Request("http://localhost/projects/123", {
+        headers: { cookie: cookieHeader },
+      });
+      const result = await requireAuth({ request: req });
+      expect(result._id).toEqual(user._id);
+    });
+  });
+});

--- a/app/modules/authentication/__tests__/sanitizeReturnTo.test.ts
+++ b/app/modules/authentication/__tests__/sanitizeReturnTo.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import sanitizeReturnTo from "../helpers/sanitizeReturnTo";
+
+describe("sanitizeReturnTo", () => {
+  it("returns valid paths as-is", () => {
+    expect(sanitizeReturnTo("/projects/123")).toBe("/projects/123");
+    expect(sanitizeReturnTo("/")).toBe("/");
+  });
+
+  it("allows paths with query strings", () => {
+    // Safe now that returnTo lives in the session — not exposed in public URLs
+    expect(sanitizeReturnTo("/projects/123?foo=bar")).toBe(
+      "/projects/123?foo=bar",
+    );
+    expect(sanitizeReturnTo("/projects/123?searchValue=hello&page=2")).toBe(
+      "/projects/123?searchValue=hello&page=2",
+    );
+  });
+
+  it("returns / for non-string values", () => {
+    expect(sanitizeReturnTo(null)).toBe("/");
+    expect(sanitizeReturnTo(undefined)).toBe("/");
+    expect(sanitizeReturnTo(42)).toBe("/");
+    expect(sanitizeReturnTo({})).toBe("/");
+  });
+
+  it("returns / for empty string", () => {
+    expect(sanitizeReturnTo("")).toBe("/");
+  });
+
+  it("blocks protocol-relative URLs (//evil.com)", () => {
+    expect(sanitizeReturnTo("//evil.com")).toBe("/");
+    expect(sanitizeReturnTo("//evil.com/path")).toBe("/");
+  });
+
+  it("blocks absolute URLs", () => {
+    expect(sanitizeReturnTo("https://evil.com")).toBe("/");
+    expect(sanitizeReturnTo("http://evil.com/path")).toBe("/");
+  });
+
+  it("blocks values not starting with /", () => {
+    expect(sanitizeReturnTo("evil.com")).toBe("/");
+    expect(sanitizeReturnTo("relative/path")).toBe("/");
+  });
+
+  describe("open redirect bypass attempts", () => {
+    it("blocks backslash bypass (/\\evil.com)", () => {
+      // Browsers normalize /\ to // in Location headers
+      expect(sanitizeReturnTo("/\\evil.com")).toBe("/");
+    });
+
+    it("blocks unicode fullwidth slash (／/evil.com)", () => {
+      // U+FF0F looks like / but is a different character — does not start with /
+      expect(sanitizeReturnTo("\uFF0F\uFF0Fevil.com")).toBe("/");
+    });
+
+    it("blocks javascript: scheme", () => {
+      expect(sanitizeReturnTo("javascript:alert(1)")).toBe("/");
+    });
+
+    it("blocks data: scheme", () => {
+      expect(sanitizeReturnTo("data:text/html,<script>alert(1)</script>")).toBe(
+        "/",
+      );
+    });
+
+    it("allows a valid path that contains a colon", () => {
+      // Colons are valid in path segments (e.g. timestamps), not a bypass
+      expect(sanitizeReturnTo("/projects/123:detail")).toBe(
+        "/projects/123:detail",
+      );
+    });
+  });
+});

--- a/app/modules/authentication/containers/authCallback.route.tsx
+++ b/app/modules/authentication/containers/authCallback.route.tsx
@@ -2,6 +2,7 @@ import { redirect } from "react-router";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import sessionStorage from "../../../../sessionStorage";
 import { authenticator } from "../authentication.server";
+import sanitizeReturnTo from "../helpers/sanitizeReturnTo";
 import type { Route } from "./+types/authCallback.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -10,6 +11,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const session = await sessionStorage.getSession(
     request.headers.get("cookie"),
   );
+
+  const returnTo = sanitizeReturnTo(session.get("returnTo"));
 
   session.set("user", user);
 
@@ -23,5 +26,5 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     return redirect("/onboarding", { headers });
   }
 
-  return redirect("/", { headers });
+  return redirect(returnTo, { headers });
 }

--- a/app/modules/authentication/containers/authentication.route.tsx
+++ b/app/modules/authentication/containers/authentication.route.tsx
@@ -77,6 +77,7 @@ export async function action({ request }: Route.ActionArgs) {
     }
     session.flash("inviteId", data.inviteId);
   }
+
   try {
     await authenticator.authenticate(data.provider, request);
   } catch (error) {

--- a/app/modules/authentication/containers/onboarding.route.tsx
+++ b/app/modules/authentication/containers/onboarding.route.tsx
@@ -6,7 +6,7 @@ import {
   useLoaderData,
   useNavigate,
 } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { UserService } from "~/modules/users/user";
 import Onboarding from "../components/onboarding";
 import TermsAcceptance from "../components/termsAcceptance";
@@ -28,15 +28,13 @@ const VALID_USE_CASES = [
 ] as const;
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
   if (user.onboardingComplete && user.termsAcceptedAt) return redirect("/");
   return { termsAccepted: Boolean(user.termsAcceptedAt) };
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
   if (user.onboardingComplete && user.termsAcceptedAt) return redirect("/");
 
   const { intent, payload = {} } = await request.json();

--- a/app/modules/authentication/helpers/requireAuth.ts
+++ b/app/modules/authentication/helpers/requireAuth.ts
@@ -1,8 +1,18 @@
 import { redirect } from "react-router";
+import sessionStorage from "../../../../sessionStorage";
 import getSessionUser from "./getSessionUser";
 
 export default async function requireAuth({ request }: { request: Request }) {
   const user = await getSessionUser({ request });
-  if (!user) throw redirect("/");
+  if (!user) {
+    const { pathname, search } = new URL(request.url);
+    const session = await sessionStorage.getSession(
+      request.headers.get("cookie"),
+    );
+    session.flash("returnTo", pathname + search);
+    throw redirect("/signup", {
+      headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
+    });
+  }
   return user;
 }

--- a/app/modules/authentication/helpers/requireAuth.ts
+++ b/app/modules/authentication/helpers/requireAuth.ts
@@ -1,0 +1,8 @@
+import { redirect } from "react-router";
+import getSessionUser from "./getSessionUser";
+
+export default async function requireAuth({ request }: { request: Request }) {
+  const user = await getSessionUser({ request });
+  if (!user) throw redirect("/");
+  return user;
+}

--- a/app/modules/authentication/helpers/sanitizeReturnTo.ts
+++ b/app/modules/authentication/helpers/sanitizeReturnTo.ts
@@ -1,0 +1,11 @@
+export default function sanitizeReturnTo(value: unknown): string {
+  if (typeof value !== "string") return "/";
+  // Block open redirect bypasses — protocol-relative (//) and backslash normalization (/\)
+  if (
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.startsWith("/\\")
+  )
+    return "/";
+  return value;
+}

--- a/app/modules/codebooks/containers/codebook.route.tsx
+++ b/app/modules/codebooks/containers/codebook.route.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-router";
 import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import CodebookAuthorization from "~/modules/codebooks/authorization";
 import addDialog from "~/modules/dialogs/addDialog";
 import PromptAuthorization from "~/modules/prompts/authorization";
@@ -23,10 +23,7 @@ import EditCodebookDialog from "../components/editCodebookDialog";
 import type { Route } from "./+types/codebook.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
   const codebook = await CodebookService.findById(params.id);
   if (!codebook) {
     return redirect("/codebooks");
@@ -46,10 +43,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const { version } = payload;
 
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
   const codebook = await CodebookService.findById(entityId);
   if (!codebook) {
     throw new Error("Codebook not found");

--- a/app/modules/codebooks/containers/codebookEditor.route.tsx
+++ b/app/modules/codebooks/containers/codebookEditor.route.tsx
@@ -4,9 +4,8 @@ import {
   useNavigation,
   useSubmit,
 } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
-import type { User } from "~/modules/users/users.types";
 import CodebookAuthorization from "../authorization";
 import { CodebookService } from "../codebook";
 import type { CodebookCategory } from "../codebooks.types";
@@ -16,10 +15,7 @@ import SaveCodebookVersionDialog from "../components/saveCodebookVersionDialog";
 import type { Route } from "./+types/codebookEditor.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const codebook = await CodebookService.findById(params.id);
 
@@ -51,10 +47,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const { name, categories } = payload;
 
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const codebookVersion = await CodebookVersionService.findById(entityId);
 
@@ -96,7 +89,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export default function CodebookEditorRoute() {
-  const data = useLoaderData();
+  const data = useLoaderData<typeof loader>();
   const navigation = useNavigation();
   const submit = useSubmit();
 

--- a/app/modules/codebooks/containers/codebooks.route.tsx
+++ b/app/modules/codebooks/containers/codebooks.route.tsx
@@ -1,15 +1,15 @@
 import find from "lodash/find";
 import map from "lodash/map";
 import { useContext, useEffect } from "react";
-import { data, redirect, useFetcher, useNavigate } from "react-router";
+import { data, useFetcher, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import CodebookAuthorization from "~/modules/codebooks/authorization";
 import addDialog from "~/modules/dialogs/addDialog";
 import type { User } from "~/modules/users/users.types";
@@ -58,15 +58,11 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+  const user = await requireAuth({ request });
+
   const { intent, entityId, payload = {} } = await request.json();
 
   const { name, description, team } = payload;
-
-  const user = (await getSessionUser({ request })) as User;
-
-  if (!user) {
-    return redirect("/");
-  }
 
   switch (intent) {
     case "CREATE_CODEBOOK": {

--- a/app/modules/datasets/__tests__/downloadMtmDataset.test.ts
+++ b/app/modules/datasets/__tests__/downloadMtmDataset.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action } from "../containers/downloadMtmDataset.route";
 
@@ -22,16 +23,14 @@ describe("downloadMtmDataset.route action", () => {
     await clearDocumentDB();
   });
 
-  it("throws when not authenticated", async () => {
+  it("redirects to / when not authenticated", async () => {
     const request = new Request("http://localhost/api/downloadMtmDataset", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ intent: "REQUEST_MTM_DOWNLOAD" }),
     });
 
-    await expect(action({ request })).rejects.toThrow(
-      "Authentication required",
-    );
+    await expectAuthRequired(() => action({ request }));
   });
 
   it("throws when agreed is not true", async () => {

--- a/app/modules/datasets/containers/downloadMtmDataset.route.tsx
+++ b/app/modules/datasets/containers/downloadMtmDataset.route.tsx
@@ -1,6 +1,6 @@
 import fse from "fs-extra";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
 import type { MtmLatest } from "../datasets.types";
 import {
@@ -9,8 +9,7 @@ import {
 } from "../helpers/getDatasetStoragePath";
 
 export async function action({ request }: { request: Request }) {
-  const user = await getSessionUser({ request });
-  if (!user) throw new Error("Authentication required");
+  const user = await requireAuth({ request });
 
   const { intent, agreed } = await request.json();
 

--- a/app/modules/evaluations/containers/evaluation.route.tsx
+++ b/app/modules/evaluations/containers/evaluation.route.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-router";
 import { toast } from "sonner";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import Evaluation from "~/modules/evaluations/components/evaluation";
 import AdjudicationDialogContainer from "~/modules/evaluations/containers/adjudicationDialog.container";
@@ -21,14 +21,10 @@ import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
 import { RunSetService } from "~/modules/runSets/runSet";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/evaluation.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -72,10 +68,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/evaluations/containers/evaluationCreate.route.tsx
+++ b/app/modules/evaluations/containers/evaluationCreate.route.tsx
@@ -9,7 +9,7 @@ import {
   useSubmit,
 } from "react-router";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import EvaluationCreate from "~/modules/evaluations/components/evaluationCreate";
 import { EvaluationService } from "~/modules/evaluations/evaluation";
 import getAnnotationSchemaFieldCounts from "~/modules/evaluations/helpers/getAnnotationSchemaFieldCounts";
@@ -20,14 +20,10 @@ import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
 import { RunSetService } from "~/modules/runSets/runSet";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/evaluationCreate.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -54,10 +50,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/events/__tests__/events.route.test.ts
+++ b/app/modules/events/__tests__/events.route.test.ts
@@ -3,6 +3,7 @@ import { ProjectService } from "~/modules/projects/project";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/events.route";
 import { emitter } from "../emitter";
@@ -34,18 +35,13 @@ describe("events.route loader", () => {
     await clearDocumentDB();
   });
 
-  it("returns 401 when unauthenticated", async () => {
-    let caughtError: unknown;
-    try {
-      await loader({
+  it("redirects to / when unauthenticated", async () => {
+    await expectAuthRequired(() =>
+      loader({
         request: new Request("http://localhost/api/events"),
         params: {},
-      } as any);
-    } catch (e) {
-      caughtError = e;
-    }
-    expect(caughtError).toBeInstanceOf(Response);
-    expect((caughtError as Response).status).toBe(401);
+      } as any),
+    );
   });
 
   it("only forwards UPLOAD_FILES events for the user's own projects", async () => {

--- a/app/modules/events/containers/events.route.tsx
+++ b/app/modules/events/containers/events.route.tsx
@@ -1,15 +1,12 @@
 import { type LoaderFunctionArgs } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { userIsSuperAdmin } from "~/modules/authorization/helpers/superAdmin";
 import { ProjectService } from "~/modules/projects/project";
 import { emitter } from "../emitter";
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) {
-    throw new Response("Unauthorized", { status: 401 });
-  }
+  const user = await requireAuth({ request });
 
   // Project IDs are snapshotted at connection time. If team membership or project
   // assignments change while the SSE stream is open, the filter will be stale

--- a/app/modules/featureFlags/__tests__/featureFlag.route.test.ts
+++ b/app/modules/featureFlags/__tests__/featureFlag.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/featureFlag.route";
 import { FeatureFlagService } from "../featureFlag";
@@ -12,14 +13,14 @@ describe("featureFlag.route", () => {
 
   describe("loader", () => {
     it("redirects to / when there is no session cookie", async () => {
-      const res = await loader({
-        request: new Request("http://localhost/"),
-        params: { id: "test-id" },
-        unstable_pattern: "",
-        context: {},
-      } as any);
-      expect(res).toBeInstanceOf(Response);
-      expect((res as Response).headers.get("Location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/"),
+          params: { id: "test-id" },
+          unstable_pattern: "",
+          context: {},
+        } as any),
+      );
     });
 
     it("returns feature flag with users that have it", async () => {

--- a/app/modules/featureFlags/containers/featureFlag.route.tsx
+++ b/app/modules/featureFlags/containers/featureFlag.route.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { data, redirect, useFetcher } from "react-router";
 import { toast } from "sonner";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
 import addDialog from "~/modules/dialogs/addDialog";
 import getQueue from "~/modules/queues/helpers/getQueue";
@@ -16,7 +16,7 @@ import type { Route } from "./+types/featureFlag.route";
 import AddUsersToFeatureFlagDialogContainer from "./addUsersToFeatureFlagDialog.container";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
     return redirect("/");
   }
@@ -34,7 +34,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
     return data({ errors: { general: "Access denied" } }, { status: 403 });
   }

--- a/app/modules/featureFlags/containers/featureFlags.route.tsx
+++ b/app/modules/featureFlags/containers/featureFlags.route.tsx
@@ -2,10 +2,9 @@ import get from "lodash/get";
 import { useEffect } from "react";
 import { data, redirect, useFetcher, useMatch, useMatches } from "react-router";
 import { toast } from "sonner";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
 import addDialog from "~/modules/dialogs/addDialog";
-import type { User } from "~/modules/users/users.types";
 import CreateFeatureFlagDialog from "../components/createFeatureFlagDialog";
 import FeatureFlags from "../components/featureFlags";
 import { FeatureFlagService } from "../featureFlag";
@@ -13,7 +12,7 @@ import type { FeatureFlag } from "../featureFlags.types";
 import type { Route } from "./+types/featureFlags.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
     return redirect("/");
   }
@@ -22,7 +21,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
     return data({ errors: { general: "Access denied" } }, { status: 403 });
   }

--- a/app/modules/files/__tests__/uploadFiles.route.test.ts
+++ b/app/modules/files/__tests__/uploadFiles.route.test.ts
@@ -6,6 +6,7 @@ import "~/modules/teams/team";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/uploadFiles.route";
 
@@ -21,12 +22,12 @@ describe("uploadFiles.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/projects/123/upload-files"),
-      params: { projectId: "123" },
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/projects/123/upload-files"),
+        params: { projectId: "123" },
+      } as any),
+    );
   });
 
   it("redirects to / when project not found", async () => {
@@ -120,12 +121,12 @@ describe("uploadFiles.route action", () => {
       body: formData,
     });
 
-    const res = await action({
-      request: req,
-      params: { projectId: "123" },
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      action({
+        request: req,
+        params: { projectId: "123" },
+      } as any),
+    );
   });
 
   it("returns 404 when project not found", async () => {

--- a/app/modules/files/containers/uploadFiles.route.tsx
+++ b/app/modules/files/containers/uploadFiles.route.tsx
@@ -9,18 +9,16 @@ import { data, Link, redirect, useFetcher, useNavigate } from "react-router";
 import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import insertMtmDataset from "~/modules/datasets/services/insertMtmDataset.server";
 import { FileService } from "~/modules/files/file";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/uploadFiles.route";
 import UploadFilesContainer from "./uploadFiles.container";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) return redirect("/");
@@ -39,8 +37,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/humanAnnotations/containers/downloadAnnotationTemplate.route.tsx
+++ b/app/modules/humanAnnotations/containers/downloadAnnotationTemplate.route.tsx
@@ -1,21 +1,18 @@
 import fse from "fs-extra";
 import { json2csv } from "json-2-csv";
-import { redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import type { AnnotationTemplateConfig } from "~/modules/humanAnnotations/humanAnnotations.types";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunSetService } from "~/modules/runSets/runSet";
 import { SessionService } from "~/modules/sessions/session";
 import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
-import type { User } from "~/modules/users/users.types";
 import buildAnnotationTemplateColumns from "../helpers/buildAnnotationTemplateColumns";
 import buildAnnotationTemplateRows from "../helpers/buildAnnotationTemplateRows";
 import type { Route } from "./+types/downloadAnnotationTemplate.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const runSet = await RunSetService.findById(params.runSetId);
   if (!runSet) throw new Error("Run set not found");

--- a/app/modules/humanAnnotations/containers/humanAnnotations.route.tsx
+++ b/app/modules/humanAnnotations/containers/humanAnnotations.route.tsx
@@ -1,11 +1,10 @@
 import path from "path";
 import { data } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunSetService } from "~/modules/runSets/runSet";
 import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
-import type { User } from "~/modules/users/users.types";
 import buildAnnotationSchemaFromHeaders from "../helpers/buildAnnotationSchemaFromHeaders";
 import analyzeHumanCsv from "../services/analyzeHumanCsv.server";
 import createHumanRun from "../services/createHumanRun.server";
@@ -13,10 +12,7 @@ import uploadHumanAnnotations from "../services/uploadHumanAnnotations.server";
 import type { Route } from "./+types/humanAnnotations.route";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    throw new Error("Authentication required");
-  }
+  const user = await requireAuth({ request });
 
   const runSet = await RunSetService.findById(params.runSetId);
   if (!runSet) {

--- a/app/modules/migrations/__tests__/migrations.route.test.ts
+++ b/app/modules/migrations/__tests__/migrations.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import type { Route } from "../containers/+types/migrations.route";
 import { action, loader } from "../containers/migrations.route";
@@ -22,15 +23,14 @@ describe("migrations.route", () => {
 
   describe("loader", () => {
     it("redirects if user is not authenticated", async () => {
-      const res = (await loader({
-        request: new Request("http://localhost/migrations"),
-        params: {},
-        unstable_pattern: "",
-        context: {},
-      } as any)) as any;
-
-      expect(res.status).toBe(302);
-      expect(res.headers.get("location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/migrations"),
+          params: {},
+          unstable_pattern: "",
+          context: {},
+        } as any),
+      );
     });
 
     it("redirects if user is not a super admin", async () => {
@@ -103,7 +103,7 @@ describe("migrations.route", () => {
   });
 
   describe("action", () => {
-    it("throws error if user is not authenticated", async () => {
+    it("redirects to / if user is not authenticated", async () => {
       const request = new Request("http://localhost/migrations", {
         method: "POST",
         body: JSON.stringify({
@@ -112,14 +112,14 @@ describe("migrations.route", () => {
         }),
       });
 
-      await expect(
+      await expectAuthRequired(() =>
         action({
           request,
           params: {},
           unstable_pattern: "",
           context: {},
         } as Route.ActionArgs),
-      ).rejects.toThrow("Access denied");
+      );
     });
 
     it("throws error if user is not a super admin", async () => {

--- a/app/modules/migrations/containers/migrations.route.tsx
+++ b/app/modules/migrations/containers/migrations.route.tsx
@@ -1,5 +1,5 @@
 import { redirect, useSubmit } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
 import getQueue from "~/modules/queues/helpers/getQueue";
 import Migrations from "../components/migrations";
@@ -7,7 +7,7 @@ import { MigrationService } from "../migration";
 import type { Route } from "./+types/migrations.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.Migrations.canManage(user)) {
     return redirect("/");
   }
@@ -18,8 +18,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user || !SystemAdminAuthorization.Migrations.canManage(user)) {
+  const user = await requireAuth({ request });
+  if (!SystemAdminAuthorization.Migrations.canManage(user)) {
     throw new Error("Access denied");
   }
 

--- a/app/modules/projects/__tests__/project.route.test.ts
+++ b/app/modules/projects/__tests__/project.route.test.ts
@@ -4,6 +4,7 @@ import "~/modules/teams/team";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/project.route";
 import { ProjectService } from "../project";
@@ -16,12 +17,12 @@ describe("project.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/projects/123"),
-      params: { id: "123" },
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/projects/123"),
+        params: { id: "123" },
+      } as any),
+    );
   });
 
   it("redirects to / when project not found", async () => {

--- a/app/modules/projects/containers/project.route.tsx
+++ b/app/modules/projects/containers/project.route.tsx
@@ -11,12 +11,11 @@ import {
   useRevalidator,
 } from "react-router";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { FileService } from "~/modules/files/file";
 import { RunService } from "~/modules/runs/run";
 import { RunSetService } from "~/modules/runSets/runSet";
 import { SessionService } from "~/modules/sessions/session";
-import type { User } from "~/modules/users/users.types";
 import ProjectAuthorization from "../authorization";
 import Project from "../components/project";
 import { useProjectActions } from "../hooks/useProjectActions";
@@ -24,11 +23,7 @@ import { ProjectService } from "../project";
 import type { Route } from "./+types/project.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.id);
   if (!project) {

--- a/app/modules/projects/containers/projects.route.tsx
+++ b/app/modules/projects/containers/projects.route.tsx
@@ -2,21 +2,15 @@ import escapeRegExp from "lodash/escapeRegExp";
 import find from "lodash/find";
 import map from "lodash/map";
 import { useContext, useEffect } from "react";
-import {
-  data,
-  redirect,
-  useLocation,
-  useNavigate,
-  useRevalidator,
-} from "react-router";
+import { data, useLocation, useNavigate, useRevalidator } from "react-router";
 import { toast } from "sonner";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import { TeamService } from "~/modules/teams/team";
 import type { User } from "~/modules/users/users.types";
@@ -58,11 +52,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const { intent, entityId, payload = {} } = await request.json();
   const { name, team } = payload;

--- a/app/modules/prompts/__tests__/prompt.route.test.ts
+++ b/app/modules/prompts/__tests__/prompt.route.test.ts
@@ -4,6 +4,7 @@ import { RunService } from "~/modules/runs/run";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action } from "../containers/prompt.route";
 import { PromptService } from "../prompt";
@@ -77,22 +78,21 @@ describe("prompt.route action", () => {
         createdBy: user._id,
       });
 
-      const response = await action({
-        request: new Request("http://localhost/", {
-          method: "POST",
-          body: JSON.stringify({
-            intent: "CREATE_PROMPT_VERSION",
-            entityId: prompt._id,
-            payload: { version: 1 },
+      await expectAuthRequired(() =>
+        action({
+          request: new Request("http://localhost/", {
+            method: "POST",
+            body: JSON.stringify({
+              intent: "CREATE_PROMPT_VERSION",
+              entityId: prompt._id,
+              payload: { version: 1 },
+            }),
           }),
-        }),
-        params: { id: prompt._id },
-        context: {},
-        unstable_pattern: "",
-      } as any);
-
-      expect(response).toBeInstanceOf(Response);
-      expect((response as Response).headers.get("Location")).toBe("/");
+          params: { id: prompt._id },
+          context: {},
+          unstable_pattern: "",
+        } as any),
+      );
     });
 
     it("throws when prompt does not exist", async () => {

--- a/app/modules/prompts/__tests__/promptVersionsList.route.test.ts
+++ b/app/modules/prompts/__tests__/promptVersionsList.route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/promptVersionsList.route";
 import { PromptService } from "../prompt";
@@ -13,12 +14,12 @@ describe("promptVersionsList.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/"),
-      params: {},
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/"),
+        params: {},
+      } as any),
+    );
   });
 
   it("redirects to / when prompt param is missing", async () => {

--- a/app/modules/prompts/__tests__/promptsList.route.test.ts
+++ b/app/modules/prompts/__tests__/promptsList.route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/promptsList.route";
 import { PromptService } from "../prompt";
@@ -13,12 +14,12 @@ describe("promptsList.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/"),
-      params: {},
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/"),
+        params: {},
+      } as any),
+    );
   });
 
   it("returns prompts that have at least one saved version, filtered by annotationType + teamId", async () => {

--- a/app/modules/prompts/containers/prompt.route.tsx
+++ b/app/modules/prompts/containers/prompt.route.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-router";
 import { toast } from "sonner";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import PromptAuthorization from "~/modules/prompts/authorization";
 import { usePromptActions } from "~/modules/prompts/hooks/usePromptActions";
 import { RunService } from "~/modules/runs/run";
@@ -19,10 +19,7 @@ import { PromptVersionService } from "../promptVersion";
 import type { Route } from "./+types/prompt.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
   const prompt = await PromptService.findById(params.id);
   if (!prompt) {
     return redirect("/prompts");
@@ -42,10 +39,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const { version } = payload;
 
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
   const prompt = await PromptService.findById(entityId);
   if (!prompt) {
     throw new Error("Prompt not found");

--- a/app/modules/prompts/containers/promptEditor.route.tsx
+++ b/app/modules/prompts/containers/promptEditor.route.tsx
@@ -5,11 +5,10 @@ import {
   useSubmit,
   type ShouldRevalidateFunctionArgs,
 } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { CodebookService } from "~/modules/codebooks/codebook";
 import { CodebookVersionService } from "~/modules/codebooks/codebookVersion";
 import addDialog from "~/modules/dialogs/addDialog";
-import type { User } from "~/modules/users/users.types";
 import PromptAuthorization from "../authorization";
 import PromptEditor from "../components/promptEditor";
 import { SYSTEM_FIELDS } from "../helpers/defaultPrompts";
@@ -20,10 +19,7 @@ import type { Route } from "./+types/promptEditor.route";
 import SavePromptVersionDialogContainer from "./savePromptVersionDialogContainer";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const prompt = await PromptService.findById(params.id);
 
@@ -73,10 +69,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const { name, userPrompt, annotationSchema } = payload;
 
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const promptVersion = await PromptVersionService.findById(entityId);
 

--- a/app/modules/prompts/containers/promptVersionAlignment.route.tsx
+++ b/app/modules/prompts/containers/promptVersionAlignment.route.tsx
@@ -1,16 +1,12 @@
-import { data, redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
-import type { User } from "~/modules/users/users.types";
+import { data } from "react-router";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import PromptAuthorization from "../authorization";
 import checkPromptAndAnnotationSchemaAlignment from "../services/checkPromptAndAnnotationSchemaAlignment.server";
 import suggestPromptAndAnnotationSchemaChanges from "../services/suggestPromptAndAnnotationSchemaChanges.server";
 import type { Route } from "./+types/promptVersionAlignment.route";
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const {
     intent,

--- a/app/modules/prompts/containers/promptVersionsList.route.tsx
+++ b/app/modules/prompts/containers/promptVersionsList.route.tsx
@@ -1,16 +1,12 @@
 import { redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { PromptService } from "~/modules/prompts/prompt";
 import { PromptVersionService } from "~/modules/prompts/promptVersion";
-import type { User } from "~/modules/users/users.types";
 import PromptAuthorization from "../authorization";
 import type { Route } from "./+types/promptVersionsList.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const url = new URL(request.url);
   const promptId = url.searchParams.get("prompt");

--- a/app/modules/prompts/containers/prompts.route.tsx
+++ b/app/modules/prompts/containers/prompts.route.tsx
@@ -1,13 +1,7 @@
 import find from "lodash/find";
 import map from "lodash/map";
 import { useContext, useEffect } from "react";
-import {
-  data,
-  redirect,
-  useFetcher,
-  useLocation,
-  useNavigate,
-} from "react-router";
+import { data, useFetcher, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
@@ -15,8 +9,8 @@ import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import PromptAuthorization from "~/modules/prompts/authorization";
 import { usePromptActions } from "~/modules/prompts/hooks/usePromptActions";
@@ -32,8 +26,7 @@ import { PromptVersionService } from "../promptVersion";
 import type { Route } from "./+types/prompts.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  await requireAuth({ request });
 
   const authenticationTeams = await getSessionUserTeams({ request });
   const teamIds = map(authenticationTeams, "team");
@@ -76,11 +69,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const { intent, payload = {} } = await request.json();
 

--- a/app/modules/prompts/containers/promptsList.route.tsx
+++ b/app/modules/prompts/containers/promptsList.route.tsx
@@ -1,17 +1,12 @@
 import map from "lodash/map";
-import { redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
-import type { User } from "~/modules/users/users.types";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import isValidAnnotationType from "../helpers/isValidAnnotationType";
 import { PromptService } from "../prompt";
 import type { Route } from "./+types/promptsList.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  await requireAuth({ request });
   const authenticationTeams = await getSessionUserTeams({ request });
   const teamIds = map(authenticationTeams, "team");
   const url = new URL(request.url);

--- a/app/modules/queues/__tests__/queue.route.test.ts
+++ b/app/modules/queues/__tests__/queue.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/queue.route";
 
@@ -10,13 +11,12 @@ describe("queue.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/queue/prompts"),
-      params: { type: "prompts" },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/queue/prompts"),
+        params: { type: "prompts" },
+      } as any),
+    );
   });
 
   it("requires super admin access", async () => {

--- a/app/modules/queues/__tests__/queueJobs.route.test.ts
+++ b/app/modules/queues/__tests__/queueJobs.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/queueJobs.route";
 
@@ -10,13 +11,12 @@ describe("queueJobs.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/queue/prompts/waiting"),
-      params: { type: "prompts", state: "waiting" },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/queue/prompts/waiting"),
+        params: { type: "prompts", state: "waiting" },
+      } as any),
+    );
   });
 
   it("requires super admin access", async () => {

--- a/app/modules/queues/containers/queue.route.tsx
+++ b/app/modules/queues/containers/queue.route.tsx
@@ -6,9 +6,8 @@ import {
   useParams,
 } from "react-router";
 import usePollingRevalidation from "~/modules/app/hooks/usePollingRevalidation";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
-import type { User } from "~/modules/users/users.types";
 import QueueControls from "../components/queueControls";
 import QueueStateTabs from "../components/queueStateTabs";
 import getQueue from "../helpers/getQueue";
@@ -16,7 +15,7 @@ import isQueuePro from "../helpers/isQueuePro";
 import type { Route } from "./+types/queue.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.Queues.canManage(user)) {
     return redirect("/");
   }
@@ -43,7 +42,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.Queues.canManage(user)) {
     throw new Error("Access denied");
   }

--- a/app/modules/queues/containers/queueJobs.route.tsx
+++ b/app/modules/queues/containers/queueJobs.route.tsx
@@ -10,10 +10,9 @@ import { toast } from "sonner";
 import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
 import addDialog from "~/modules/dialogs/addDialog";
-import type { User } from "~/modules/users/users.types";
 import DeleteJobDialog from "../components/deleteJobDialog";
 import JobDetailsDialog from "../components/jobDetailsDialog";
 import JobsList from "../components/jobsList";
@@ -25,7 +24,7 @@ import type { Job } from "../queues.types";
 import type { Route } from "./+types/queueJobs.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.Queues.canManage(user)) {
     return redirect("/");
   }
@@ -98,7 +97,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.Queues.canManage(user)) {
     return data({ errors: { general: "Access denied" } }, { status: 403 });
   }

--- a/app/modules/queues/containers/queuesLayout.route.tsx
+++ b/app/modules/queues/containers/queuesLayout.route.tsx
@@ -1,14 +1,13 @@
 import { redirect, useLoaderData } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
-import type { User } from "~/modules/users/users.types";
 import QueuesLayout from "../components/queuesLayout";
 import getQueue from "../helpers/getQueue";
 import isQueuePro from "../helpers/isQueuePro";
 import type { Route } from "./+types/queuesLayout.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
   if (!SystemAdminAuthorization.Queues.canManage(user)) {
     return redirect("/");
   }

--- a/app/modules/runSets/__tests__/downloadRunSet.route.test.ts
+++ b/app/modules/runSets/__tests__/downloadRunSet.route.test.ts
@@ -14,6 +14,7 @@ import type { User } from "~/modules/users/users.types";
 import "~/storageAdapters/local";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/downloadRunSet.route";
 
@@ -115,16 +116,15 @@ describe("downloadRunSet.route loader", () => {
   }
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request(
-        `http://localhost/api/downloads/${project._id}/run-sets/${runSet._id}?exportType=CSV`,
-      ),
-      params: { projectId: project._id, runSetId: runSet._id },
-      context: {},
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request(
+          `http://localhost/api/downloads/${project._id}/run-sets/${runSet._id}?exportType=CSV`,
+        ),
+        params: { projectId: project._id, runSetId: runSet._id },
+        context: {},
+      } as any),
+    );
   });
 
   it("redirects to / when project not found", async () => {

--- a/app/modules/runSets/__tests__/runSetAddRuns.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetAddRuns.route.test.ts
@@ -7,6 +7,7 @@ import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/runSetAddRuns.route";
 
@@ -16,13 +17,12 @@ beforeEach(async () => {
 
 describe("runSetAddRuns.route loader", () => {
   it("redirects to / when there is no session", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/"),
-      params: { projectId: "any", runSetId: "any" },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/"),
+        params: { projectId: "any", runSetId: "any" },
+      } as any),
+    );
   });
 
   it("redirects to / when project not found", async () => {

--- a/app/modules/runSets/__tests__/runSetCreate.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetCreate.route.test.ts
@@ -15,6 +15,7 @@ import type { Team } from "~/modules/teams/teams.types";
 import { UserService } from "~/modules/users/user";
 import type { User } from "~/modules/users/users.types";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/runSetCreate.route";
 
@@ -68,15 +69,14 @@ describe("runSetCreate.route", () => {
 
   describe("loader", () => {
     it("redirects to / when there is no session", async () => {
-      const res = await loader({
-        request: new Request("http://localhost/"),
-        params: { projectId: project._id },
-        unstable_pattern: "",
-        context: {},
-      } as any);
-
-      expect(res).toBeInstanceOf(Response);
-      expect((res as Response).headers.get("Location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/"),
+          params: { projectId: project._id },
+          unstable_pattern: "",
+          context: {},
+        } as any),
+      );
     });
 
     it("redirects to / when project not found", async () => {
@@ -194,17 +194,16 @@ describe("runSetCreate.route", () => {
         },
       });
 
-      const res = await action({
-        request: new Request("http://localhost/", {
-          method: "POST",
-          body,
-        }),
-        params: { projectId: project._id },
-        context: {},
-      } as any);
-
-      expect(res).toBeInstanceOf(Response);
-      expect((res as Response).headers.get("Location")).toBe("/");
+      await expectAuthRequired(() =>
+        action({
+          request: new Request("http://localhost/", {
+            method: "POST",
+            body,
+          }),
+          params: { projectId: project._id },
+          context: {},
+        } as any),
+      );
     });
   });
 });

--- a/app/modules/runSets/__tests__/runSetCreateRuns.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetCreateRuns.route.test.ts
@@ -12,6 +12,7 @@ import type { Team } from "~/modules/teams/teams.types";
 import { UserService } from "~/modules/users/user";
 import type { User } from "~/modules/users/users.types";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/runSetCreateRuns.route";
 import { buildUsedPromptModelKey } from "../helpers/getUsedPromptModels";
@@ -73,13 +74,12 @@ describe("runSetCreateRuns.route", () => {
 
   describe("loader", () => {
     it("redirects to / when there is no session", async () => {
-      const res = await loader({
-        request: new Request("http://localhost/"),
-        params: { projectId: project._id, runSetId: runSet._id },
-      } as any);
-
-      expect(res).toBeInstanceOf(Response);
-      expect((res as Response).headers.get("Location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/"),
+          params: { projectId: project._id, runSetId: runSet._id },
+        } as any),
+      );
     });
 
     it("redirects to / when user cannot view project", async () => {

--- a/app/modules/runSets/__tests__/runSetDetail.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetDetail.route.test.ts
@@ -14,6 +14,7 @@ import { UserService } from "~/modules/users/user";
 import type { User } from "~/modules/users/users.types";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/runSetDetail.route";
 
@@ -70,15 +71,14 @@ describe("runSetDetail.route loader", () => {
   });
 
   it("redirects to / when there is no session", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/"),
-      params: { projectId: project._id, runSetId: runSet._id },
-      unstable_pattern: "",
-      context: {},
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/"),
+        params: { projectId: project._id, runSetId: runSet._id },
+        unstable_pattern: "",
+        context: {},
+      } as any),
+    );
   });
 
   it("redirects to / when project not found", async () => {

--- a/app/modules/runSets/__tests__/runSetMerge.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetMerge.route.test.ts
@@ -7,6 +7,7 @@ import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/runSetMerge.route";
 
@@ -16,13 +17,12 @@ beforeEach(async () => {
 
 describe("runSetMerge.route loader", () => {
   it("redirects to / when there is no session", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/"),
-      params: { projectId: "any", runSetId: "any" },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/"),
+        params: { projectId: "any", runSetId: "any" },
+      } as any),
+    );
   });
 
   it("redirects to / when project not found", async () => {

--- a/app/modules/runSets/__tests__/runSetOverview.route.test.ts
+++ b/app/modules/runSets/__tests__/runSetOverview.route.test.ts
@@ -12,6 +12,7 @@ import { UserService } from "~/modules/users/user";
 import type { User } from "~/modules/users/users.types";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/runSetOverview.route";
 
@@ -68,15 +69,14 @@ describe("runSetOverview.route loader", () => {
   });
 
   it("redirects to / when there is no session", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/"),
-      params: { projectId: project._id, runSetId: runSet._id },
-      unstable_pattern: "",
-      context: {},
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/"),
+        params: { projectId: project._id, runSetId: runSet._id },
+        unstable_pattern: "",
+        context: {},
+      } as any),
+    );
   });
 
   it("returns empty runs and sessions for empty runSet", async () => {
@@ -398,20 +398,19 @@ describe("runSetOverview.route action", () => {
   });
 
   it("redirects to / when unauthenticated for REMOVE_RUN_FROM_RUN_SET", async () => {
-    const res = await action({
-      request: new Request("http://localhost/", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          intent: "REMOVE_RUN_FROM_RUN_SET",
-          payload: { runId: run._id },
+    await expectAuthRequired(() =>
+      action({
+        request: new Request("http://localhost/", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            intent: "REMOVE_RUN_FROM_RUN_SET",
+            payload: { runId: run._id },
+          }),
         }),
-      }),
-      params: { projectId: project._id, runSetId: runSet._id },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+        params: { projectId: project._id, runSetId: runSet._id },
+      } as any),
+    );
   });
 
   it("removes run from run set when authenticated", async () => {

--- a/app/modules/runSets/containers/downloadRunSet.route.tsx
+++ b/app/modules/runSets/containers/downloadRunSet.route.tsx
@@ -3,13 +3,12 @@ import map from "lodash/map";
 import { PassThrough, Readable } from "node:stream";
 import { redirect } from "react-router";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
 import type { RunSet } from "~/modules/runSets/runSets.types";
 import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
 import type { StorageAdapter } from "~/modules/storage/storage.types";
-import type { User } from "~/modules/users/users.types";
 import { RunSetService } from "../runSet";
 import type { Route } from "./+types/downloadRunSet.route";
 
@@ -66,8 +65,7 @@ async function downloadFiles(
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
   const teamIds = map(user.teams, "team");
 
   const project = await ProjectService.findOne({

--- a/app/modules/runSets/containers/runSetAddRuns.route.tsx
+++ b/app/modules/runSets/containers/runSetAddRuns.route.tsx
@@ -19,20 +19,16 @@ import {
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { getRunModelDisplayName } from "~/modules/runs/helpers/runModel";
 import type { Run } from "~/modules/runs/runs.types";
 import { RunSetService } from "~/modules/runSets/runSet";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/runSetAddRuns.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -76,10 +72,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runSets/containers/runSetCreate.route.tsx
+++ b/app/modules/runSets/containers/runSetCreate.route.tsx
@@ -10,7 +10,7 @@ import {
 import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { getAvailableModels } from "~/modules/llm/modelRegistry";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
@@ -28,14 +28,10 @@ import type {
   PromptReference,
 } from "~/modules/runSets/runSets.types";
 import { SessionService } from "~/modules/sessions/session";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/runSetCreate.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -217,10 +213,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runSets/containers/runSetCreateRuns.route.tsx
+++ b/app/modules/runSets/containers/runSetCreateRuns.route.tsx
@@ -10,7 +10,7 @@ import {
 import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import ProjectAuthorization from "~/modules/projects/authorization";
@@ -22,15 +22,11 @@ import getUsedPromptModels, {
 } from "~/modules/runSets/helpers/getUsedPromptModels";
 import { RunSetService } from "~/modules/runSets/runSet";
 import { SessionService } from "~/modules/sessions/session";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/runSetCreateRuns.route";
 import RunSetCreateRunsContainer from "./runSetCreateRuns.container";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -80,10 +76,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runSets/containers/runSetDetail.route.tsx
+++ b/app/modules/runSets/containers/runSetDetail.route.tsx
@@ -12,7 +12,7 @@ import {
 import type { Breadcrumb } from "~/modules/app/app.types";
 import triggerDownload from "~/modules/app/helpers/triggerDownload";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import DownloadAnnotationTemplateDialog from "~/modules/humanAnnotations/components/downloadAnnotationTemplateDialog";
 import getAnnotationFieldsFromRuns from "~/modules/humanAnnotations/helpers/getAnnotationFieldsFromRuns";
@@ -26,14 +26,10 @@ import StopRunSetDialog from "~/modules/runSets/components/stopRunSetDialog";
 import exportRunSet from "~/modules/runSets/helpers/exportRunSet";
 import { useRunSetActions } from "~/modules/runSets/hooks/useRunSetActions";
 import { RunSetService } from "~/modules/runSets/runSet";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/runSetDetail.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -87,10 +83,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runSets/containers/runSetEvaluations.route.tsx
+++ b/app/modules/runSets/containers/runSetEvaluations.route.tsx
@@ -1,25 +1,16 @@
-import {
-  redirect,
-  useLoaderData,
-  useNavigate,
-  useOutletContext,
-} from "react-router";
+import { useLoaderData, useNavigate, useOutletContext } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { EvaluationService } from "~/modules/evaluations/evaluation";
 import isAbleToCreateEvaluation from "~/modules/evaluations/helpers/isAbleToCreateEvaluation";
 import RunSetEvaluations from "~/modules/runSets/components/runSetEvaluations";
 import type { RunSet } from "~/modules/runSets/runSets.types";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/runSetEvaluations.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  await requireAuth({ request });
 
   const queryParams = getQueryParamsFromRequest(request, {
     searchValue: "",

--- a/app/modules/runSets/containers/runSetMerge.route.tsx
+++ b/app/modules/runSets/containers/runSetMerge.route.tsx
@@ -18,19 +18,15 @@ import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import getDateString from "~/modules/app/helpers/getDateString";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunSetService } from "~/modules/runSets/runSet";
 import type { RunSet } from "~/modules/runSets/runSets.types";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/runSetMerge.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -73,10 +69,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runSets/containers/runSetOverview.route.tsx
+++ b/app/modules/runSets/containers/runSetOverview.route.tsx
@@ -14,7 +14,7 @@ import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromR
 import triggerDownload from "~/modules/app/helpers/triggerDownload";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
@@ -27,14 +27,10 @@ import { RunSetService } from "~/modules/runSets/runSet";
 import type { RunSet } from "~/modules/runSets/runSets.types";
 import ViewSessionContainer from "~/modules/sessions/containers/viewSessionContainer";
 import { SessionService } from "~/modules/sessions/session";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/runSetOverview.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -109,8 +105,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runSets/containers/runSetsList.route.tsx
+++ b/app/modules/runSets/containers/runSetsList.route.tsx
@@ -2,21 +2,17 @@ import { data, redirect, useNavigate } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { useRunSetActions } from "~/modules/runSets/hooks/useRunSetActions";
 import { RunSetService } from "~/modules/runSets/runSet";
 import type { RunSet } from "~/modules/runSets/runSets.types";
-import type { User } from "~/modules/users/users.types";
 import RunSetsList from "../components/runSetsList";
 import type { Route } from "./+types/runSetsList.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.id);
   if (!project) {
@@ -47,10 +43,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.id);
   if (!project) {

--- a/app/modules/runs/__tests__/downloadRun.route.test.ts
+++ b/app/modules/runs/__tests__/downloadRun.route.test.ts
@@ -2,6 +2,7 @@ import { Types } from "mongoose";
 import { beforeEach, describe, expect, it } from "vitest";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/downloadRun.route";
 
@@ -13,13 +14,14 @@ describe("downloadRun.route loader", () => {
   it("redirects to / when there is no session cookie", async () => {
     const fakeRunId = new Types.ObjectId().toString();
 
-    const res = await loader({
-      request: new Request("http://localhost/runs/" + fakeRunId + "/download"),
-      params: { runId: fakeRunId },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request(
+          "http://localhost/runs/" + fakeRunId + "/download",
+        ),
+        params: { runId: fakeRunId },
+      } as any),
+    );
   });
 
   it("returns error when run not found", async () => {

--- a/app/modules/runs/__tests__/run.route.test.ts
+++ b/app/modules/runs/__tests__/run.route.test.ts
@@ -7,6 +7,7 @@ import "~/modules/teams/team";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/run.route";
 
@@ -284,20 +285,19 @@ describe("run.route action", () => {
       shouldRunVerification: false,
     });
 
-    const res = await action({
-      request: new Request(
-        "http://localhost/projects/" + project._id + "/runs/" + run._id,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ intent: "DELETE_RUN", payload: {} }),
-        },
-      ),
-      params: { projectId: project._id, runId: run._id },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      action({
+        request: new Request(
+          "http://localhost/projects/" + project._id + "/runs/" + run._id,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ intent: "DELETE_RUN", payload: {} }),
+          },
+        ),
+        params: { projectId: project._id, runId: run._id },
+      } as any),
+    );
   });
 
   it("redirects to / when user is not in project team", async () => {

--- a/app/modules/runs/__tests__/runAddToRunSet.route.test.ts
+++ b/app/modules/runs/__tests__/runAddToRunSet.route.test.ts
@@ -5,6 +5,7 @@ import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { ProjectService } from "../../projects/project";
 import { action } from "../containers/runAddToRunSet.route";
@@ -286,13 +287,12 @@ describe("runAddToRunSet.route action - CREATE_RUN_SET", () => {
       },
     );
 
-    const resp = await action({
-      request: req,
-      params: { projectId: project._id, runId: run._id },
-    } as any);
-
-    expect(resp).toBeInstanceOf(Response);
-    expect((resp as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      action({
+        request: req,
+        params: { projectId: project._id, runId: run._id },
+      } as any),
+    );
   });
 
   it("ADD_TO_RUN_SETS returns 404 when runSetIds belong to a different project", async () => {

--- a/app/modules/runs/__tests__/runs.route.test.ts
+++ b/app/modules/runs/__tests__/runs.route.test.ts
@@ -5,6 +5,7 @@ import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import createTestRun from "../../../../test/helpers/createTestRun";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/runs.route";
 
@@ -25,15 +26,14 @@ describe("runs.route loader - authorization", () => {
       team: team._id,
     });
 
-    const res = await loader({
-      request: new Request(
-        "http://localhost/projects/" + project._id + "/runs",
-      ),
-      params: { id: project._id },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).status).toBe(302);
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request(
+          "http://localhost/projects/" + project._id + "/runs",
+        ),
+        params: { id: project._id },
+      } as any),
+    );
   });
 
   it("redirects users who are not members of the project's team", async () => {

--- a/app/modules/runs/containers/createRun.route.tsx
+++ b/app/modules/runs/containers/createRun.route.tsx
@@ -10,8 +10,8 @@ import {
 import { toast } from "sonner";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import useSubmitGuard from "~/modules/app/hooks/useSubmitGuard";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import ProjectAuthorization from "~/modules/projects/authorization";
@@ -71,8 +71,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runs/containers/downloadRun.route.tsx
+++ b/app/modules/runs/containers/downloadRun.route.tsx
@@ -3,16 +3,14 @@ import map from "lodash/map";
 import { PassThrough, Readable } from "node:stream";
 import { redirect } from "react-router";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { ProjectService } from "~/modules/projects/project";
 import getStorageAdapter from "~/modules/storage/helpers/getStorageAdapter";
-import type { User } from "~/modules/users/users.types";
 import { RunService } from "../run";
 import type { Route } from "./+types/downloadRun.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
   const teamIds = map(user.teams, "team");
 
   const project = await ProjectService.findOne({

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -13,8 +13,8 @@ import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromR
 import triggerDownload from "~/modules/app/helpers/triggerDownload";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
@@ -97,8 +97,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project || !ProjectAuthorization.Runs.canManage(user, project)) {

--- a/app/modules/runs/containers/runAddToRunSet.route.tsx
+++ b/app/modules/runs/containers/runAddToRunSet.route.tsx
@@ -9,20 +9,16 @@ import {
 import { toast } from "sonner";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
 import { RunSetService } from "~/modules/runSets/runSet";
-import type { User } from "~/modules/users/users.types";
 import RunAddToRunSet from "../components/runAddToRunSet";
 import type { Route } from "./+types/runAddToRunSet.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {
@@ -66,10 +62,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.projectId);
   if (!project) {

--- a/app/modules/runs/containers/runSessions.route.tsx
+++ b/app/modules/runs/containers/runSessions.route.tsx
@@ -3,7 +3,7 @@ import map from "lodash/map";
 import { redirect, useLoaderData, useNavigation } from "react-router";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { ProjectService } from "~/modules/projects/project";
 import { RunService } from "~/modules/runs/run";
 import { RunSetService } from "~/modules/runSets/runSet";
@@ -16,8 +16,8 @@ export const meta: Route.MetaFunction = () => [
 ];
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const authenticationTeams = await getSessionUserTeams({ request });
-  const teamIds = map(authenticationTeams, "team");
+  const user = await requireAuth({ request });
+  const teamIds = map(user.teams, "team");
   const project = await ProjectService.findOne({
     _id: params.projectId,
     team: { $in: teamIds },

--- a/app/modules/runs/containers/runs.route.tsx
+++ b/app/modules/runs/containers/runs.route.tsx
@@ -12,8 +12,8 @@ import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import useHandleSockets from "~/modules/app/hooks/useHandleSockets";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import getSessionUserTeams from "~/modules/authentication/helpers/getSessionUserTeams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { ProjectService } from "~/modules/projects/project";
 import { useCreateRunSetForRun } from "~/modules/runs/hooks/useCreateRunSetForRun";
 import { useRunActions } from "~/modules/runs/hooks/useRunActions";
@@ -23,8 +23,7 @@ import Runs from "../components/runs";
 import type { Route } from "./+types/runs.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  await requireAuth({ request });
 
   const authenticationTeams = await getSessionUserTeams({ request });
   const teamIds = map(authenticationTeams, "team");

--- a/app/modules/sessions/__tests__/sessions.route.test.ts
+++ b/app/modules/sessions/__tests__/sessions.route.test.ts
@@ -5,6 +5,7 @@ import "~/modules/teams/team";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/sessions.route";
 
@@ -42,15 +43,14 @@ describe("sessions.route loader", () => {
       team: team._id,
     });
 
-    const res = await loader({
-      request: new Request(
-        "http://localhost/projects/" + project._id + "/sessions",
-      ),
-      params: { id: project._id.toString() },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request(
+          "http://localhost/projects/" + project._id + "/sessions",
+        ),
+        params: { id: project._id.toString() },
+      } as any),
+    );
   });
 
   it("returns sessions for authorized user", async () => {
@@ -99,20 +99,19 @@ describe("sessions.route action", () => {
       team: team._id,
     });
 
-    const res = await action({
-      request: new Request(
-        "http://localhost/projects/" + project._id + "/sessions",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ intent: "RE_RUN" }),
-        },
-      ),
-      params: { id: project._id.toString() },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      action({
+        request: new Request(
+          "http://localhost/projects/" + project._id + "/sessions",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ intent: "RE_RUN" }),
+          },
+        ),
+        params: { id: project._id.toString() },
+      } as any),
+    );
   });
 
   it("redirects to / when user cannot view project for RE_RUN", async () => {

--- a/app/modules/sessions/containers/files.route.tsx
+++ b/app/modules/sessions/containers/files.route.tsx
@@ -2,19 +2,15 @@ import { redirect, useNavigate } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { FileService } from "~/modules/files/file";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
-import type { User } from "~/modules/users/users.types";
 import Files from "../components/files";
 import type { Route } from "./+types/files.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.id);
   if (!project) {

--- a/app/modules/sessions/containers/sessions.route.tsx
+++ b/app/modules/sessions/containers/sessions.route.tsx
@@ -3,23 +3,19 @@ import { redirect, useLoaderData, useSubmit } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
 import ViewSessionContainer from "~/modules/sessions/containers/viewSessionContainer";
 import { SessionService } from "~/modules/sessions/session";
 import type { Session } from "~/modules/sessions/sessions.types";
-import type { User } from "~/modules/users/users.types";
 import Sessions from "../components/sessions";
 import createSessionsFromFiles from "../services/createSessionsFromFiles.server";
 import type { Route } from "./+types/sessions.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.id);
   if (!project) {
@@ -51,8 +47,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const project = await ProjectService.findById(params.id);
   if (!project || !ProjectAuthorization.canView(user, project)) {

--- a/app/modules/sessions/containers/sessionsList.route.tsx
+++ b/app/modules/sessions/containers/sessionsList.route.tsx
@@ -1,16 +1,12 @@
 import { redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
-import type { User } from "~/modules/users/users.types";
 import { SessionService } from "../session";
 import type { Route } from "./+types/sessionsList.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const url = new URL(request.url);
   const projectId = url.searchParams.get("project");

--- a/app/modules/storage/containers/storage.route.tsx
+++ b/app/modules/storage/containers/storage.route.tsx
@@ -1,8 +1,7 @@
 import type { ActionFunctionArgs } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
-import type { User } from "~/modules/users/users.types";
 import getStorageAdapter from "../helpers/getStorageAdapter";
 
 function extractProjectIdFromUrl(rawUrl: string): string {
@@ -21,10 +20,7 @@ function extractProjectIdFromUrl(rawUrl: string): string {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    throw new Error("Authentication required");
-  }
+  const user = await requireAuth({ request });
 
   const { intent, payload } = await request.json();
 

--- a/app/modules/support/containers/supportArticles.route.tsx
+++ b/app/modules/support/containers/supportArticles.route.tsx
@@ -2,9 +2,7 @@ import Markdoc from "@markdoc/markdoc";
 import fs from "fs";
 import matter from "gray-matter";
 import path from "path";
-import { redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
-import type { User } from "~/modules/users/users.types";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import type { Route } from "./+types/supportArticles.route";
 
 interface SupportArticle {
@@ -14,10 +12,7 @@ interface SupportArticle {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  await requireAuth({ request });
 
   const supportArticles: SupportArticle[] = [];
 

--- a/app/modules/systemSettings/__tests__/maintenance.route.test.ts
+++ b/app/modules/systemSettings/__tests__/maintenance.route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { AuditService } from "~/modules/audits/audit";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/maintenance.route";
 import { SystemSettingsService } from "../systemSettings";
@@ -13,15 +14,14 @@ describe("maintenance.route", () => {
 
   describe("loader", () => {
     it("redirects when not authenticated", async () => {
-      const res = (await loader({
-        request: new Request("http://localhost/admin/maintenance"),
-        params: {},
-        unstable_pattern: "",
-        context: {},
-      } as any)) as any;
-
-      expect(res.status).toBe(302);
-      expect(res.headers.get("location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/admin/maintenance"),
+          params: {},
+          unstable_pattern: "",
+          context: {},
+        } as any),
+      );
     });
 
     it("redirects when user is not a super admin", async () => {
@@ -67,22 +67,21 @@ describe("maintenance.route", () => {
   });
 
   describe("action - TOGGLE_MAINTENANCE", () => {
-    it("returns 403 when not authenticated", async () => {
-      const res = (await action({
-        request: new Request("http://localhost/admin/maintenance", {
-          method: "POST",
-          body: JSON.stringify({
-            intent: "TOGGLE_MAINTENANCE",
-            payload: { maintenanceMode: true, maintenanceMessage: "" },
+    it("redirects to / when not authenticated", async () => {
+      await expectAuthRequired(() =>
+        action({
+          request: new Request("http://localhost/admin/maintenance", {
+            method: "POST",
+            body: JSON.stringify({
+              intent: "TOGGLE_MAINTENANCE",
+              payload: { maintenanceMode: true, maintenanceMessage: "" },
+            }),
           }),
-        }),
-        params: {},
-        unstable_pattern: "",
-        context: {},
-      } as any)) as any;
-
-      expect(res.init?.status).toBe(403);
-      expect(res.data?.errors?.general).toBe("Access denied");
+          params: {},
+          unstable_pattern: "",
+          context: {},
+        } as any),
+      );
     });
 
     it("returns 403 when user is not a super admin", async () => {

--- a/app/modules/systemSettings/containers/maintenance.route.tsx
+++ b/app/modules/systemSettings/containers/maintenance.route.tsx
@@ -2,15 +2,15 @@ import { useEffect, useState } from "react";
 import { data, redirect, useFetcher } from "react-router";
 import { toast } from "sonner";
 import { AuditService } from "~/modules/audits/audit";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
 import Maintenance from "../components/maintenance";
 import { SystemSettingsService } from "../systemSettings";
 import type { Route } from "./+types/maintenance.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user || !SystemAdminAuthorization.Maintenance.canManage(user)) {
+  const user = await requireAuth({ request });
+  if (!SystemAdminAuthorization.Maintenance.canManage(user)) {
     return redirect("/");
   }
 
@@ -20,8 +20,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user || !SystemAdminAuthorization.Maintenance.canManage(user)) {
+  const user = await requireAuth({ request });
+  if (!SystemAdminAuthorization.Maintenance.canManage(user)) {
     return data({ errors: { general: "Access denied" } }, { status: 403 });
   }
 

--- a/app/modules/teams/__tests__/team.route.test.ts
+++ b/app/modules/teams/__tests__/team.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/team.route";
 import { TeamService } from "../team";
@@ -13,12 +14,12 @@ describe("team.route loader", () => {
   it("redirects to / when there is no session cookie", async () => {
     const team = await TeamService.create({ name: "test team" });
 
-    const res = await loader({
-      request: new Request("http://localhost/teams/" + team._id),
-      params: { id: team._id },
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/teams/" + team._id),
+        params: { id: team._id },
+      } as any),
+    );
   });
 
   it("returns team when user is super admin", async () => {
@@ -43,12 +44,11 @@ describe("team.route loader", () => {
   });
 
   it("redirects to / when team does not exist and no auth", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/teams/nonexistent"),
-      params: { id: "nonexistent" },
-    } as any);
-
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request("http://localhost/teams/nonexistent"),
+        params: { id: "nonexistent" },
+      } as any),
+    );
   });
 });

--- a/app/modules/teams/__tests__/teamUsers.route.test.ts
+++ b/app/modules/teams/__tests__/teamUsers.route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/teamUsers.route";
 
@@ -14,15 +15,14 @@ describe("teamUsers.route", () => {
     it("redirects to / when there is no session cookie", async () => {
       const team = await TeamService.create({ name: "test-team" });
 
-      const res = await loader({
-        request: new Request("http://localhost/"),
-        params: { id: team._id },
-        unstable_pattern: "",
-        context: {},
-      } as any);
-
-      expect(res).toBeInstanceOf(Response);
-      expect((res as Response).headers.get("Location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/"),
+          params: { id: team._id },
+          unstable_pattern: "",
+          context: {},
+        } as any),
+      );
     });
 
     it("redirects to / when user is not authorized to view team users", async () => {

--- a/app/modules/teams/__tests__/teams.route.test.ts
+++ b/app/modules/teams/__tests__/teams.route.test.ts
@@ -4,6 +4,7 @@ import { TeamBillingPlanService } from "~/modules/billing/teamBillingPlan";
 import { TeamCreditService } from "~/modules/billing/teamCredit";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/teams.route";
 import { TeamService } from "../team";
@@ -15,12 +16,12 @@ describe("teams.route", () => {
 
   describe("loader", () => {
     it("redirects to / when there is no session cookie", async () => {
-      const res = await loader({
-        request: new Request("http://localhost/teams"),
-        params: {},
-      } as any);
-      expect(res).toBeInstanceOf(Response);
-      expect((res as Response).headers.get("Location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/teams"),
+          params: {},
+        } as any),
+      );
     });
 
     it("returns all teams for super admin", async () => {

--- a/app/modules/teams/containers/generateInviteToTeam.route.tsx
+++ b/app/modules/teams/containers/generateInviteToTeam.route.tsx
@@ -1,14 +1,13 @@
 import crypto from "crypto";
-import { data, redirect } from "react-router";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import { data } from "react-router";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { UserService } from "~/modules/users/user";
 import TeamAuthorization from "../authorization";
 import { isTeamRole } from "../teams.types";
 import type { Route } from "./+types/generateInviteToTeam.route";
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const { intent, payload = {} } = await request.json();
   const { teamId, role, name } = payload;

--- a/app/modules/teams/containers/team.route.tsx
+++ b/app/modules/teams/containers/team.route.tsx
@@ -1,11 +1,10 @@
 import { useEffect } from "react";
 import { redirect, useFetcher } from "react-router";
 import { toast } from "sonner";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import BillingAuthorization from "~/modules/billing/authorization";
 import isBillingEnabled from "~/modules/billing/helpers/isBillingEnabled.server";
 import addDialog from "~/modules/dialogs/addDialog";
-import type { User } from "~/modules/users/users.types";
 import TeamAuthorization from "../authorization";
 import EditTeamDialog from "../components/editTeamDialog";
 import TeamComponent from "../components/team";
@@ -14,11 +13,7 @@ import type { Team } from "../teams.types";
 import type { Route } from "./+types/team.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const userSession = (await getSessionUser({ request })) as User;
-
-  if (!userSession) {
-    return redirect("/");
-  }
+  const userSession = await requireAuth({ request });
 
   if (!TeamAuthorization.canView(userSession, params.id)) {
     return redirect("/");

--- a/app/modules/teams/containers/teamBilling.route.tsx
+++ b/app/modules/teams/containers/teamBilling.route.tsx
@@ -11,7 +11,7 @@ import { toast } from "sonner";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import BillingAuthorization from "~/modules/billing/authorization";
 import { BillingPeriodService } from "~/modules/billing/billingPeriod";
 import { BillingPlanService } from "~/modules/billing/billingPlan";
@@ -38,8 +38,7 @@ import { TeamService } from "../team";
 import type { Route } from "./+types/teamBilling.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   if (!TeamAuthorization.canView(user, params.id)) {
     return redirect("/");
@@ -156,8 +155,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) throw new Error("Authentication required");
+  const user = await requireAuth({ request });
 
   const { intent, payload = {} } = await request.json();
 

--- a/app/modules/teams/containers/teamProjects.route.tsx
+++ b/app/modules/teams/containers/teamProjects.route.tsx
@@ -12,7 +12,7 @@ import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import CreateProjectDialog from "~/modules/projects/components/createProjectDialog";
@@ -23,10 +23,7 @@ import TeamProjects from "../components/teamProjects";
 import type { Route } from "./+types/teamProjects.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
   if (!TeamAuthorization.canView(user, params.id)) {
     return redirect("/");
   }
@@ -69,8 +66,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const { intent, payload = {} } = await request.json();
   const { name } = payload;
 
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   if (!ProjectAuthorization.canCreate(user, params.id)) {
     throw new Error(

--- a/app/modules/teams/containers/teamPrompts.route.tsx
+++ b/app/modules/teams/containers/teamPrompts.route.tsx
@@ -13,7 +13,7 @@ import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.serve
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import PromptAuthorization from "~/modules/prompts/authorization";
 import CreatePromptDialog from "~/modules/prompts/components/createPromptDialog";
@@ -25,10 +25,7 @@ import TeamPrompts from "../components/teamPrompts";
 import type { Route } from "./+types/teamPrompts.route";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
   if (!TeamAuthorization.canView(user, params.id)) {
     return redirect("/");
   }
@@ -71,8 +68,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const { intent, payload = {} } = await request.json();
   const { name, annotationType } = payload;
 
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   if (!PromptAuthorization.canCreate(user, params.id)) {
     throw new Error(

--- a/app/modules/teams/containers/teamUsers.route.tsx
+++ b/app/modules/teams/containers/teamUsers.route.tsx
@@ -11,7 +11,7 @@ import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import addDialog from "~/modules/dialogs/addDialog";
 import { UserService } from "~/modules/users/user";
 import type { User } from "~/modules/users/users.types";
@@ -27,10 +27,7 @@ import AddUserToTeamDialogContainer from "./addUserToTeamDialog.container";
 import InviteUserToTeamDialogContainer from "./inviteUserToTeamDialogContainer";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
   if (!TeamAuthorization.Users.canView(user, params.id)) {
     return redirect("/");
   }
@@ -55,8 +52,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User | null;
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const { intent, payload = {} } = await request.json();
   const { userId } = payload;

--- a/app/modules/teams/containers/teams.route.tsx
+++ b/app/modules/teams/containers/teams.route.tsx
@@ -1,13 +1,13 @@
 import find from "lodash/find";
 import map from "lodash/map";
 import { useContext, useEffect } from "react";
-import { data, redirect, useFetcher, useNavigate } from "react-router";
+import { data, useFetcher, useNavigate } from "react-router";
 import { toast } from "sonner";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { TeamBillingService } from "~/modules/billing/teamBilling";
 import addDialog from "~/modules/dialogs/addDialog";
 import type { User } from "~/modules/users/users.types";
@@ -20,11 +20,7 @@ import type { Team } from "../teams.types";
 import type { Route } from "./+types/teams.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const userSession = (await getSessionUser({ request })) as User;
-
-  if (!userSession) {
-    return redirect("/");
-  }
+  const userSession = await requireAuth({ request });
 
   let match = {};
   if (userSession.role !== "SUPER_ADMIN") {
@@ -73,11 +69,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const { name } = payload;
 
-  const user = (await getSessionUser({ request })) as User;
-
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   switch (intent) {
     case "CREATE_TEAM": {

--- a/app/modules/users/__tests__/adminUsers.route.test.ts
+++ b/app/modules/users/__tests__/adminUsers.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { AuditService } from "~/modules/audits/audit";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { action, loader } from "../containers/adminUsers.route";
 import { UserService } from "../user";
@@ -12,13 +13,12 @@ describe("adminUsers.route", () => {
 
   describe("loader", () => {
     it("redirects to / when there is no session cookie", async () => {
-      const res = await loader({
-        request: new Request("http://localhost/userManagement"),
-        params: {},
-      } as any);
-
-      expect(res).toBeInstanceOf(Response);
-      expect((res as Response).headers.get("Location")).toBe("/");
+      await expectAuthRequired(() =>
+        loader({
+          request: new Request("http://localhost/userManagement"),
+          params: {},
+        } as any),
+      );
     });
 
     it("redirects to / when user is not a super admin", async () => {

--- a/app/modules/users/__tests__/availableFeatureFlagUsers.route.test.ts
+++ b/app/modules/users/__tests__/availableFeatureFlagUsers.route.test.ts
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import { beforeEach, describe, expect, it } from "vitest";
 import { FeatureFlagService } from "~/modules/featureFlags/featureFlag";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/availableFeatureFlagUsers.route";
 import { UserService } from "../user";
@@ -14,14 +15,14 @@ describe("availableFeatureFlagUsers.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request(
-        "http://localhost/available-feature-flag-users?featureFlagId=123",
-      ),
-      params: {},
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request(
+          "http://localhost/available-feature-flag-users?featureFlagId=123",
+        ),
+        params: {},
+      } as any),
+    );
   });
 
   it("throws error when featureFlagId is not provided", async () => {

--- a/app/modules/users/__tests__/availableTeamUsers.route.test.ts
+++ b/app/modules/users/__tests__/availableTeamUsers.route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { TeamService } from "~/modules/teams/team";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import expectAuthRequired from "../../../../test/helpers/expectAuthRequired";
 import loginUser from "../../../../test/helpers/loginUser";
 import { loader } from "../containers/availableTeamUsers.route";
 import { UserService } from "../user";
@@ -11,12 +12,14 @@ describe("availableTeamUsers.route loader", () => {
   });
 
   it("redirects to / when there is no session cookie", async () => {
-    const res = await loader({
-      request: new Request("http://localhost/available-team-users?teamId=123"),
-      params: {},
-    } as any);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).headers.get("Location")).toBe("/");
+    await expectAuthRequired(() =>
+      loader({
+        request: new Request(
+          "http://localhost/available-team-users?teamId=123",
+        ),
+        params: {},
+      } as any),
+    );
   });
 
   it("throws error when teamId is not provided", async () => {

--- a/app/modules/users/containers/adminUsers.route.tsx
+++ b/app/modules/users/containers/adminUsers.route.tsx
@@ -5,7 +5,7 @@ import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import { AuditService } from "~/modules/audits/audit";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { userIsSuperAdmin } from "~/modules/authorization/helpers/superAdmin";
 import addDialog from "~/modules/dialogs/addDialog";
 import { TeamService } from "~/modules/teams/team";
@@ -21,9 +21,9 @@ import RevokeSuperAdminDialogContainer from "./revokeSuperAdminDialogContainer";
 import type { Route } from "./+types/adminUsers.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
+  const user = await requireAuth({ request });
 
-  if (!user || !userIsSuperAdmin(user)) {
+  if (!userIsSuperAdmin(user)) {
     return redirect("/");
   }
 
@@ -84,9 +84,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const user = (await getSessionUser({ request })) as User;
+  const user = await requireAuth({ request });
 
-  if (!user || !userIsSuperAdmin(user)) {
+  if (!userIsSuperAdmin(user)) {
     return data({ errors: { general: "Access denied" } }, { status: 403 });
   }
 

--- a/app/modules/users/containers/availableFeatureFlagUsers.route.tsx
+++ b/app/modules/users/containers/availableFeatureFlagUsers.route.tsx
@@ -1,18 +1,13 @@
-import { redirect } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import SystemAdminAuthorization from "~/modules/authorization/systemAdminAuthorization";
 import { FeatureFlagService } from "~/modules/featureFlags/featureFlag";
 import { UserService } from "~/modules/users/user";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/availableTeamUsers.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   if (!SystemAdminAuthorization.FeatureFlags.canManage(user)) {
     throw new Error("Access denied");

--- a/app/modules/users/containers/availableTeamUsers.route.tsx
+++ b/app/modules/users/containers/availableTeamUsers.route.tsx
@@ -1,17 +1,12 @@
-import { redirect } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import TeamAuthorization from "~/modules/teams/authorization";
 import { UserService } from "~/modules/users/user";
-import type { User } from "~/modules/users/users.types";
 import type { Route } from "./+types/availableTeamUsers.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = (await getSessionUser({ request })) as User;
-  if (!user) {
-    return redirect("/");
-  }
+  const user = await requireAuth({ request });
 
   const url = new URL(request.url);
   const teamId = url.searchParams.get("teamId");

--- a/app/modules/users/containers/teamMembers.route.tsx
+++ b/app/modules/users/containers/teamMembers.route.tsx
@@ -1,14 +1,12 @@
-import { redirect } from "react-router";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
-import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import TeamAuthorization from "~/modules/teams/authorization";
 import { UserService } from "~/modules/users/user";
 import type { Route } from "./+types/teamMembers.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = await getSessionUser({ request });
-  if (!user) return redirect("/");
+  const user = await requireAuth({ request });
 
   const url = new URL(request.url);
   const teamId = url.searchParams.get("teamId");

--- a/test/helpers/expectAuthRequired.ts
+++ b/test/helpers/expectAuthRequired.ts
@@ -9,5 +9,5 @@ export default async function expectAuthRequired(fn: () => Promise<unknown>) {
   }
   expect(thrown).toBeInstanceOf(Response);
   expect((thrown as Response).status).toBe(302);
-  expect((thrown as Response).headers.get("Location")).toBe("/");
+  expect((thrown as Response).headers.get("Location")).toBe("/signup");
 }

--- a/test/helpers/expectAuthRequired.ts
+++ b/test/helpers/expectAuthRequired.ts
@@ -1,0 +1,13 @@
+import { expect } from "vitest";
+
+export default async function expectAuthRequired(fn: () => Promise<unknown>) {
+  let thrown: unknown;
+  try {
+    await fn();
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(Response);
+  expect((thrown as Response).status).toBe(302);
+  expect((thrown as Response).headers.get("Location")).toBe("/");
+}


### PR DESCRIPTION
The PR basically handles two things

1. Replaces
```
 const user = (await getSessionUser({ request })) as User;
  if (!user) {
    return redirect("/");
  }
```
with 
```
const user = await requireAuth({ request });
```

2. We redirect unauthenticated requests to /signup and add support for returnTo, so after login you go to the initial page. Most testing for this is for preventing open redirects, which we handle