### PR TITLE
Copy shouldRunVerification when using run set as template

### DIFF
--- a/app/modules/runSets/__tests__/getRunSetPrefillData.test.ts
+++ b/app/modules/runSets/__tests__/getRunSetPrefillData.test.ts
@@ -172,6 +172,26 @@ describe("getRunSetPrefillData", () => {
       expect(result.prefillSessionIds).toContain(sessionId);
     });
 
+    it("copies shouldRunVerification from source run", async () => {
+      const run = await RunService.create({
+        project: projectId,
+        name: "Verified Run",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: true,
+      });
+
+      const result = await RunSetService.getPrefillDataFromRun(
+        run._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.shouldRunVerification).toBe(true);
+    });
+
     it("uses empty string for prompt name when prompt no longer exists", async () => {
       const deletedId = new Types.ObjectId().toString();
       const run = await RunService.create({
@@ -435,6 +455,68 @@ describe("getRunSetPrefillData", () => {
       );
       expect(result.prefillData!.selectedPrompts).toHaveLength(0);
       expect(result.prefillData!.selectedModels).toHaveLength(0);
+    });
+
+    it("copies shouldRunVerification when any run has it enabled", async () => {
+      const runWithout = await RunService.create({
+        project: projectId,
+        name: "Run Without Verification",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      const runWith = await RunService.create({
+        project: projectId,
+        name: "Run With Verification",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: true,
+      });
+      const runSet = await RunSetService.create({
+        name: "Mixed Verification RunSet",
+        project: projectId,
+        runs: [runWithout._id, runWith._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.shouldRunVerification).toBe(true);
+    });
+
+    it("keeps shouldRunVerification false when no runs have it enabled", async () => {
+      const run = await RunService.create({
+        project: projectId,
+        name: "Run Without Verification",
+        sessions: [],
+        annotationType: "PER_UTTERANCE",
+        prompt: promptId,
+        promptVersion: 1,
+        modelCode: testModel,
+        shouldRunVerification: false,
+      });
+      const runSet = await RunSetService.create({
+        name: "No Verification RunSet",
+        project: projectId,
+        runs: [run._id],
+        annotationType: "PER_UTTERANCE",
+      });
+
+      const result = await RunSetService.getPrefillDataFromRunSet(
+        runSet._id,
+        projectId,
+      );
+
+      expect(result.prefillData!.shouldRunVerification).toBe(false);
     });
 
     it("includes validation error when a model is no longer available", async () => {

--- a/app/modules/runSets/containers/runSetCreator.container.tsx
+++ b/app/modules/runSets/containers/runSetCreator.container.tsx
@@ -54,7 +54,9 @@ export default function RunSetCreatorContainer({
   const [selectedSessions, setSelectedSessions] = useState<SessionData[]>(
     prefillData?.selectedSessions || [],
   );
-  const [shouldRunVerification, setShouldRunVerification] = useState(false);
+  const [shouldRunVerification, setShouldRunVerification] = useState(
+    prefillData?.shouldRunVerification ?? false,
+  );
   const [removedKeys, setRemovedKeys] = useState<Set<string>>(new Set());
 
   const allDefinitions = useMemo(

--- a/app/modules/runSets/runSets.types.ts
+++ b/app/modules/runSets/runSets.types.ts
@@ -33,6 +33,7 @@ export interface PrefillData {
   selectedPrompts: PromptReference[];
   selectedModels: string[];
   selectedSessions: SessionData[];
+  shouldRunVerification?: boolean;
   validationErrors?: string[];
 }
 

--- a/app/modules/runSets/services/getRunSetPrefillData.server.ts
+++ b/app/modules/runSets/services/getRunSetPrefillData.server.ts
@@ -40,6 +40,7 @@ export async function getPrefillDataFromRun(
         },
       ],
       selectedModels: modelCode ? [modelCode] : [],
+      shouldRunVerification: run.shouldRunVerification ?? false,
       selectedSessions: [],
     },
     prefillSessionIds: sessionIds,
@@ -75,9 +76,11 @@ export async function getPrefillDataFromRunSet(
 
   const promptMap = new Map<string, { promptId: string; version: number }>();
   const modelSet = new Set<string>();
+  let shouldRunVerification = false;
 
   for (const run of runs) {
     if (run.isHuman) continue;
+    if (run.shouldRunVerification) shouldRunVerification = true;
     const key = `${run.prompt}-${run.promptVersion}`;
     if (!promptMap.has(key)) {
       promptMap.set(key, {
@@ -133,6 +136,7 @@ export async function getPrefillDataFromRunSet(
       annotationType,
       selectedPrompts,
       selectedModels,
+      shouldRunVerification,
       selectedSessions: [],
       validationErrors:
         validationErrors.length > 0 ? validationErrors : undefined,


### PR DESCRIPTION
The "Use as Template" flow was resetting the verification toggle to false. Now it copies the value from the source run(s) so the user doesn't have to re-enable it manually.

Fixes #2089