### PR TITLE
Display initial credits amount consistently from server config

### DIFF
--- a/app/modules/authentication/components/splash/announcementBanner.tsx
+++ b/app/modules/authentication/components/splash/announcementBanner.tsx
@@ -1,9 +1,16 @@
+import { useRouteLoaderData } from "react-router";
+
 export function AnnouncementBanner() {
+  const rootData = useRouteLoaderData("root") as
+    | { initialCredits: number }
+    | undefined;
+  const initialCredits = rootData?.initialCredits ?? 20;
+
   return (
     <div className="fixed top-0 right-0 left-0 z-[60] bg-[#367181] py-2 text-center">
       <span className="text-[0.82rem] font-semibold tracking-[0.02em] text-white">
-        🎁 New users get <strong>$20 in free credits</strong> to start
-        annotating
+        🎁 New users get <strong>${initialCredits} in free credits</strong> to
+        start annotating
       </span>
     </div>
   );

--- a/app/modules/home/components/home.tsx
+++ b/app/modules/home/components/home.tsx
@@ -18,9 +18,11 @@ import { Link } from "react-router";
 export default function Home({
   onDownloadClicked,
   isDownloading,
+  initialCredits,
 }: {
   onDownloadClicked: () => void;
   isDownloading: boolean;
+  initialCredits: number;
 }) {
   const [agreed, setAgreed] = useState(false);
   return (
@@ -54,7 +56,7 @@ export default function Home({
         </div>
         <div className="border-primary flex w-48 shrink-0 flex-col items-center rounded-lg border-2 bg-gradient-to-br from-[#e8f4f7] to-[#f0f7f4] p-4 text-center">
           <p className="text-primary text-4xl leading-none font-extrabold">
-            $20
+            ${initialCredits}
           </p>
           <p className="text-primary mt-1 text-xs font-semibold">
             free credit included

--- a/app/modules/home/containers/home.route.tsx
+++ b/app/modules/home/containers/home.route.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useFetcher } from "react-router";
+import { useFetcher, useRouteLoaderData } from "react-router";
 import Home from "../components/home";
 
 export function loader() {
@@ -11,6 +11,9 @@ export function HydrateFallback() {
 }
 
 export default function HomeRoute() {
+  const rootData = useRouteLoaderData("root") as
+    | { initialCredits: number }
+    | undefined;
   const fetcher = useFetcher();
   const isDownloading = fetcher.state !== "idle";
 
@@ -33,6 +36,10 @@ export default function HomeRoute() {
   };
 
   return (
-    <Home onDownloadClicked={onDownloadClicked} isDownloading={isDownloading} />
+    <Home
+      onDownloadClicked={onDownloadClicked}
+      isDownloading={isDownloading}
+      initialCredits={rootData?.initialCredits ?? 20}
+    />
   );
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,6 +16,7 @@ import { Toaster } from "sonner";
 import sandpiperFavicon from "~/assets/sandpiper-favicon.svg";
 import * as ga from "~/modules/analytics/analytics";
 import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
+import getInitialCreditsAmount from "~/modules/billing/helpers/getInitialCreditsAmount.server";
 import { SystemSettingsService } from "~/modules/systemSettings/systemSettings";
 import type { Route } from "./+types/root";
 import "./app.css";
@@ -68,6 +69,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   return {
     googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID || null,
     maintenanceMode,
+    initialCredits: getInitialCreditsAmount(),
   };
 }
 


### PR DESCRIPTION
Replace hardcoded $20 in the announcement banner and home page with a dynamic value sourced from getInitialCreditsAmount() via the root loader, matching the signup page's existing behaviour.

Fixes #2073