### PR TITLE
Split addCredits from topUp authorization

### DIFF
--- a/app/modules/billing/__tests__/authorization.test.ts
+++ b/app/modules/billing/__tests__/authorization.test.ts
@@ -15,7 +15,7 @@ describe("BillingAuthorization", () => {
     _id: "billing-user-1",
     username: "billing_user",
     role: "USER",
-    teams: [{ team: "team-1", role: "ADMIN" }],
+    teams: [{ team: "team-1", role: "MEMBER" }],
   } as User;
 
   const teamAdminUser = {
@@ -219,29 +219,49 @@ describe("BillingAuthorization", () => {
 
   describe("canAddCredits", () => {
     it("allows super admins", () => {
-      expect(BillingAuthorization.canAddCredits(superAdminUser, team)).toBe(
-        true,
-      );
+      expect(BillingAuthorization.canAddCredits(superAdminUser)).toBe(true);
     });
 
-    it("allows the billing user", () => {
-      expect(BillingAuthorization.canAddCredits(billingUser, team)).toBe(true);
+    it("denies the billing user", () => {
+      expect(BillingAuthorization.canAddCredits(billingUser)).toBe(false);
     });
 
     it("denies team admins", () => {
-      expect(BillingAuthorization.canAddCredits(teamAdminUser, team)).toBe(
-        false,
-      );
+      expect(BillingAuthorization.canAddCredits(teamAdminUser)).toBe(false);
     });
 
     it("denies team members", () => {
-      expect(BillingAuthorization.canAddCredits(teamMemberUser, team)).toBe(
-        false,
-      );
+      expect(BillingAuthorization.canAddCredits(teamMemberUser)).toBe(false);
     });
 
     it("denies null users", () => {
-      expect(BillingAuthorization.canAddCredits(null, team)).toBe(false);
+      expect(BillingAuthorization.canAddCredits(null)).toBe(false);
+    });
+  });
+
+  describe("canTopUp", () => {
+    it("denies super admins", () => {
+      expect(BillingAuthorization.canTopUp(superAdminUser, team)).toBe(false);
+    });
+
+    it("allows the billing user", () => {
+      expect(BillingAuthorization.canTopUp(billingUser, team)).toBe(true);
+    });
+
+    it("allows team admins", () => {
+      expect(BillingAuthorization.canTopUp(teamAdminUser, team)).toBe(true);
+    });
+
+    it("denies team members", () => {
+      expect(BillingAuthorization.canTopUp(teamMemberUser, team)).toBe(false);
+    });
+
+    it("denies non-team users", () => {
+      expect(BillingAuthorization.canTopUp(nonTeamUser, team)).toBe(false);
+    });
+
+    it("denies null users", () => {
+      expect(BillingAuthorization.canTopUp(null, team)).toBe(false);
     });
   });
 });

--- a/app/modules/billing/authorization.ts
+++ b/app/modules/billing/authorization.ts
@@ -32,8 +32,15 @@ const BillingAuthorization = {
     return userIsSuperAdmin(user) || userIsTeamAdmin(user, teamId);
   },
 
-  canAddCredits(user: User | null, team: Team | null): boolean {
-    return userIsSuperAdmin(user) || userIsTeamBillingUser(user, team);
+  canAddCredits(user: User | null): boolean {
+    return userIsSuperAdmin(user);
+  },
+
+  canTopUp(user: User | null, team: Team | null): boolean {
+    return (
+      userIsTeamBillingUser(user, team) ||
+      userIsTeamAdmin(user, team?._id ?? "")
+    );
   },
 };
 

--- a/app/modules/teams/__tests__/teamBilling.route.test.ts
+++ b/app/modules/teams/__tests__/teamBilling.route.test.ts
@@ -5,7 +5,6 @@ import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
 import loginUser from "../../../../test/helpers/loginUser";
 import { BillingPlanService } from "../../billing/billingPlan";
 import { TeamBillingPlanService } from "../../billing/teamBillingPlan";
-import { TeamCreditService } from "../../billing/teamCredit";
 import { action } from "../containers/teamBilling.route";
 
 function buildActionRequest(
@@ -193,7 +192,7 @@ describe("teamBilling.route action", () => {
   });
 
   describe("ADD_CREDITS", () => {
-    it("allows billing user to add credits", async () => {
+    it("denies billing user from adding credits", async () => {
       const team = await TeamService.create({ name: "Test Team" });
       const billingUser = await UserService.create({
         username: "billing",
@@ -201,11 +200,6 @@ describe("teamBilling.route action", () => {
         teams: [{ team: team._id, role: "ADMIN" }],
       });
       await TeamService.updateById(team._id, { billingUser: billingUser._id });
-      await BillingPlanService.create({
-        name: "Standard",
-        markupRate: 1.5,
-        isDefault: true,
-      });
 
       const cookie = await loginUser(billingUser._id);
 
@@ -216,12 +210,8 @@ describe("teamBilling.route action", () => {
         }),
       );
 
-      expect(result.data.success).toBe(true);
-
-      const credits = await TeamCreditService.findByTeam(team._id);
-      expect(credits).toHaveLength(1);
-      expect(credits[0].amount).toBe(50);
-      expect(credits[0].note).toBe("Test top-up");
+      expect(result.init?.status).toBe(403);
+      expect(result.data.errors.general).toContain("permission");
     });
 
     it("allows super admin to add credits", async () => {
@@ -317,6 +307,87 @@ describe("teamBilling.route action", () => {
       );
 
       expect(result.data.errors.general).toContain("Invalid");
+    });
+  });
+
+  describe("INITIATE_TOPUP", () => {
+    it("allows billing user to initiate top up", async () => {
+      const team = await TeamService.create({ name: "Test Team" });
+      const billingUser = await UserService.create({
+        username: "billing",
+        role: "USER",
+        teams: [{ team: team._id, role: "MEMBER" }],
+      });
+      await TeamService.updateById(team._id, { billingUser: billingUser._id });
+      const cookie = await loginUser(billingUser._id);
+
+      const result: any = await action(
+        buildActionRequest(cookie, team._id, {
+          intent: "INITIATE_TOPUP",
+          payload: { amount: 50 },
+        }),
+      );
+
+      expect(result.data.errors.general).toContain("Billing is not enabled");
+    });
+
+    it("allows team admins to initiate top up", async () => {
+      const team = await TeamService.create({ name: "Test Team" });
+      const admin = await UserService.create({
+        username: "teamadmin",
+        role: "USER",
+        teams: [{ team: team._id, role: "ADMIN" }],
+      });
+      const cookie = await loginUser(admin._id);
+
+      const result: any = await action(
+        buildActionRequest(cookie, team._id, {
+          intent: "INITIATE_TOPUP",
+          payload: { amount: 50 },
+        }),
+      );
+
+      expect(result.data.errors.general).toContain("Billing is not enabled");
+    });
+
+    it("denies regular members from initiating top up", async () => {
+      const team = await TeamService.create({ name: "Test Team" });
+      const member = await UserService.create({
+        username: "member",
+        role: "USER",
+        teams: [{ team: team._id, role: "MEMBER" }],
+      });
+      const cookie = await loginUser(member._id);
+
+      const result: any = await action(
+        buildActionRequest(cookie, team._id, {
+          intent: "INITIATE_TOPUP",
+          payload: { amount: 50 },
+        }),
+      );
+
+      expect(result.init?.status).toBe(403);
+      expect(result.data.errors.general).toContain("permission");
+    });
+
+    it("denies non-team users from initiating top up", async () => {
+      const team = await TeamService.create({ name: "Test Team" });
+      const outsider = await UserService.create({
+        username: "outsider",
+        role: "USER",
+        teams: [],
+      });
+      const cookie = await loginUser(outsider._id);
+
+      const result: any = await action(
+        buildActionRequest(cookie, team._id, {
+          intent: "INITIATE_TOPUP",
+          payload: { amount: 50 },
+        }),
+      );
+
+      expect(result.init?.status).toBe(403);
+      expect(result.data.errors.general).toContain("permission");
     });
   });
 });

--- a/app/modules/teams/components/billingOverview.tsx
+++ b/app/modules/teams/components/billingOverview.tsx
@@ -40,7 +40,8 @@ export default function BillingOverview({
   onAssignPlanClicked,
 }: BillingOverviewProps) {
   const user = useContext(AuthenticationContext) as User | null;
-  const canAddCredits = BillingAuthorization.canAddCredits(user, team);
+  const canAddCredits = BillingAuthorization.canAddCredits(user);
+  const canTopUp = BillingAuthorization.canTopUp(user, team);
   const canAssignPlan = BillingAuthorization.canAssignPlan(user);
   const isLowBalance = balanceSummary.balance < 1 && balanceSummary.balance > 0;
   const isNegativeBalance = balanceSummary.balance < 0;
@@ -129,22 +130,24 @@ export default function BillingOverview({
         </Card>
       </div>
 
-      {canAddCredits && (
+      {(canAddCredits || canTopUp) && (
         <div className="flex gap-2">
-          {isBillingEnabled && (
+          {isBillingEnabled && canTopUp && (
             <Button onClick={onTopUpClicked} disabled={isSubmitting}>
               <Plus className="mr-1 h-4 w-4" />
               Top up
             </Button>
           )}
-          <Button
-            variant="outline"
-            onClick={onAddCreditsClicked}
-            disabled={isSubmitting}
-          >
-            <Plus className="mr-1 h-4 w-4" />
-            Add credits
-          </Button>
+          {canAddCredits && (
+            <Button
+              variant="outline"
+              onClick={onAddCreditsClicked}
+              disabled={isSubmitting}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Add credits
+            </Button>
+          )}
         </div>
       )}
     </>

--- a/app/modules/teams/containers/teamBilling.route.tsx
+++ b/app/modules/teams/containers/teamBilling.route.tsx
@@ -164,7 +164,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   switch (intent) {
     case "ADD_CREDITS": {
-      if (!BillingAuthorization.canAddCredits(user, team)) {
+      if (!BillingAuthorization.canAddCredits(user)) {
         return data(
           { errors: { general: "You do not have permission to add credits" } },
           { status: 403 },
@@ -251,13 +251,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     }
 
     case "INITIATE_TOPUP": {
-      if (!isBillingEnabled()) {
-        return data(
-          { errors: { general: "Billing is not enabled" } },
-          { status: 400 },
-        );
-      }
-      if (!BillingAuthorization.canAddCredits(user, team)) {
+      if (!BillingAuthorization.canTopUp(user, team)) {
         return data(
           {
             errors: {
@@ -265,6 +259,12 @@ export async function action({ request, params }: Route.ActionArgs) {
             },
           },
           { status: 403 },
+        );
+      }
+      if (!isBillingEnabled()) {
+        return data(
+          { errors: { general: "Billing is not enabled" } },
+          { status: 400 },
         );
       }
       const amount = payload.amount;


### PR DESCRIPTION
## Summary

- `canAddCredits`: restricted to super admins only (manual, free credit addition — no payment)
- `canTopUp`: billing user or team admin (Stripe payment flow)
- `INITIATE_TOPUP` action now checks authorization before the billing-enabled guard
- `billingOverview` gates each button independently so team admins/billing users see Top up but not Add credits

Fixes #2075