### PR TITLE
Hide run-set Export when runs have errored

### DIFF
--- a/app/modules/runSets/components/runSetDetail.tsx
+++ b/app/modules/runSets/components/runSetDetail.tsx
@@ -58,6 +58,7 @@ export default function RunSetDetail({
   annotationProgress: {
     totalRuns: number;
     completedRuns: number;
+    erroredRuns: number;
     totalSessions: number;
     completedSessions: number;
     processing: number;
@@ -86,7 +87,8 @@ export default function RunSetDetail({
           <div className="text-muted-foreground flex gap-1">
             {annotationProgress.totalRuns > 0 &&
               annotationProgress.completedRuns ===
-                annotationProgress.totalRuns && (
+                annotationProgress.totalRuns &&
+              annotationProgress.erroredRuns === 0 && (
                 <DownloadDropdown
                   isExporting={isExporting}
                   onExportButtonClicked={onExportRunSetButtonClicked}

--- a/app/modules/runSets/containers/runSetDetail.route.tsx
+++ b/app/modules/runSets/containers/runSetDetail.route.tsx
@@ -52,6 +52,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   let annotationProgress = {
     totalRuns: runIds.length,
     completedRuns: 0,
+    erroredRuns: 0,
     totalSessions: 0,
     completedSessions: 0,
     processing: 0,

--- a/app/modules/runs/containers/run.route.tsx
+++ b/app/modules/runs/containers/run.route.tsx
@@ -125,6 +125,8 @@ export async function action({ request, params }: Route.ActionArgs) {
       return {};
     }
     case "EXPORT_RUN": {
+      if (!run.isComplete)
+        throw new Error("Cannot export a run that is not complete");
       if (run.hasErrored)
         throw new Error("Cannot export a run that has errors");
       await exportRun({ runId: params.runId, exportType });

--- a/app/modules/runs/services/__tests__/aggregateProgress.test.ts
+++ b/app/modules/runs/services/__tests__/aggregateProgress.test.ts
@@ -27,6 +27,7 @@ describe("aggregateProgress", () => {
     const result = await aggregateProgress([]);
     expect(result).toEqual({
       completedRuns: 0,
+      erroredRuns: 0,
       totalSessions: 0,
       completedSessions: 0,
       processing: 0,
@@ -92,6 +93,28 @@ describe("aggregateProgress", () => {
 
     expect(result.completedRuns).toBe(1);
     expect(result.processing).toBe(2);
+  });
+
+  it("counts runs with hasErrored set", async () => {
+    const run1 = await createTestRun({
+      name: "Errored",
+      project: projectId as any,
+      isComplete: true,
+      hasErrored: true,
+      sessions: buildSessions(["DONE"]),
+    });
+    const run2 = await createTestRun({
+      name: "Clean",
+      project: projectId as any,
+      isComplete: true,
+      hasErrored: false,
+      sessions: buildSessions(["DONE"]),
+    });
+
+    const result = await aggregateProgress([run1._id, run2._id]);
+
+    expect(result.erroredRuns).toBe(1);
+    expect(result.completedRuns).toBe(2);
   });
 
   it("returns the earliest startedAt", async () => {

--- a/app/modules/runs/services/aggregateProgress.server.ts
+++ b/app/modules/runs/services/aggregateProgress.server.ts
@@ -3,6 +3,7 @@ import { RunModel } from "../run";
 
 export interface AggregateProgressResult {
   completedRuns: number;
+  erroredRuns: number;
   totalSessions: number;
   completedSessions: number;
   processing: number;
@@ -23,6 +24,9 @@ export default async function aggregateProgress(
           _id: null,
           completedRuns: {
             $sum: { $cond: ["$isComplete", 1, 0] },
+          },
+          erroredRuns: {
+            $sum: { $cond: ["$hasErrored", 1, 0] },
           },
           processing: {
             $sum: {
@@ -75,6 +79,7 @@ export default async function aggregateProgress(
 
   return {
     completedRuns: progress?.completedRuns ?? 0,
+    erroredRuns: progress?.erroredRuns ?? 0,
     totalSessions: progress?.totalSessions ?? 0,
     completedSessions: progress?.completedSessions ?? 0,
     processing: progress?.processing ?? 0,


### PR DESCRIPTION
The run-set Export button was shown whenever all runs had finished but didn't check for errors, so clicking Export triggered a server rejection that surfaced as a silent failure. Track errored runs in aggregateProgress and hide the button when any run errored. Also tighten the single-run EXPORT_RUN action to reject incomplete runs, matching the UI visibility rule.

Fixes #2097