### PR TITLE
Exempt /api health endpoint from maintenance mode

### DIFF
--- a/app/modules/systemSettings/__tests__/maintenanceMiddleware.test.ts
+++ b/app/modules/systemSettings/__tests__/maintenanceMiddleware.test.ts
@@ -89,6 +89,7 @@ describe("maintenanceMiddleware", () => {
       "/socket.io/connect",
       "/api/sockets",
       "/api/webhooks/stripe",
+      "/api",
     ])("allows %s through during maintenance", async (path) => {
       await SystemSettingsService.update({ maintenanceMode: true });
 

--- a/app/modules/systemSettings/maintenanceMiddleware.ts
+++ b/app/modules/systemSettings/maintenanceMiddleware.ts
@@ -5,15 +5,15 @@ import sessionStorage from "../../../sessionStorage";
 import maintenancePageHtml from "./helpers/maintenancePageHtml";
 import { SystemSettingsService } from "./systemSettings";
 
-const EXEMPT_PATHS = [
-  "/assets/",
-  "/socket.io/",
-  "/api/sockets",
-  "/api/webhooks/stripe",
-];
+const EXEMPT_PREFIXES = ["/assets/", "/socket.io/", "/api/sockets"];
+
+const EXEMPT_EXACT = ["/api", "/api/webhooks/stripe"];
 
 function isExempt(path: string): boolean {
-  return EXEMPT_PATHS.some((exempt) => path.startsWith(exempt));
+  return (
+    EXEMPT_EXACT.includes(path) ||
+    EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix))
+  );
 }
 
 export default async function maintenanceMiddleware(


### PR DESCRIPTION
The load balancer health check hits GET /api, which was blocked by the maintenance middleware returning 503. This caused instances to be marked unhealthy and pulled out of rotation.

Split the exempt list into prefix matches and exact matches, and add /api to the exact list. Moved /api/webhooks/stripe to exact as well since it's a single route, not a prefix.

Fixes #2142