### PR TITLE
Phase 3: Extract business logic from route hotspots

### DIFF
--- a/app/modules/evaluations/__tests__/buildEvaluationReport.test.ts
+++ b/app/modules/evaluations/__tests__/buildEvaluationReport.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import type { Run } from "~/modules/runs/runs.types";
+import type { Evaluation } from "../evaluations.types";
+import buildEvaluationReport, {
+  type SessionFileCache,
+} from "../helpers/buildEvaluationReport";
+
+function makeRun(
+  id: string,
+  name: string,
+  opts: { isHuman?: boolean; isAdjudication?: boolean } = {},
+): Run {
+  return {
+    _id: id,
+    name,
+    isHuman: opts.isHuman ?? false,
+    isAdjudication: opts.isAdjudication ?? false,
+    snapshot: {
+      prompt: {
+        annotationType: "PER_SESSION",
+        name: "",
+        userPrompt: "",
+        annotationSchema: [],
+        version: 1,
+      },
+      model: { code: "gpt-4", provider: "openai", name: "GPT-4" },
+    },
+  } as unknown as Run;
+}
+
+function makeEvaluation(
+  baseRun: string,
+  runs: string[],
+  annotationFields: string[],
+): Evaluation {
+  return {
+    _id: "eval-1",
+    name: "Test Eval",
+    project: "proj-1",
+    runSet: "rs-1",
+    baseRun,
+    runs,
+    annotationFields,
+  };
+}
+
+describe("buildEvaluationReport", () => {
+  it("returns zero-filled reports when no common sessions", async () => {
+    const runs = [makeRun("r1", "Run 1"), makeRun("r2", "Run 2")];
+    const evaluation = makeEvaluation("r1", ["r1", "r2"], ["quality"]);
+
+    const reports = await buildEvaluationReport(evaluation, runs, {}, []);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].fieldKey).toBe("quality");
+    expect(reports[0].meanKappa).toBe(0);
+    expect(reports[0].pairwise).toEqual([]);
+    expect(reports[0].runSummaries).toEqual([]);
+  });
+
+  it("returns one report per annotation field", async () => {
+    const runs = [makeRun("r1", "Run 1"), makeRun("r2", "Run 2")];
+    const evaluation = makeEvaluation("r1", ["r1", "r2"], ["quality", "tone"]);
+
+    const reports = await buildEvaluationReport(evaluation, runs, {}, []);
+
+    expect(reports).toHaveLength(2);
+    expect(reports.map((r) => r.fieldKey)).toEqual(["quality", "tone"]);
+  });
+
+  it("computes perfect agreement (kappa=1) when labels match", async () => {
+    const session = "sess-1";
+    const cache: SessionFileCache = {
+      r1: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a1", identifiedBy: "model", quality: "good" }],
+        },
+      },
+      r2: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a2", identifiedBy: "model", quality: "good" }],
+        },
+      },
+    };
+    const runs = [makeRun("r1", "Run 1"), makeRun("r2", "Run 2")];
+    const evaluation = makeEvaluation("r1", ["r1", "r2"], ["quality"]);
+
+    const reports = await buildEvaluationReport(evaluation, runs, cache, [
+      session,
+    ]);
+
+    expect(reports[0].pairwise[0].kappa).toBe(1);
+    expect(reports[0].meanKappa).toBe(1);
+  });
+
+  it("includes precision/recall/f1 when one run is the base run", async () => {
+    const session = "sess-1";
+    const cache: SessionFileCache = {
+      base: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a1", identifiedBy: "model", quality: "good" }],
+        },
+      },
+      other: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a2", identifiedBy: "model", quality: "good" }],
+        },
+      },
+    };
+    const runs = [makeRun("base", "Base Run"), makeRun("other", "Other Run")];
+    const evaluation = makeEvaluation("base", ["base", "other"], ["quality"]);
+
+    const reports = await buildEvaluationReport(evaluation, runs, cache, [
+      session,
+    ]);
+
+    const pairwiseResult = reports[0].pairwise[0];
+    expect(pairwiseResult.precision).toBeDefined();
+    expect(pairwiseResult.recall).toBeDefined();
+    expect(pairwiseResult.f1).toBeDefined();
+  });
+
+  it("does not include precision/recall/f1 for pairs not involving the base run", async () => {
+    const session = "sess-1";
+    const cache: SessionFileCache = {
+      base: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a1", identifiedBy: "model", quality: "good" }],
+        },
+      },
+      r2: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a2", identifiedBy: "model", quality: "good" }],
+        },
+      },
+      r3: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a3", identifiedBy: "model", quality: "good" }],
+        },
+      },
+    };
+    const runs = [
+      makeRun("base", "Base"),
+      makeRun("r2", "R2"),
+      makeRun("r3", "R3"),
+    ];
+    const evaluation = makeEvaluation(
+      "base",
+      ["base", "r2", "r3"],
+      ["quality"],
+    );
+
+    const reports = await buildEvaluationReport(evaluation, runs, cache, [
+      session,
+    ]);
+
+    const r2r3Pair = reports[0].pairwise.find(
+      (p) => p.runA === "r2" && p.runB === "r3",
+    );
+    expect(r2r3Pair).toBeDefined();
+    expect(r2r3Pair!.precision).toBeUndefined();
+    expect(r2r3Pair!.recall).toBeUndefined();
+    expect(r2r3Pair!.f1).toBeUndefined();
+  });
+
+  it("generates all pairwise combinations for N runs", async () => {
+    const session = "sess-1";
+    const makeEntry = (label: string) => ({
+      transcript: [] as never[],
+      leadRole: "tutor",
+      annotations: [{ _id: "a", identifiedBy: "model", quality: label }],
+    });
+    const cache: SessionFileCache = {
+      r1: { [session]: makeEntry("good") },
+      r2: { [session]: makeEntry("good") },
+      r3: { [session]: makeEntry("good") },
+    };
+    const runs = [
+      makeRun("r1", "R1"),
+      makeRun("r2", "R2"),
+      makeRun("r3", "R3"),
+    ];
+    const evaluation = makeEvaluation("r1", ["r1", "r2", "r3"], ["quality"]);
+
+    const reports = await buildEvaluationReport(evaluation, runs, cache, [
+      session,
+    ]);
+
+    expect(reports[0].pairwise).toHaveLength(3);
+  });
+
+  it("carries isHuman and isAdjudication flags in run summaries", async () => {
+    const session = "sess-1";
+    const cache: SessionFileCache = {
+      human: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a1", identifiedBy: "model", quality: "good" }],
+        },
+      },
+      adj: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a2", identifiedBy: "model", quality: "good" }],
+        },
+      },
+    };
+    const runs = [
+      makeRun("human", "Human Run", { isHuman: true }),
+      makeRun("adj", "Adj Run", { isAdjudication: true }),
+    ];
+    const evaluation = makeEvaluation("human", ["human", "adj"], ["quality"]);
+
+    const reports = await buildEvaluationReport(evaluation, runs, cache, [
+      session,
+    ]);
+
+    const humanSummary = reports[0].runSummaries.find(
+      (s) => s.runId === "human",
+    );
+    const adjSummary = reports[0].runSummaries.find((s) => s.runId === "adj");
+    expect(humanSummary!.isHuman).toBe(true);
+    expect(adjSummary!.isAdjudication).toBe(true);
+  });
+
+  it("skips sessions missing from the cache", async () => {
+    const session = "sess-present";
+    const cache: SessionFileCache = {
+      r1: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a1", identifiedBy: "model", quality: "good" }],
+        },
+      },
+      r2: {
+        [session]: {
+          transcript: [],
+          leadRole: "tutor",
+          annotations: [{ _id: "a2", identifiedBy: "model", quality: "good" }],
+        },
+      },
+    };
+    const runs = [makeRun("r1", "Run 1"), makeRun("r2", "Run 2")];
+    const evaluation = makeEvaluation("r1", ["r1", "r2"], ["quality"]);
+
+    const reports = await buildEvaluationReport(evaluation, runs, cache, [
+      session,
+      "sess-missing",
+    ]);
+
+    expect(reports[0].pairwise[0].sampleSize).toBe(1);
+  });
+});

