### PR TITLE
Fix prompt authorization test for updated canCreate

### DIFF
--- a/app/modules/prompts/__tests__/authorization.test.ts
+++ b/app/modules/prompts/__tests__/authorization.test.ts
@@ -76,9 +76,9 @@ describe("PromptAuthorization", () => {
       );
     });
 
-    it("denies team members from creating prompts", () => {
+    it("allows team members to create prompts in their team", () => {
       expect(PromptAuthorization.canCreate(teamMemberUser, "team-1")).toBe(
-        false,
+        true,
       );
     });
 


### PR DESCRIPTION
## Summary
- Updated prompt authorization test to reflect that team members can now create prompts (not just admins)
- `canCreate` was changed to use `userIsTeamMember` but the test still expected denial for members