### PR TITLE
Add structured LiteLLM request tags for observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ GITHUB_CLIENT_ID='' # Github OAuth App Client ID
 GITHUB_CLIENT_SECRET=''# Github OAuth App Client Secret
 SUPER_ADMIN_GITHUB_ID='' # Github ID to configure for super admin rights on application setup
 AUTH_CALLBACK_URL='http://localhost:5173/auth/callback'
+# DEPLOY_ENV='development' # Deployment environment: development, staging, production (used in LLM request tags)
 PROJECT_ROOT='' # Path to the project root directory, e.g. /home/user/sandpiper
 # REDIS_LOCAL='true' # Use local Redis (localhost:6379) running with `yarn redis`. Overrides REDIS_URL
 # REDIS_URL='' # External Redis URL

--- a/app/functions/annotatePerSession/app.ts
+++ b/app/functions/annotatePerSession/app.ts
@@ -43,7 +43,7 @@ export const handler = async (event: { body: LambdaBody }) => {
 
   const llm = new LLM({
     model,
-    user: team,
+    team,
     source: "annotation:per-session",
     sourceId: sessionId,
     billingEventId,

--- a/app/functions/annotatePerUtterance/app.ts
+++ b/app/functions/annotatePerUtterance/app.ts
@@ -43,7 +43,7 @@ export const handler = async (event: { body: LambdaBody }) => {
 
   const llm = new LLM({
     model,
-    user: team,
+    team,
     source: "annotation:per-utterance",
     sourceId: sessionId,
     billingEventId,

--- a/app/functions/convertSessionDataToJSON/app.ts
+++ b/app/functions/convertSessionDataToJSON/app.ts
@@ -39,7 +39,7 @@ export const handler = async (event: LambdaEvent) => {
   const llm = new LLM({
     retries: 3,
     model: getDefaultModelCode(),
-    user: team,
+    team,
     source: "file-conversion",
     sourceId: sessionId,
     billingEventId,

--- a/app/modules/codebooks/services/createPromptFromCodebook.server.ts
+++ b/app/modules/codebooks/services/createPromptFromCodebook.server.ts
@@ -70,7 +70,7 @@ export default async function createPromptFromCodebook({
 
     const llm = new LLM({
       model: "anthropic.claude-4.6-opus",
-      user: teamId,
+      team: teamId,
       source: "codebook-prompt-generation",
       sourceId: codebookId,
       billingEventId: `codebook-prompt-generation:${codebookVersionId}`,

--- a/app/modules/llm/__tests__/llm.test.ts
+++ b/app/modules/llm/__tests__/llm.test.ts
@@ -142,7 +142,7 @@ describe("LLM", () => {
         model: MODEL,
         sourceId: "session-123",
         billingEventId: "event-123",
-        user: "team-456",
+        team: "team-456",
       });
       llm.addUserMessage("test", {});
       await llm.createChat();
@@ -196,7 +196,7 @@ describe("LLM", () => {
         model: MODEL,
         retries: 3,
         billingEventId: makeBillingEventId("orchestrator-attempts"),
-        user: "team-1",
+        team: "team-1",
       });
       llm.setOrchestratorMessage("Check this", {});
       llm.addUserMessage("test", {});
@@ -222,7 +222,7 @@ describe("LLM", () => {
         source: SOURCE,
         model: MODEL,
         billingEventId: makeBillingEventId("ledger-write-fails"),
-        user: "team-1",
+        team: "team-1",
       });
       llm.addUserMessage("test", {});
 

--- a/app/modules/llm/llm.ts
+++ b/app/modules/llm/llm.ts
@@ -24,7 +24,7 @@ interface LLMOptions {
   model: string;
   sourceId?: string;
   billingEventId: string;
-  user?: string;
+  team?: string;
   schema?: object;
   retries?: number;
   timeout?: number;
@@ -95,7 +95,7 @@ class LLM {
     };
 
     if (delta.inputTokens === 0 && delta.outputTokens === 0) return;
-    if (!this.options.user) return;
+    if (!this.options.team) return;
 
     try {
       const applyBillingDebit = (
@@ -107,7 +107,7 @@ class LLM {
         outputTokens: delta.outputTokens,
       });
       await applyBillingDebit({
-        teamId: this.options.user,
+        teamId: this.options.team,
         model: this.options.model,
         source: this.options.source,
         sourceId: this.options.sourceId,
@@ -118,7 +118,7 @@ class LLM {
         idempotencyKey: [
           "llm-cost",
           this.options.billingEventId,
-          this.options.user,
+          this.options.team,
           this.options.source,
           this.options.sourceId ?? "none",
           this.totalUsage.inputTokens,
@@ -132,21 +132,21 @@ class LLM {
   }
 
   private async checkBalance() {
-    if (!this.options.user) return;
+    if (!this.options.team) return;
     if (mongoose.connection.readyState !== 1) return;
 
     const { TeamBillingService } =
       await import("~/modules/billing/teamBilling");
-    const balance = await TeamBillingService.getBalance(this.options.user);
+    const balance = await TeamBillingService.getBalance(this.options.team);
 
     if (balance <= 0) {
       const { insufficientBalanceCounter } =
         await import("~/modules/billing/helpers/billingMetrics");
-      insufficientBalanceCounter.add(1, { team: this.options.user });
+      insufficientBalanceCounter.add(1, { team: this.options.team });
 
       const { InsufficientCreditsError } =
         await import("~/modules/billing/errors/insufficientCreditsError");
-      throw new InsufficientCreditsError(this.options.user);
+      throw new InsufficientCreditsError(this.options.team);
     }
   }
 

--- a/app/modules/llm/providers/aiGateway.ts
+++ b/app/modules/llm/providers/aiGateway.ts
@@ -36,16 +36,19 @@ registerLLM("AI_GATEWAY", {
     messages: Array<{ role: string; content: string }>;
     schema?: object;
   }) => {
-    const { model, user } = options;
+    const { model, team, billingEventId } = options;
+    const env = process.env.DEPLOY_ENV || process.env.NODE_ENV || "development";
+
+    const prefix = `sandpiper.${env}`;
+    const tags: string[] = [];
+    if (team) tags.push(`${prefix}.team.${team}`);
+    if (billingEventId) tags.push(`${prefix}.billing.${billingEventId}`);
 
     const metadata: Record<string, unknown> = {};
-
-    if (user) {
-      metadata.tags = [user];
-    }
+    if (tags.length > 0) metadata.tags = tags;
 
     const requestParams: Record<string, unknown> = {
-      user,
+      user: team,
       model: model,
       messages: messages,
       metadata,

--- a/app/modules/prompts/services/checkPromptAndAnnotationSchemaAlignment.server.ts
+++ b/app/modules/prompts/services/checkPromptAndAnnotationSchemaAlignment.server.ts
@@ -39,7 +39,7 @@ export default async function checkPromptAndAnnotationSchemaAlignment({
 
   const llm = new LLM({
     model: "anthropic.claude-4.6-sonnet",
-    user: team,
+    team,
     source: "prompt-alignment",
     sourceId: promptId,
     billingEventId: `prompt-alignment:check:${promptId}`,

--- a/app/modules/prompts/services/suggestPromptAndAnnotationSchemaChanges.server.ts
+++ b/app/modules/prompts/services/suggestPromptAndAnnotationSchemaChanges.server.ts
@@ -59,7 +59,7 @@ export default async function checkPromptAndAnnotationSchemaAlignment({
 
   const llm = new LLM({
     model: "anthropic.claude-4.6-sonnet",
-    user: team,
+    team,
     source: "prompt-alignment",
     sourceId: promptId,
     billingEventId: `prompt-alignment:suggest:${promptId}`,

--- a/app/modules/sessions/helpers/getAttributeMappingFromFile.ts
+++ b/app/modules/sessions/helpers/getAttributeMappingFromFile.ts
@@ -56,7 +56,7 @@ export default async function getAttributeMappingFromFile({
   try {
     const llm = new LLM({
       model: getDefaultModelCode(),
-      user: team,
+      team,
       source: "attribute-mapping",
       sourceId: projectId,
       billingEventId: `attribute-mapping:${projectId ?? "no-project"}`,

--- a/workers/tasks/adjudicatePerSession.ts
+++ b/workers/tasks/adjudicatePerSession.ts
@@ -80,7 +80,7 @@ export default async function adjudicatePerSession(job: Job) {
 
       const llm = new LLM({
         model,
-        user: team,
+        team,
         schema: responseSchema,
         source: "adjudication:per-session",
         sourceId: sessionId,

--- a/workers/tasks/adjudicatePerUtterance.ts
+++ b/workers/tasks/adjudicatePerUtterance.ts
@@ -86,7 +86,7 @@ export default async function adjudicatePerUtterance(job: Job) {
 
       const llm = new LLM({
         model,
-        user: team,
+        team,
         schema: responseSchema,
         source: "adjudication:per-utterance",
         sourceId: sessionId,

--- a/workers/tasks/annotatePerSession.ts
+++ b/workers/tasks/annotatePerSession.ts
@@ -71,7 +71,7 @@ export default async function annotatePerSession(job: Job) {
 
     const llm = new LLM({
       model,
-      user: team,
+      team,
       schema: responseSchema,
       source: "annotation:per-session",
       sourceId: runId,
@@ -97,7 +97,7 @@ export default async function annotatePerSession(job: Job) {
 
       const verifyLlm = new LLM({
         model,
-        user: team,
+        team,
         schema: responseSchema,
         source: "verification:per-session",
         sourceId: runId,

--- a/workers/tasks/annotatePerUtterance.ts
+++ b/workers/tasks/annotatePerUtterance.ts
@@ -71,7 +71,7 @@ export default async function annotatePerUtterance(job: Job) {
 
     const llm = new LLM({
       model,
-      user: team,
+      team,
       schema: responseSchema,
       source: "annotation:per-utterance",
       sourceId: runId,
@@ -97,7 +97,7 @@ export default async function annotatePerUtterance(job: Job) {
 
       const verifyLlm = new LLM({
         model,
-        user: team,
+        team,
         schema: responseSchema,
         source: "verification:per-utterance",
         sourceId: runId,


### PR DESCRIPTION
Tag every LLM request with `sandpiper.[env].team.[id]` and `sandpiper.[env].billing.[billingEventId]` so we can filter and correlate requests in the LiteLLM dashboard. Rename the `user` option to `team` in LLMOptions to reflect what it actually is.

Fixes #2145