### PR TITLE
Fix session viewer losing sidebar page when clicking sessions

### DIFF
--- a/app/modules/runs/components/runSessions.tsx
+++ b/app/modules/runs/components/runSessions.tsx
@@ -18,6 +18,7 @@ export default function RunSessions({
   sidebarSearchValue,
   sidebarCurrentPage,
   sidebarIsSyncing,
+  sidebarSearch,
   isLoadingSession,
   onSidebarSearchValueChanged,
   onSidebarPaginationChanged,
@@ -32,6 +33,7 @@ export default function RunSessions({
   sidebarSearchValue: string;
   sidebarCurrentPage: number;
   sidebarIsSyncing: boolean;
+  sidebarSearch: string;
   isLoadingSession: boolean;
   onSidebarSearchValueChanged: (value: string) => void;
   onSidebarPaginationChanged: (value: number) => void;
@@ -50,6 +52,7 @@ export default function RunSessions({
           count={paginatedSessions.count}
           currentSessionId={currentSessionId}
           runLink={runLink}
+          search={sidebarSearch}
           searchValue={sidebarSearchValue}
           currentPage={sidebarCurrentPage}
           isSyncing={sidebarIsSyncing}

--- a/app/modules/runs/containers/runSessions.route.tsx
+++ b/app/modules/runs/containers/runSessions.route.tsx
@@ -1,6 +1,11 @@
 import fse from "fs-extra";
 import map from "lodash/map";
-import { redirect, useLoaderData, useNavigation } from "react-router";
+import {
+  redirect,
+  useLoaderData,
+  useLocation,
+  useNavigation,
+} from "react-router";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import requireAuth from "~/modules/authentication/helpers/requireAuth";
@@ -133,6 +138,7 @@ export default function ProjectRunSessionsRoute({
     { paramPrefix: "sidebar" },
   );
 
+  const location = useLocation();
   const navigation = useNavigation();
   const isLoadingSession =
     navigation.state === "loading" &&
@@ -151,6 +157,7 @@ export default function ProjectRunSessionsRoute({
       sidebarSearchValue={sidebarSearchValue}
       sidebarCurrentPage={sidebarCurrentPage}
       sidebarIsSyncing={sidebarIsSyncing}
+      sidebarSearch={location.search}
       isLoadingSession={isLoadingSession}
       onSidebarSearchValueChanged={setSidebarSearchValue}
       onSidebarPaginationChanged={setSidebarCurrentPage}

--- a/app/modules/sessions/components/sessionListSidebar.tsx
+++ b/app/modules/sessions/components/sessionListSidebar.tsx
@@ -17,6 +17,7 @@ export default function SessionListSidebar({
   count,
   currentSessionId,
   runLink,
+  search,
   searchValue,
   currentPage,
   isSyncing,
@@ -28,6 +29,7 @@ export default function SessionListSidebar({
   count: number;
   currentSessionId: string;
   runLink: string;
+  search: string;
   searchValue: string;
   currentPage: number;
   isSyncing: boolean;
@@ -95,7 +97,10 @@ export default function SessionListSidebar({
             <Link
               key={session.sessionId}
               ref={isCurrent ? activeRef : undefined}
-              to={`${runLink}/sessions/${session.sessionId}`}
+              to={{
+                pathname: `${runLink}/sessions/${session.sessionId}`,
+                search,
+              }}
               className={clsx("block border-b px-3 py-2", {
                 "bg-accent": isCurrent,
                 "hover:bg-muted": !isCurrent,


### PR DESCRIPTION
Session links used path-only URLs which stripped search params, causing sidebarCurrentPage to reset to 1 on every session click. Preserve search params by passing location.search through to the sidebar Link components.

Fixes #2137