--- a/app/modules/runSets/__tests__/getRunSetPrefillData.test.ts
+++ b/app/modules/runSets/__tests__/getRunSetPrefillData.test.ts
@@ -1,0 +1,412 @@
+import { Types } from "mongoose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAvailableProviders } from "~/modules/llm/modelRegistry";
+import { ProjectService } from "~/modules/projects/project";
+import { PromptService } from "~/modules/prompts/prompt";
+import { PromptVersionService } from "~/modules/prompts/promptVersion";
+import { RunService } from "~/modules/runs/run";
+import { RunSetService } from "~/modules/runSets/runSet";
+import { TeamService } from "~/modules/teams/team";
+import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+
+const testModel = getAvailableProviders()[0].models[0].code;
+
+vi.mock("~/modules/runs/services/buildRunSnapshot.server", () => ({
+  default: vi.fn(
+    async ({
+      promptVersionNumber,
+      modelCode,
+    }: {
+      promptVersionNumber: number;
+      modelCode: string;
+    }) => ({
+      prompt: {
+        name: "Mock Prompt",
+        userPrompt: "Mock",
+        annotationSchema: [],
+        annotationType: "PER_UTTERANCE",
+        version: promptVersionNumber,
+      },
+      model: { code: modelCode, provider: "openai", name: modelCode },
+    }),
+  ),
+}));
+
+vi.mock("~/modules/runs/helpers/buildRunSessions.server", () => ({
+  default: vi.fn(async (sessionIds: string[]) =>
+    sessionIds.map((id) => ({
+      sessionId: id,
+      name: "Mock Session",
+      fileType: "",
+      status: "NOT_STARTED",
+      startedAt: new Date(),
+      finishedAt: new Date(),
+    })),
+  ),
+}));
+
+describe("getRunSetPrefillData", () => {
+  let projectId: string;
+  let promptId: string;
+
+  beforeEach(async () => {
+    await clearDocumentDB();
+
+    const team = await TeamService.create({ name: "Test Team" });
+    const project = await ProjectService.create({
+      name: "Test Project",
+      team: team._id,
+      createdBy: new Types.ObjectId().toString(),
+    });
+    projectId = project._id;
+
+    const prompt = await PromptService.create({
+      name: "Test Prompt",
+      annotationType: "PER_UTTERANCE",
+    });
+    await PromptVersionService.create({
+      prompt: prompt._id,
+      version: 1,
+      userPrompt: "Test prompt content",
+      annotationSchema: [],
+    });
+    promptId = prompt._id;
+  });
+
+  describe("getPrefillDataFromRun", () => {
+    it("returns null when run is not found", async () => {
+      const result = await RunSetService.getPrefillDataFromRun(
+        new Types.ObjectId().toString(),
+        projectId,
+      );
+
+      expect(result.prefillData).toBeNull();
+      expect(result.prefillSessionIds).toEqual([]);
+    });
+
+    it("returns null when run belongs to a different project (IDOR)", async () => {
+      const otherTeam = await TeamService.create({ name: "Other Team" });
+      const otherProject = await ProjectService.create({
+        name: "Other Project",
+        team: otherTeam._id,
+        createdBy: new Types.ObjectId().toString(),
+      });
+      const run = await RunService.create({
+        project: otherProject._id,
+        name: "Other Run",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+
+      const result = await RunSetService.getPrefillDataFromRun(
+        run._id,
+        projectId,
+      );
+
+      expect(result.prefillData).toBeNull();
+      expect(result.prefillSessionIds).toEqual([]);
+    });
+
+    it("returns prefill data from an existing run", async () => {
+      const sessionId = new Types.ObjectId().toString();
+      const run = await RunService.create({
+        project: projectId,
+        name: "Test Run",
+        sessions: [sessionId],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+
+      const result = await RunSetService.getPrefillDataFromRun(
+        run._id,
+        projectId,
+      );
+
+      expect(result.prefillData).not.toBeNull();
+      expect(result.prefillData!.sourceRunId).toBe(run._id);
+      expect(result.prefillData!.sourceRunName).toBe("Test Run");
+      expect(result.prefillData!.annotationType).toBe("PER_UTTERANCE");
+      expect(result.prefillData!.selectedPrompts).toHaveLength(1);
+      expect(result.prefillData!.selectedPrompts[0].promptId).toBe(promptId);
+      expect(result.prefillData!.selectedPrompts[0].promptName).toBe(
+        "Test Prompt",
+      );
+      expect(result.prefillData!.selectedPrompts[0].version).toBe(1);
+      expect(result.prefillData!.selectedModels).toContain(testModel);
+      expect(result.prefillData!.selectedSessions).toEqual([]);
+      expect(result.prefillSessionIds).toContain(sessionId);
+    });
+
+    it("uses empty string for prompt name when prompt no longer exists", async () => {
+      const deletedId = new Types.ObjectId().toString();
+      const run = await RunService.create({
+        project: projectId,
+        name: "Stale Run",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      await RunService.updateById(run._id, { prompt: deletedId });
+
+      const result = await RunSetService.getPrefillDataFromRun(
+        run._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.selectedPrompts[0].promptName).toBe("");
+    });
+  });
+
+  describe("getPrefillDataFromRunSet", () => {
+    it("returns null when runSet is not found", async () => {
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        new Types.ObjectId().toString(),
+        projectId,
+      );
+
+      expect(result.prefillData).toBeNull();
+      expect(result.prefillSessionIds).toEqual([]);
+    });
+
+    it("returns null when runSet belongs to a different project (IDOR)", async () => {
+      const otherTeam = await TeamService.create({ name: "Other Team" });
+      const otherProject = await ProjectService.create({
+        name: "Other Project",
+        team: otherTeam._id,
+        createdBy: new Types.ObjectId().toString(),
+      });
+      const runSet = await RunSetService.create({
+        name: "Other RunSet",
+        project: otherProject._id,
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData).toBeNull();
+      expect(result.prefillSessionIds).toEqual([]);
+    });
+
+    it("returns prefill data with validation error when runSet has no runs", async () => {
+      const runSet = await RunSetService.create({
+        name: "Empty RunSet",
+        project: projectId,
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData).not.toBeNull();
+      expect(result.prefillData!.validationErrors).toContain(
+        "Source runSet has no runs to use as template",
+      );
+    });
+
+    it("returns prefill data from a runSet with runs", async () => {
+      const sessionId = new Types.ObjectId().toString();
+      const run = await RunService.create({
+        project: projectId,
+        name: "Run 1",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      const runSet = await RunSetService.create({
+        name: "Test RunSet",
+        project: projectId,
+        sessions: [sessionId],
+        runs: [run._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData).not.toBeNull();
+      expect(result.prefillData!.sourceRunSetId).toBe(runSet._id);
+      expect(result.prefillData!.sourceRunSetName).toBe("Test RunSet");
+      expect(result.prefillData!.selectedPrompts).toHaveLength(1);
+      expect(result.prefillData!.selectedPrompts[0].promptId).toBe(promptId);
+      expect(result.prefillData!.selectedPrompts[0].promptName).toBe(
+        "Test Prompt",
+      );
+      expect(result.prefillData!.selectedModels).toContain(testModel);
+      expect(result.prefillData!.validationErrors).toBeUndefined();
+      expect(result.prefillSessionIds).toContain(sessionId);
+    });
+
+    it("deduplicates runs that share the same prompt+version", async () => {
+      const run1 = await RunService.create({
+        project: projectId,
+        name: "Run 1",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      const run2 = await RunService.create({
+        project: projectId,
+        name: "Run 2",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      const runSet = await RunSetService.create({
+        name: "Dedup RunSet",
+        project: projectId,
+        runs: [run1._id, run2._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.selectedPrompts).toHaveLength(1);
+      expect(result.prefillData!.selectedModels).toHaveLength(1);
+    });
+
+    it("includes validation error when a prompt no longer exists", async () => {
+      const run = await RunService.create({
+        project: projectId,
+        name: "Run",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      const deletedId = new Types.ObjectId().toString();
+      await RunService.updateById(run._id, { prompt: deletedId });
+      const runSet = await RunSetService.create({
+        name: "RunSet",
+        project: projectId,
+        runs: [run._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.validationErrors).toEqual(
+        expect.arrayContaining([expect.stringContaining("no longer exists")]),
+      );
+    });
+
+    it("skips human runs when building prompt and model selections", async () => {
+      const llmRun = await RunService.create({
+        project: projectId,
+        name: "LLM Run",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      const humanRun = await RunService.createFromData({
+        project: projectId,
+        name: "Human Run",
+        annotationType: "PER_UTTERANCE",
+        isHuman: true,
+        annotator: { name: "Alice" },
+        sessions: [],
+        snapshot: {
+          prompt: {
+            name: "Human Annotation",
+            userPrompt: "",
+            annotationSchema: [],
+            annotationType: "PER_UTTERANCE",
+            version: 1,
+          },
+        },
+      });
+      const runSet = await RunSetService.create({
+        name: "Mixed RunSet",
+        project: projectId,
+        runs: [llmRun._id, humanRun._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.selectedPrompts).toHaveLength(1);
+      expect(result.prefillData!.selectedPrompts[0].promptId).toBe(promptId);
+      expect(result.prefillData!.selectedModels).toContain(testModel);
+      expect(result.prefillData!.validationErrors).toBeUndefined();
+    });
+
+    it("includes validation error when a model is no longer available", async () => {
+      const run = await RunService.create({
+        project: projectId,
+        name: "Run",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      await RunService.updateById(run._id, {
+        snapshot: {
+          ...run.snapshot,
+          model: {
+            code: "DEPRECATED_MODEL_XYZ",
+            provider: "openai",
+            name: "Deprecated",
+          },
+        },
+      });
+      const runSet = await RunSetService.create({
+        name: "RunSet",
+        project: projectId,
+        runs: [run._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.validationErrors).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("no longer available"),
+        ]),
+      );
+    });
+  });
+});

--- a/app/modules/runSets/__tests__/getRunSetPrefillData.test.ts
+++ b/app/modules/runSets/__tests__/getRunSetPrefillData.test.ts
@@ -111,6 +111,34 @@ describe("getRunSetPrefillData", () => {
       expect(result.prefillSessionIds).toEqual([]);
     });
 
+    it("returns null when run is human-annotated", async () => {
+      const humanRun = await RunService.createFromData({
+        project: projectId,
+        name: "Human Run",
+        annotationType: "PER_UTTERANCE",
+        isHuman: true,
+        annotator: { name: "Alice" },
+        sessions: [],
+        snapshot: {
+          prompt: {
+            name: "Human Annotation",
+            userPrompt: "",
+            annotationSchema: [],
+            annotationType: "PER_UTTERANCE",
+            version: 1,
+          },
+        },
+      });
+
+      const result = await RunSetService.getPrefillDataFromRun(
+        humanRun._id,
+        projectId,
+      );
+
+      expect(result.prefillData).toBeNull();
+      expect(result.prefillSessionIds).toEqual([]);
+    });
+
     it("returns prefill data from an existing run", async () => {
       const sessionId = new Types.ObjectId().toString();
       const run = await RunService.create({
@@ -367,6 +395,46 @@ describe("getRunSetPrefillData", () => {
       expect(result.prefillData!.selectedPrompts[0].promptId).toBe(promptId);
       expect(result.prefillData!.selectedModels).toContain(testModel);
       expect(result.prefillData!.validationErrors).toBeUndefined();
+    });
+
+    it("includes validation error when all runs are human-annotated", async () => {
+      const humanRun = await RunService.createFromData({
+        project: projectId,
+        name: "Human Run",
+        annotationType: "PER_UTTERANCE",
+        isHuman: true,
+        annotator: { name: "Alice" },
+        sessions: [],
+        snapshot: {
+          prompt: {
+            name: "Human Annotation",
+            userPrompt: "",
+            annotationSchema: [],
+            annotationType: "PER_UTTERANCE",
+            version: 1,
+          },
+        },
+      });
+      const runSet = await RunSetService.create({
+        name: "Human-only RunSet",
+        project: projectId,
+        runs: [humanRun._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData).not.toBeNull();
+      expect(result.prefillData!.validationErrors).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("all runs are human-annotated"),
+        ]),
+      );
+      expect(result.prefillData!.selectedPrompts).toHaveLength(0);
+      expect(result.prefillData!.selectedModels).toHaveLength(0);
     });
 
     it("includes validation error when a model is no longer available", async () => {

--- a/app/modules/runSets/containers/runSetCreate.route.tsx
+++ b/app/modules/runSets/containers/runSetCreate.route.tsx
@@ -12,21 +12,15 @@ import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.serve
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import requireAuth from "~/modules/authentication/helpers/requireAuth";
 import { TeamBillingService } from "~/modules/billing/teamBilling";
-import { getAvailableModels } from "~/modules/llm/modelRegistry";
 import { LlmCostService } from "~/modules/llmCosts/llmCost";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import { ProjectService } from "~/modules/projects/project";
-import { PromptService } from "~/modules/prompts/prompt";
 import createGeneralJob from "~/modules/queues/helpers/createGeneralJob";
-import { getRunModelCode } from "~/modules/runs/helpers/runModel";
 import { RunService } from "~/modules/runs/run";
 import type { RunAnnotationType } from "~/modules/runs/runs.types";
 import RunSetCreatorContainer from "~/modules/runSets/containers/runSetCreator.container";
 import { RunSetService } from "~/modules/runSets/runSet";
-import type {
-  PrefillData,
-  PromptReference,
-} from "~/modules/runSets/runSets.types";
+import type { PrefillData } from "~/modules/runSets/runSets.types";
 import { SessionService } from "~/modules/sessions/session";
 import type { Route } from "./+types/runSetCreate.route";
 
@@ -42,7 +36,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     return redirect("/");
   }
 
-  // Check for fromRun or fromRunSet query parameter
   const url = new URL(request.url);
   const fromRunId = url.searchParams.get("fromRun");
   const fromRunSetId = url.searchParams.get("fromRunSet");
@@ -51,135 +44,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   let prefillSessionIds: string[] = [];
 
   if (fromRunId) {
-    try {
-      const run = await RunService.findOne({
-        _id: fromRunId,
-        project: params.projectId,
-      });
-
-      // Validate run exists and belongs to this project
-      if (run) {
-        // Extract session IDs
-        const sessionIds = run.sessions.map((s) => s.sessionId);
-
-        // Fetch prompt details for display
-        const prompt = await PromptService.findById(run.prompt as string);
-
-        const modelCode = getRunModelCode(run);
-        prefillSessionIds = sessionIds;
-        prefillData = {
-          sourceRunId: run._id,
-          sourceRunName: run.name,
-          annotationType: run.annotationType,
-          selectedPrompts: [
-            {
-              promptId: run.prompt as string,
-              promptName: prompt?.name || "",
-              version: run.promptVersion ?? 0,
-            },
-          ],
-          selectedModels: modelCode ? [modelCode] : [],
-          selectedSessions: [],
-        };
-      }
-    } catch (error) {
-      // If there's an error fetching run data, just continue with empty form
-      console.error("Error fetching run for prefill:", error);
-    }
+    ({ prefillData, prefillSessionIds } =
+      await RunSetService.getPrefillDataFromRun(fromRunId, params.projectId));
   } else if (fromRunSetId) {
-    try {
-      const runSet = await RunSetService.findById(fromRunSetId);
-
-      if (runSet && runSet.project === params.projectId) {
-        const validationErrors: string[] = [];
-
-        // Fetch all runs in the runSet
-        const runs = runSet.runs?.length
-          ? await RunService.find({ match: { _id: { $in: runSet.runs } } })
-          : [];
-
-        if (runs.length === 0) {
-          validationErrors.push("Source runSet has no runs to use as template");
-        }
-
-        // Get annotation type from first run (all runs should have same type)
-        const annotationType = runs[0]?.annotationType || "PER_UTTERANCE";
-
-        // Collect unique prompts and models from all runs
-        const promptMap = new Map<
-          string,
-          { promptId: string; version: number }
-        >();
-        const modelSet = new Set<string>();
-
-        for (const run of runs) {
-          const key = `${run.prompt}-${run.promptVersion}`;
-          if (!promptMap.has(key)) {
-            promptMap.set(key, {
-              promptId: run.prompt as string,
-              version: run.promptVersion ?? 0,
-            });
-          }
-          const modelCode = getRunModelCode(run);
-          if (modelCode) {
-            modelSet.add(modelCode);
-          }
-        }
-
-        // Fetch all prompts in a single query
-        const promptIds = Array.from(promptMap.values()).map((p) => p.promptId);
-        const prompts = await PromptService.find({
-          match: { _id: { $in: promptIds } },
-        });
-        const promptsById = new Map(prompts.map((p) => [p._id, p]));
-
-        // Validate prompts still exist and build selected prompts
-        const selectedPrompts: PromptReference[] = [];
-        for (const [, promptRef] of promptMap) {
-          const prompt = promptsById.get(promptRef.promptId);
-          if (prompt) {
-            selectedPrompts.push({
-              promptId: promptRef.promptId,
-              promptName: prompt.name,
-              version: promptRef.version,
-            });
-          } else {
-            validationErrors.push(
-              `Prompt "${promptRef.promptId}" no longer exists`,
-            );
-          }
-        }
-
-        // Validate models exist in config
-        const availableModelCodes = new Set(
-          getAvailableModels().map((m) => m.code),
-        );
-        const selectedModels: string[] = [];
-        for (const modelCode of modelSet) {
-          if (availableModelCodes.has(modelCode)) {
-            selectedModels.push(modelCode);
-          } else {
-            validationErrors.push(
-              `Model "${modelCode}" is no longer available`,
-            );
-          }
-        }
-
-        prefillSessionIds = runSet.sessions || [];
-        prefillData = {
-          sourceRunSetId: runSet._id,
-          sourceRunSetName: runSet.name,
-          annotationType,
-          selectedPrompts,
-          selectedModels,
-          selectedSessions: [],
-          validationErrors:
-            validationErrors.length > 0 ? validationErrors : undefined,
-        };
-      }
-    } catch (error) {
-      console.error("Error fetching runSet for prefill:", error);
-    }
+    ({ prefillData, prefillSessionIds } =
+      await RunSetService.getPrefillDataFromRunSet(
+        fromRunSetId,
+        params.projectId,
+      ));
   }
 
   const [avgSecondsPerSession, outputToInputRatio, prefillSessions, balance] =

--- a/app/modules/runSets/runSet.ts
+++ b/app/modules/runSets/runSet.ts
@@ -12,6 +12,10 @@ import deleteRunSetService from "./services/deleteRunSet.server";
 import findEligibleRunSetsForRunService from "./services/findEligibleRunSetsForRun.server";
 import findEligibleRunsService from "./services/findEligibleRuns.server";
 import findMergeableRunSetsService from "./services/findMergeableRunSets.server";
+import {
+  getPrefillDataFromRun,
+  getPrefillDataFromRunSet,
+} from "./services/getRunSetPrefillData.server";
 import mergeRunSetsService from "./services/mergeRunSets.server";
 import stopAllRunsService from "./services/stopAllRuns.server";
 
@@ -206,6 +210,14 @@ export class RunSetService {
     acknowledgedInsufficientCredits?: boolean;
   }) {
     return createRunsForRunSetService(payload);
+  }
+
+  static async getPrefillDataFromRun(runId: string, projectId: string) {
+    return getPrefillDataFromRun(runId, projectId);
+  }
+
+  static async getPrefillDataFromRunSet(runSetId: string, projectId: string) {
+    return getPrefillDataFromRunSet(runSetId, projectId);
   }
 
   static async stopAllRuns(runSetId: string): Promise<number> {

--- a/app/modules/runSets/services/getRunSetPrefillData.server.ts
+++ b/app/modules/runSets/services/getRunSetPrefillData.server.ts
@@ -19,7 +19,7 @@ export async function getPrefillDataFromRun(
 ): Promise<PrefillResult> {
   const run = await RunService.findOne({ _id: runId, project: projectId });
 
-  if (!run) {
+  if (!run || run.isHuman) {
     return { prefillData: null, prefillSessionIds: [] };
   }
 
@@ -89,6 +89,12 @@ export async function getPrefillDataFromRunSet(
     if (modelCode) {
       modelSet.add(modelCode);
     }
+  }
+
+  if (runs.length > 0 && promptMap.size === 0) {
+    validationErrors.push(
+      "Source runSet has no LLM runs to use as template; all runs are human-annotated",
+    );
   }
 
   const promptIds = Array.from(promptMap.values()).map((p) => p.promptId);

--- a/app/modules/runSets/services/getRunSetPrefillData.server.ts
+++ b/app/modules/runSets/services/getRunSetPrefillData.server.ts
@@ -1,0 +1,136 @@
+import { findModelByCode } from "~/modules/llm/modelRegistry";
+import { PromptService } from "~/modules/prompts/prompt";
+import { getRunModelCode } from "~/modules/runs/helpers/runModel";
+import { RunService } from "~/modules/runs/run";
+import { RunSetService } from "~/modules/runSets/runSet";
+import type {
+  PrefillData,
+  PromptReference,
+} from "~/modules/runSets/runSets.types";
+
+export interface PrefillResult {
+  prefillData: PrefillData | null;
+  prefillSessionIds: string[];
+}
+
+export async function getPrefillDataFromRun(
+  runId: string,
+  projectId: string,
+): Promise<PrefillResult> {
+  const run = await RunService.findOne({ _id: runId, project: projectId });
+
+  if (!run) {
+    return { prefillData: null, prefillSessionIds: [] };
+  }
+
+  const sessionIds = run.sessions.map((s) => s.sessionId);
+  const prompt = await PromptService.findById(run.prompt as string);
+  const modelCode = getRunModelCode(run);
+
+  return {
+    prefillData: {
+      sourceRunId: run._id,
+      sourceRunName: run.name,
+      annotationType: run.annotationType,
+      selectedPrompts: [
+        {
+          promptId: run.prompt as string,
+          promptName: prompt?.name || "",
+          version: run.promptVersion ?? 0,
+        },
+      ],
+      selectedModels: modelCode ? [modelCode] : [],
+      selectedSessions: [],
+    },
+    prefillSessionIds: sessionIds,
+  };
+}
+
+export async function getPrefillDataFromRunSet(
+  runSetId: string,
+  projectId: string,
+): Promise<PrefillResult> {
+  const runSet = await RunSetService.findOne({
+    _id: runSetId,
+    project: projectId,
+  });
+
+  if (!runSet) {
+    return { prefillData: null, prefillSessionIds: [] };
+  }
+
+  const validationErrors: string[] = [];
+
+  const runs = runSet.runs?.length
+    ? await RunService.find({
+        match: { _id: { $in: runSet.runs }, project: projectId },
+      })
+    : [];
+
+  if (runs.length === 0) {
+    validationErrors.push("Source runSet has no runs to use as template");
+  }
+
+  const annotationType = runs[0]?.annotationType || runSet.annotationType;
+
+  const promptMap = new Map<string, { promptId: string; version: number }>();
+  const modelSet = new Set<string>();
+
+  for (const run of runs) {
+    if (run.isHuman) continue;
+    const key = `${run.prompt}-${run.promptVersion}`;
+    if (!promptMap.has(key)) {
+      promptMap.set(key, {
+        promptId: run.prompt as string,
+        version: run.promptVersion ?? 0,
+      });
+    }
+    const modelCode = getRunModelCode(run);
+    if (modelCode) {
+      modelSet.add(modelCode);
+    }
+  }
+
+  const promptIds = Array.from(promptMap.values()).map((p) => p.promptId);
+  const prompts = await PromptService.find({
+    match: { _id: { $in: promptIds } },
+  });
+  const promptsById = new Map(prompts.map((p) => [p._id, p]));
+
+  const selectedPrompts: PromptReference[] = [];
+  for (const [, promptRef] of promptMap) {
+    const prompt = promptsById.get(promptRef.promptId);
+    if (prompt) {
+      selectedPrompts.push({
+        promptId: promptRef.promptId,
+        promptName: prompt.name,
+        version: promptRef.version,
+      });
+    } else {
+      validationErrors.push(`Prompt "${promptRef.promptId}" no longer exists`);
+    }
+  }
+
+  const selectedModels: string[] = [];
+  for (const modelCode of modelSet) {
+    if (findModelByCode(modelCode)) {
+      selectedModels.push(modelCode);
+    } else {
+      validationErrors.push(`Model "${modelCode}" is no longer available`);
+    }
+  }
+
+  return {
+    prefillData: {
+      sourceRunSetId: runSet._id,
+      sourceRunSetName: runSet.name,
+      annotationType,
+      selectedPrompts,
+      selectedModels,
+      selectedSessions: [],
+      validationErrors:
+        validationErrors.length > 0 ? validationErrors : undefined,
+    },
+    prefillSessionIds: runSet.sessions || [],
+  };
+}

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -112,28 +112,25 @@ export async function action({ request, params }: Route.ActionArgs) {
     _id: params.runId,
     project: params.projectId,
   });
+  if (!run) throw new Error("Run not found");
 
   switch (intent) {
     case "STOP_RUN": {
-      if (!run) throw new Error("Run not found");
       if (run.isComplete || run.stoppedAt) throw new Error("Run is not active");
       await RunService.stop(run._id);
       return {};
     }
     case "RE_RUN": {
-      if (!run) throw new Error("Run not found");
       await RunService.start(run);
       return {};
     }
     case "EXPORT_RUN": {
-      if (!run) throw new Error("Run not found");
       if (run.hasErrored)
         throw new Error("Cannot export a run that has errors");
       await exportRun({ runId: params.runId, exportType });
       return {};
     }
     case "GET_ALL_RUN_SETS": {
-      if (!run) return { runSets: [] };
       const allRunSets = await RunSetService.paginate({
         match: { runs: params.runId },
         page: 1,
@@ -142,7 +139,6 @@ export async function action({ request, params }: Route.ActionArgs) {
       return { runSets: allRunSets.data };
     }
     case "UPDATE_RUN": {
-      if (!run) throw new Error("Run not found");
       if (typeof payload.name !== "string") {
         throw new Error("Run name is required and must be a string.");
       }
@@ -150,7 +146,6 @@ export async function action({ request, params }: Route.ActionArgs) {
       return { success: true, intent: "UPDATE_RUN" };
     }
     case "DELETE_RUN": {
-      if (!run) throw new Error("Run not found");
       await RunService.deleteById(run._id);
       return { success: true, intent: "DELETE_RUN" };
     }

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -108,32 +108,24 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const { exportType } = payload;
 
+  const run = await RunService.findOne({
+    _id: params.runId,
+    project: params.projectId,
+  });
+
   switch (intent) {
     case "STOP_RUN": {
-      const run = await RunService.findOne({
-        _id: params.runId,
-        project: params.projectId,
-      });
       if (!run) throw new Error("Run not found");
       if (run.isComplete || run.stoppedAt) throw new Error("Run is not active");
       await RunService.stop(run._id);
       return {};
     }
     case "RE_RUN": {
-      const run = await RunService.findOne({
-        _id: params.runId,
-        project: params.projectId,
-      });
       if (!run) throw new Error("Run not found");
       await RunService.start(run);
-
       return {};
     }
     case "EXPORT_RUN": {
-      const run = await RunService.findOne({
-        _id: params.runId,
-        project: params.projectId,
-      });
       if (!run) throw new Error("Run not found");
       if (run.hasErrored)
         throw new Error("Cannot export a run that has errors");
@@ -141,10 +133,6 @@ export async function action({ request, params }: Route.ActionArgs) {
       return {};
     }
     case "GET_ALL_RUN_SETS": {
-      const run = await RunService.findOne({
-        _id: params.runId,
-        project: params.projectId,
-      });
       if (!run) return { runSets: [] };
       const allRunSets = await RunSetService.paginate({
         match: { runs: params.runId },
@@ -154,10 +142,6 @@ export async function action({ request, params }: Route.ActionArgs) {
       return { runSets: allRunSets.data };
     }
     case "UPDATE_RUN": {
-      const run = await RunService.findOne({
-        _id: params.runId,
-        project: params.projectId,
-      });
       if (!run) throw new Error("Run not found");
       if (typeof payload.name !== "string") {
         throw new Error("Run name is required and must be a string.");
@@ -166,10 +150,6 @@ export async function action({ request, params }: Route.ActionArgs) {
       return { success: true, intent: "UPDATE_RUN" };
     }
     case "DELETE_RUN": {
-      const run = await RunService.findOne({
-        _id: params.runId,
-        project: params.projectId,
-      });
       if (!run) throw new Error("Run not found");
       await RunService.deleteById(run._id);
       return { success: true, intent: "DELETE_RUN" };

--- a/app/modules/teams/__tests__/teamBilling.route.test.ts
+++ b/app/modules/teams/__tests__/teamBilling.route.test.ts
@@ -281,7 +281,7 @@ describe("teamBilling.route action", () => {
       expect(result.data.errors.general).toContain("Invalid");
     });
 
-    it("rejects amount below minimum", async () => {
+    it("rejects non-integer amount", async () => {
       const admin = await UserService.create({
         username: "admin",
         role: "SUPER_ADMIN",
@@ -293,11 +293,30 @@ describe("teamBilling.route action", () => {
       const result: any = await action(
         buildActionRequest(cookie, team._id, {
           intent: "ADD_CREDITS",
-          payload: { amount: 5 },
+          payload: { amount: 10.5 },
         }),
       );
 
-      expect(result.data.errors.general).toContain("Minimum");
+      expect(result.data.errors.general).toContain("whole dollar");
+    });
+
+    it("rejects null amount", async () => {
+      const admin = await UserService.create({
+        username: "admin",
+        role: "SUPER_ADMIN",
+        teams: [],
+      });
+      const team = await TeamService.create({ name: "Test Team" });
+      const cookie = await loginUser(admin._id);
+
+      const result: any = await action(
+        buildActionRequest(cookie, team._id, {
+          intent: "ADD_CREDITS",
+          payload: { amount: null },
+        }),
+      );
+
+      expect(result.data.errors.general).toContain("Invalid");
     });
   });
 });

--- a/app/modules/teams/containers/teamBilling.route.tsx
+++ b/app/modules/teams/containers/teamBilling.route.tsx
@@ -23,7 +23,6 @@ import SetBillingUserDialogContainer from "~/modules/billing/containers/setBilli
 import applyMarkup from "~/modules/billing/helpers/applyMarkup";
 import isBillingEnabled from "~/modules/billing/helpers/isBillingEnabled.server";
 import { groupCostsBySource } from "~/modules/billing/helpers/sourceLabels";
-import addCredits from "~/modules/billing/services/addCredits.server";
 import { StripeService } from "~/modules/billing/stripe";
 import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { TeamBillingPlanService } from "~/modules/billing/teamBillingPlan";
@@ -171,18 +170,28 @@ export async function action({ request, params }: Route.ActionArgs) {
           { status: 403 },
         );
       }
-      const result = await addCredits({
-        teamId: params.id,
-        amount: payload.amount,
-        note: payload.note,
-        addedBy: user._id,
-      });
-      if (!result.success) {
+      if (
+        typeof payload.amount !== "number" ||
+        !Number.isFinite(payload.amount)
+      ) {
+        return data({ errors: { general: "Invalid amount" } }, { status: 400 });
+      }
+      if (!Number.isInteger(payload.amount)) {
         return data(
-          { errors: { general: result.error ?? "Failed to add credits" } },
+          { errors: { general: "Amount must be a whole dollar value" } },
           { status: 400 },
         );
       }
+      const note =
+        typeof payload.note === "string" && payload.note.trim()
+          ? payload.note.trim()
+          : "Added by System Admin";
+      await TeamCreditService.create({
+        team: params.id,
+        amount: payload.amount,
+        addedBy: user._id,
+        note,
+      });
       return data({ success: true, intent: "ADD_CREDITS" });
     }
 
@@ -213,9 +222,7 @@ export async function action({ request, params }: Route.ActionArgs) {
           { status: 400 },
         );
       }
-      await TeamService.updateById(params.id, {
-        billingUser: isMember._id,
-      });
+      await TeamService.updateById(params.id, { billingUser: isMember._id });
       return data({ success: true, intent: "SET_BILLING_USER" });
     }
 


### PR DESCRIPTION
## Summary

- Extracted `getRunSetPrefillData` service from `runSetCreate.route.tsx` — consolidates prompt/model dedup logic and adds project scoping (IDOR fix for malformed run IDs)
- Hoisted run lookup before intent switch in `run.route.tsx` action — removes repeated `RunService.findOne` calls across intents
- Inlined ADD_CREDITS logic in `teamBilling.route.tsx` — moved amount validations into the route, removed the minimum top-up check which only applies to INITIATE_TOPUP
- Added tests for RunSet prefill, evaluation report aggregation, and billing route amount validation