### PR TITLE
Standardize teamBilling action responses and fix route typing

### DIFF
--- a/app/modules/prompts/containers/promptEditor.route.tsx
+++ b/app/modules/prompts/containers/promptEditor.route.tsx
@@ -144,7 +144,7 @@ export function shouldRevalidate({
 }
 
 export default function PromptEditorRoute() {
-  const data = useLoaderData();
+  const data = useLoaderData<typeof loader>();
   const navigation = useNavigation();
   const submit = useSubmit();
 
@@ -163,7 +163,7 @@ export default function PromptEditorRoute() {
       <SavePromptVersionDialogContainer
         userPrompt={userPrompt}
         annotationSchema={annotationSchema}
-        team={prompt.data.team}
+        team={prompt.data.team as string}
         promptId={prompt.data._id}
         onSaveClicked={() => {
           submit(

--- a/app/modules/runs/containers/runs.route.tsx
+++ b/app/modules/runs/containers/runs.route.tsx
@@ -66,7 +66,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export default function ProjectRunsRoute() {
-  const { runs } = useLoaderData();
+  const { runs } = useLoaderData<typeof loader>();
   const { id: projectId } = useParams();
   const navigate = useNavigate();
   const { revalidate } = useRevalidator();

--- a/app/modules/sessions/containers/sessions.route.tsx
+++ b/app/modules/sessions/containers/sessions.route.tsx
@@ -78,7 +78,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export default function ProjectSessionsRoute() {
-  const { sessions, project } = useLoaderData();
+  const { sessions, project } = useLoaderData<typeof loader>();
   const submit = useSubmit();
 
   const {

--- a/app/modules/teams/__tests__/teamBilling.route.test.ts
+++ b/app/modules/teams/__tests__/teamBilling.route.test.ts
@@ -3,10 +3,10 @@ import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import loginUser from "../../../../test/helpers/loginUser";
-import { action } from "../../teams/containers/teamBilling.route";
-import { BillingPlanService } from "../billingPlan";
-import { TeamBillingPlanService } from "../teamBillingPlan";
-import { TeamCreditService } from "../teamCredit";
+import { BillingPlanService } from "../../billing/billingPlan";
+import { TeamBillingPlanService } from "../../billing/teamBillingPlan";
+import { TeamCreditService } from "../../billing/teamCredit";
+import { action } from "../containers/teamBilling.route";
 
 function buildActionRequest(
   cookieHeader: string,
@@ -53,8 +53,7 @@ describe("teamBilling.route action", () => {
         }),
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("not a member");
+      expect(result.data.errors.general).toContain("not a member");
     });
 
     it("allows setting a team member as billing user", async () => {
@@ -72,14 +71,14 @@ describe("teamBilling.route action", () => {
 
       const cookie = await loginUser(admin._id);
 
-      const result = await action(
+      const result: any = await action(
         buildActionRequest(cookie, team._id, {
           intent: "SET_BILLING_USER",
           payload: { userId: member._id },
         }),
       );
 
-      expect(result.success).toBe(true);
+      expect(result.data.success).toBe(true);
 
       const updated = await TeamService.findById(team._id);
       expect(updated?.billingUser).toBe(member._id);
@@ -101,8 +100,7 @@ describe("teamBilling.route action", () => {
         }),
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("permission");
+      expect(result.data.errors.general).toContain("permission");
     });
   });
 
@@ -121,14 +119,14 @@ describe("teamBilling.route action", () => {
       });
       const cookie = await loginUser(admin._id);
 
-      const result = await action(
+      const result: any = await action(
         buildActionRequest(cookie, team._id, {
           intent: "ASSIGN_PLAN",
           payload: { planId: plan._id },
         }),
       );
 
-      expect(result.success).toBe(true);
+      expect(result.data.success).toBe(true);
 
       const assignment = await TeamBillingPlanService.findByTeam(team._id);
       expect(assignment).not.toBeNull();
@@ -155,14 +153,14 @@ describe("teamBilling.route action", () => {
       await TeamBillingPlanService.assignPlan(team._id, plan1._id);
       const cookie = await loginUser(admin._id);
 
-      const result = await action(
+      const result: any = await action(
         buildActionRequest(cookie, team._id, {
           intent: "ASSIGN_PLAN",
           payload: { planId: plan2._id },
         }),
       );
 
-      expect(result.success).toBe(true);
+      expect(result.data.success).toBe(true);
 
       // Reassignment is scheduled for next month — current plan stays plan1
       const current = await TeamBillingPlanService.findByTeam(team._id);
@@ -190,8 +188,7 @@ describe("teamBilling.route action", () => {
         }),
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("super admins");
+      expect(result.data.errors.general).toContain("super admins");
     });
   });
 
@@ -212,14 +209,14 @@ describe("teamBilling.route action", () => {
 
       const cookie = await loginUser(billingUser._id);
 
-      const result = await action(
+      const result: any = await action(
         buildActionRequest(cookie, team._id, {
           intent: "ADD_CREDITS",
           payload: { amount: 50, note: "Test top-up" },
         }),
       );
 
-      expect(result.success).toBe(true);
+      expect(result.data.success).toBe(true);
 
       const credits = await TeamCreditService.findByTeam(team._id);
       expect(credits).toHaveLength(1);
@@ -236,14 +233,14 @@ describe("teamBilling.route action", () => {
       const team = await TeamService.create({ name: "Test Team" });
       const cookie = await loginUser(admin._id);
 
-      const result = await action(
+      const result: any = await action(
         buildActionRequest(cookie, team._id, {
           intent: "ADD_CREDITS",
           payload: { amount: 100 },
         }),
       );
 
-      expect(result.success).toBe(true);
+      expect(result.data.success).toBe(true);
     });
 
     it("denies regular members from adding credits", async () => {
@@ -262,8 +259,7 @@ describe("teamBilling.route action", () => {
         }),
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("permission");
+      expect(result.data.errors.general).toContain("permission");
     });
 
     it("rejects invalid amount", async () => {
@@ -282,8 +278,7 @@ describe("teamBilling.route action", () => {
         }),
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Invalid");
+      expect(result.data.errors.general).toContain("Invalid");
     });
 
     it("rejects amount below minimum", async () => {
@@ -302,8 +297,7 @@ describe("teamBilling.route action", () => {
         }),
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Minimum");
+      expect(result.data.errors.general).toContain("Minimum");
     });
   });
 });

--- a/app/modules/teams/containers/teamBilling.route.tsx
+++ b/app/modules/teams/containers/teamBilling.route.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import {
+  data,
   redirect,
   useFetcher,
   useLoaderData,
@@ -167,70 +168,103 @@ export async function action({ request, params }: Route.ActionArgs) {
   switch (intent) {
     case "ADD_CREDITS": {
       if (!BillingAuthorization.canAddCredits(user, team)) {
-        return {
-          success: false,
-          error: "You do not have permission to add credits",
-        };
+        return data(
+          { errors: { general: "You do not have permission to add credits" } },
+          { status: 403 },
+        );
       }
-      return await addCredits({
+      const result = await addCredits({
         teamId: params.id,
         amount: payload.amount,
         note: payload.note,
         addedBy: user._id,
       });
+      if (!result.success) {
+        return data(
+          { errors: { general: result.error ?? "Failed to add credits" } },
+          { status: 400 },
+        );
+      }
+      return data({ success: true, intent: "ADD_CREDITS" });
     }
 
     case "SET_BILLING_USER": {
       if (!BillingAuthorization.canSetBillingUser(user, params.id)) {
-        return {
-          success: false,
-          error: "You do not have permission to set the billing user",
-        };
+        return data(
+          {
+            errors: {
+              general: "You do not have permission to set the billing user",
+            },
+          },
+          { status: 403 },
+        );
       }
-      const targetUser = await UserService.findById(payload.userId);
-      if (
-        !targetUser ||
-        !targetUser.teams.some((t: any) => t.team === params.id)
-      ) {
-        return { success: false, error: "User is not a member of this team" };
+      if (typeof payload.userId !== "string" || !payload.userId) {
+        return data(
+          { errors: { general: "Invalid user ID" } },
+          { status: 400 },
+        );
+      }
+      const isMember = await UserService.findOne({
+        _id: payload.userId,
+        "teams.team": params.id,
+      });
+      if (!isMember) {
+        return data(
+          { errors: { general: "User is not a member of this team" } },
+          { status: 400 },
+        );
       }
       await TeamService.updateById(params.id, {
-        billingUser: payload.userId,
+        billingUser: isMember._id,
       });
-      return { success: true, intent: "SET_BILLING_USER" };
+      return data({ success: true, intent: "SET_BILLING_USER" });
     }
 
     case "ASSIGN_PLAN": {
       if (!BillingAuthorization.canAssignPlan(user)) {
-        return {
-          success: false,
-          error: "Only super admins can assign billing plans",
-        };
+        return data(
+          { errors: { general: "Only super admins can assign billing plans" } },
+          { status: 403 },
+        );
       }
       if (!payload.planId) {
-        return { success: false, error: "Plan ID is required" };
+        return data(
+          { errors: { general: "Plan ID is required" } },
+          { status: 400 },
+        );
       }
       const plan = await BillingPlanService.findById(payload.planId);
       if (!plan) {
-        return { success: false, error: "Billing plan not found" };
+        return data(
+          { errors: { general: "Billing plan not found" } },
+          { status: 404 },
+        );
       }
       await TeamBillingPlanService.assignPlan(params.id, plan._id);
-      return { success: true, intent: "ASSIGN_PLAN" };
+      return data({ success: true, intent: "ASSIGN_PLAN" });
     }
 
     case "INITIATE_TOPUP": {
       if (!isBillingEnabled()) {
-        return { success: false, error: "Billing is not enabled" };
+        return data(
+          { errors: { general: "Billing is not enabled" } },
+          { status: 400 },
+        );
       }
       if (!BillingAuthorization.canAddCredits(user, team)) {
-        return {
-          success: false,
-          error: "You do not have permission to top up credits",
-        };
+        return data(
+          {
+            errors: {
+              general: "You do not have permission to top up credits",
+            },
+          },
+          { status: 403 },
+        );
       }
       const amount = payload.amount;
       if (!Number.isInteger(amount) || amount < 1 || amount > 10000) {
-        return { success: false, error: "Invalid amount" };
+        return data({ errors: { general: "Invalid amount" } }, { status: 400 });
       }
       let session;
       try {
@@ -244,20 +278,26 @@ export async function action({ request, params }: Route.ActionArgs) {
           metadata: { teamId: params.id, userId: user._id.toString() },
         });
       } catch {
-        return { success: false, error: "Failed to initiate checkout" };
+        return data(
+          { errors: { general: "Failed to initiate checkout" } },
+          { status: 500 },
+        );
       }
       if (!session.url) {
-        return { success: false, error: "Failed to create checkout session" };
+        return data(
+          { errors: { general: "Failed to create checkout session" } },
+          { status: 500 },
+        );
       }
-      return {
+      return data({
         success: true,
         intent: "INITIATE_TOPUP",
         checkoutUrl: session.url,
-      };
+      });
     }
 
     default:
-      return { success: false, error: "Invalid intent" };
+      return data({ errors: { general: "Invalid intent" } }, { status: 400 });
   }
 }
 
@@ -337,15 +377,20 @@ export default function TeamBillingRoute() {
       return;
     }
 
+    if ("errors" in fetcher.data) {
+      closeDialog();
+      toast.error(
+        (fetcher.data as { errors: { general: string } }).errors.general,
+      );
+      return;
+    }
+
     if (fetcher.data.success) {
       toast.success(
         successMessages[(fetcher.data as { intent: string }).intent] ??
           "Billing updated",
       );
       revalidate();
-    } else {
-      closeDialog();
-      toast.error((fetcher.data as { error: string }).error);
     }
   }, [fetcher.state, fetcher.data, revalidate]);
 


### PR DESCRIPTION
Moves teamBilling.route.test.ts to teams/__tests__, standardizes all action returns to data({ errors } | { success, intent }) shape, replaces the full user fetch with a scoped UserService.findOne membership check, adds userId type validation before the DB query to prevent NoSQL operator injection, and adds useLoaderData<typeof loader>() in promptEditor, runs, and sessions routes.

Fixes #2051