### PR TITLE
Add admin page to view active users by spend

### DIFF
--- a/app/modules/app/components/appSidebar.tsx
+++ b/app/modules/app/components/appSidebar.tsx
@@ -19,6 +19,7 @@ import {
 import {
   ChartNoAxesGantt,
   ChevronsUpDown,
+  CircleDollarSign,
   ClipboardList,
   Construction,
   Database,
@@ -201,6 +202,22 @@ export default function AppSidebar() {
                           <Users />
                           <span className={isActive ? "underline" : ""}>
                             Users
+                          </span>
+                        </>
+                      )}
+                    </NavLink>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </Role>
+              <Role roles={["SUPER_ADMIN"]}>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild>
+                    <NavLink to={"/admin/billing/active-users"}>
+                      {({ isActive }) => (
+                        <>
+                          <CircleDollarSign />
+                          <span className={isActive ? "underline" : ""}>
+                            Billing
                           </span>
                         </>
                       )}

--- a/app/modules/billing/__tests__/getActiveTeams.test.ts
+++ b/app/modules/billing/__tests__/getActiveTeams.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import { TeamService } from "../../teams/team";
+import { UserService } from "../../users/user";
+import {
+  activeTeamsToCSV,
+  paginateActiveTeams,
+} from "../services/getActiveTeams.server";
+import { TeamBillingBalanceService } from "../teamBillingBalance";
+
+describe("getActiveTeams", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  async function seedTeamWithSpend(options: {
+    teamName: string;
+    contactName: string;
+    email: string;
+    institution?: string;
+    totalBilledCosts: number;
+  }) {
+    const user = await UserService.create({
+      username: options.contactName,
+      name: options.contactName,
+      email: options.email,
+      institution: options.institution,
+      role: "USER",
+    });
+
+    const team = await TeamService.create({
+      name: options.teamName,
+      billingUser: user._id,
+    });
+
+    await TeamBillingBalanceService.ensureInitialized(team._id);
+    await TeamBillingBalanceService.reconcileToSnapshot({
+      teamId: team._id,
+      expectedBalance: 100 - options.totalBilledCosts,
+      lastLedgerEntryAt: new Date(),
+      currentVersion: 0,
+      runningTotals: {
+        totalCredits: 100,
+        totalBilledCosts: options.totalBilledCosts,
+        totalRawCosts: options.totalBilledCosts * 0.8,
+      },
+    });
+
+    return { user, team };
+  }
+
+  describe("paginateActiveTeams", () => {
+    it("returns teams with spend sorted by totalBilledCosts descending", async () => {
+      await seedTeamWithSpend({
+        teamName: "Low Spender",
+        contactName: "alice",
+        email: "alice@test.com",
+        totalBilledCosts: 3,
+      });
+      await seedTeamWithSpend({
+        teamName: "High Spender",
+        contactName: "bob",
+        email: "bob@test.com",
+        totalBilledCosts: 15,
+      });
+
+      const result = await paginateActiveTeams({
+        match: {},
+        sort: "-totalBilledCosts",
+        page: 1,
+      });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].teamName).toBe("High Spender");
+      expect(result.data[0].totalBilledCosts).toBe(15);
+      expect(result.data[1].teamName).toBe("Low Spender");
+      expect(result.data[1].totalBilledCosts).toBe(3);
+    });
+
+    it("excludes teams with zero spend", async () => {
+      await seedTeamWithSpend({
+        teamName: "Active",
+        contactName: "active",
+        email: "active@test.com",
+        totalBilledCosts: 7,
+      });
+
+      const zeroTeam = await TeamService.create({ name: "Zero Spend" });
+      await TeamBillingBalanceService.ensureInitialized(zeroTeam._id);
+
+      const result = await paginateActiveTeams({
+        match: {},
+        sort: "-totalBilledCosts",
+        page: 1,
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].teamName).toBe("Active");
+    });
+
+    it("filters by minimum spend threshold", async () => {
+      await seedTeamWithSpend({
+        teamName: "Under 5",
+        contactName: "low",
+        email: "low@test.com",
+        totalBilledCosts: 3,
+      });
+      await seedTeamWithSpend({
+        teamName: "Over 5",
+        contactName: "mid",
+        email: "mid@test.com",
+        totalBilledCosts: 8,
+      });
+      await seedTeamWithSpend({
+        teamName: "Over 10",
+        contactName: "high",
+        email: "high@test.com",
+        totalBilledCosts: 12,
+      });
+
+      const over5 = await paginateActiveTeams({
+        match: { totalBilledCosts: { $gt: 5 } },
+        sort: "-totalBilledCosts",
+        page: 1,
+      });
+
+      expect(over5.data).toHaveLength(2);
+      expect(over5.data[0].teamName).toBe("Over 10");
+      expect(over5.data[1].teamName).toBe("Over 5");
+
+      const over10 = await paginateActiveTeams({
+        match: { totalBilledCosts: { $gt: 10 } },
+        sort: "-totalBilledCosts",
+        page: 1,
+      });
+
+      expect(over10.data).toHaveLength(1);
+      expect(over10.data[0].teamName).toBe("Over 10");
+    });
+
+    it("resolves billingUser as the contact", async () => {
+      await seedTeamWithSpend({
+        teamName: "Test Team",
+        contactName: "owner",
+        email: "owner@university.edu",
+        institution: "State University",
+        totalBilledCosts: 6,
+      });
+
+      const result = await paginateActiveTeams({
+        match: {},
+        sort: "-totalBilledCosts",
+        page: 1,
+      });
+
+      expect(result.data[0].teamName).toBe("Test Team");
+      expect(result.data[0].contactName).toBe("owner");
+      expect(result.data[0].contactEmail).toBe("owner@university.edu");
+      expect(result.data[0].institution).toBe("State University");
+    });
+
+    it("falls back to createdBy when billingUser is not set", async () => {
+      const creator = await UserService.create({
+        username: "creator",
+        name: "Creator",
+        email: "creator@test.com",
+        role: "USER",
+      });
+
+      const team = await TeamService.create({
+        name: "No Billing User",
+        createdBy: creator._id,
+      });
+
+      await TeamBillingBalanceService.ensureInitialized(team._id);
+      await TeamBillingBalanceService.reconcileToSnapshot({
+        teamId: team._id,
+        expectedBalance: 90,
+        lastLedgerEntryAt: new Date(),
+        currentVersion: 0,
+        runningTotals: {
+          totalCredits: 100,
+          totalBilledCosts: 10,
+          totalRawCosts: 8,
+        },
+      });
+
+      const result = await paginateActiveTeams({
+        match: {},
+        sort: "-totalBilledCosts",
+        page: 1,
+      });
+
+      expect(result.data[0].contactName).toBe("Creator");
+      expect(result.data[0].contactEmail).toBe("creator@test.com");
+    });
+
+    it("paginates results", async () => {
+      for (let i = 1; i <= 25; i++) {
+        await seedTeamWithSpend({
+          teamName: `Team ${i}`,
+          contactName: `user${i}`,
+          email: `user${i}@test.com`,
+          totalBilledCosts: i,
+        });
+      }
+
+      const page1 = await paginateActiveTeams({
+        match: {},
+        sort: "-totalBilledCosts",
+        page: 1,
+      });
+
+      expect(page1.data).toHaveLength(20);
+      expect(page1.totalPages).toBe(2);
+      expect(page1.data[0].totalBilledCosts).toBe(25);
+
+      const page2 = await paginateActiveTeams({
+        match: {},
+        sort: "-totalBilledCosts",
+        page: 2,
+      });
+
+      expect(page2.data).toHaveLength(5);
+      expect(page2.data[0].totalBilledCosts).toBe(5);
+    });
+  });
+
+  describe("activeTeamsToCSV", () => {
+    it("produces valid CSV with headers", () => {
+      const csv = activeTeamsToCSV([
+        {
+          teamId: "t1",
+          teamName: "Team One",
+          contactName: "Alice",
+          contactEmail: "alice@test.com",
+          institution: "MIT",
+          totalBilledCosts: 12.5,
+        },
+      ]);
+
+      const lines = csv.split("\n");
+      expect(lines[0]).toBe("Team,Contact,Email,Institution,Total Spend");
+      expect(lines[1]).toBe("Team One,Alice,alice@test.com,MIT,$12.50");
+    });
+
+    it("sanitizes formula injection characters", () => {
+      const csv = activeTeamsToCSV([
+        {
+          teamId: "t1",
+          teamName: "=EVIL",
+          contactName: "+cmd",
+          contactEmail: "-test@test.com",
+          institution: "@inject",
+          totalBilledCosts: 5,
+        },
+      ]);
+
+      const lines = csv.split("\n");
+      expect(lines[1]).toContain("\t=EVIL");
+      expect(lines[1]).toContain("\t+cmd");
+      expect(lines[1]).toContain("\t-test@test.com");
+      expect(lines[1]).toContain("\t@inject");
+    });
+
+    it("escapes fields with commas", () => {
+      const csv = activeTeamsToCSV([
+        {
+          teamId: "t1",
+          teamName: "Team, Inc.",
+          contactName: "Bob",
+          contactEmail: "bob@test.com",
+          institution: "--",
+          totalBilledCosts: 5,
+        },
+      ]);
+
+      const lines = csv.split("\n");
+      expect(lines[1]).toContain('"Team, Inc."');
+    });
+  });
+});

--- a/app/modules/billing/components/activeUsers.tsx
+++ b/app/modules/billing/components/activeUsers.tsx
@@ -1,0 +1,80 @@
+import { Collection } from "@/components/ui/collection";
+import { Download } from "lucide-react";
+import triggerDownload from "~/modules/app/helpers/triggerDownload";
+import getActiveUserItemAttributes from "../helpers/getActiveUserItemAttributes";
+import type { ActiveTeamRow } from "../services/getActiveTeams.server";
+
+interface ActiveUsersTableProps {
+  rows: ActiveTeamRow[];
+  totalPages: number;
+  currentPage: number;
+  sortValue: string;
+  filtersValues: Record<string, string | null>;
+  isSyncing?: boolean;
+  onPaginationChanged: (page: number) => void;
+  onSortValueChanged: (sort: string) => void;
+  onFiltersValueChanged: (filters: Record<string, string | null>) => void;
+}
+
+export default function ActiveUsersTable({
+  rows,
+  totalPages,
+  currentPage,
+  sortValue,
+  filtersValues,
+  isSyncing,
+  onPaginationChanged,
+  onSortValueChanged,
+  onFiltersValueChanged,
+}: ActiveUsersTableProps) {
+  return (
+    <div>
+      <Collection
+        items={rows}
+        itemsLayout="list"
+        actions={[
+          {
+            text: "Export CSV",
+            icon: <Download className="h-4 w-4" />,
+            action: "EXPORT_CSV",
+          },
+        ]}
+        hasPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        sortValue={sortValue}
+        sortOptions={[{ text: "Total Spend", value: "totalBilledCosts" }]}
+        filters={[
+          {
+            category: "minSpend",
+            text: "Minimum Spend",
+            options: [
+              { value: "0", text: "All" },
+              { value: "5", text: "Over $5" },
+              { value: "10", text: "Over $10" },
+            ],
+          },
+        ]}
+        filtersValues={filtersValues ?? {}}
+        isSyncing={isSyncing}
+        emptyAttributes={{
+          title: "No active teams",
+          description: "No teams match the current filter",
+        }}
+        getItemAttributes={getActiveUserItemAttributes}
+        getItemActions={() => []}
+        onActionClicked={(action) => {
+          if (action === "EXPORT_CSV") {
+            const params = new URLSearchParams(window.location.search);
+            params.delete("currentPage");
+            triggerDownload(`/api/exportActiveUsers?${params.toString()}`);
+          }
+        }}
+        onItemActionClicked={() => {}}
+        onPaginationChanged={onPaginationChanged}
+        onSortValueChanged={onSortValueChanged}
+        onFiltersValueChanged={onFiltersValueChanged}
+      />
+    </div>
+  );
+}

--- a/app/modules/billing/components/billingLayout.tsx
+++ b/app/modules/billing/components/billingLayout.tsx
@@ -1,0 +1,44 @@
+import { PageHeader, PageHeaderLeft } from "@/components/ui/pageHeader";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Outlet, useLocation, useNavigate } from "react-router";
+import Breadcrumbs from "~/modules/app/components/breadcrumbs";
+
+const TABS = [{ key: "active-users", label: "Active Teams" }];
+
+export default function BillingLayout() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const currentValue =
+    TABS.find((t) => location.pathname.includes(t.key))?.key ?? TABS[0].key;
+
+  return (
+    <div className="max-w-7xl p-8">
+      <PageHeader>
+        <PageHeaderLeft>
+          <Breadcrumbs breadcrumbs={[{ text: "Billing" }]} />
+        </PageHeaderLeft>
+      </PageHeader>
+      <div className="mb-6">
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          value={currentValue}
+          onValueChange={(value) => {
+            if (value) {
+              navigate(`/admin/billing/${value}`);
+            }
+          }}
+          aria-label="Billing section"
+        >
+          {TABS.map((tab) => (
+            <ToggleGroupItem key={tab.key} value={tab.key}>
+              {tab.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+      <Outlet />
+    </div>
+  );
+}

--- a/app/modules/billing/containers/activeUsers.route.tsx
+++ b/app/modules/billing/containers/activeUsers.route.tsx
@@ -1,0 +1,78 @@
+import { redirect } from "react-router";
+import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
+import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
+import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
+import { userIsSuperAdmin } from "~/modules/authorization/helpers/superAdmin";
+import ActiveUsersTable from "../components/activeUsers";
+import { TeamBillingService } from "../teamBilling";
+
+import type { Route } from "./+types/activeUsers.route";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const user = await requireAuth({ request });
+
+  if (!userIsSuperAdmin(user)) {
+    return redirect("/");
+  }
+
+  const queryParams = getQueryParamsFromRequest(request, {
+    searchValue: "",
+    currentPage: 1,
+    sort: "-totalBilledCosts",
+    filters: { minSpend: "5" },
+  });
+
+  const query = buildQueryFromParams({
+    match: {},
+    queryParams,
+    searchableFields: [],
+    sortableFields: ["totalBilledCosts"],
+    filterableFields: [
+      {
+        minSpend: (value: string) => {
+          const amount = Number(value);
+          if (isNaN(amount) || amount <= 0) return null;
+          return { totalBilledCosts: { $gt: amount } };
+        },
+      },
+    ],
+  });
+
+  const activeUsers = await TeamBillingService.paginateActiveTeams(query);
+
+  return { activeUsers };
+}
+
+export default function ActiveUsersRoute({ loaderData }: Route.ComponentProps) {
+  const { activeUsers } = loaderData ?? {};
+
+  const {
+    currentPage,
+    setCurrentPage,
+    sortValue,
+    setSortValue,
+    filtersValues,
+    setFiltersValues,
+    isSyncing,
+  } = useSearchQueryParams({
+    searchValue: "",
+    currentPage: 1,
+    sortValue: "-totalBilledCosts",
+    filters: { minSpend: "5" },
+  });
+
+  return (
+    <ActiveUsersTable
+      rows={activeUsers?.data ?? []}
+      totalPages={activeUsers?.totalPages ?? 1}
+      currentPage={currentPage}
+      sortValue={sortValue}
+      filtersValues={filtersValues}
+      isSyncing={isSyncing}
+      onPaginationChanged={setCurrentPage}
+      onSortValueChanged={setSortValue}
+      onFiltersValueChanged={setFiltersValues}
+    />
+  );
+}

--- a/app/modules/billing/containers/billingLayout.route.tsx
+++ b/app/modules/billing/containers/billingLayout.route.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "react-router";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
+import { userIsSuperAdmin } from "~/modules/authorization/helpers/superAdmin";
+import BillingLayout from "../components/billingLayout";
+
+import type { Route } from "./+types/billingLayout.route";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const user = await requireAuth({ request });
+
+  if (!userIsSuperAdmin(user)) {
+    return redirect("/");
+  }
+
+  return {};
+}
+
+export default function BillingLayoutRoute() {
+  return <BillingLayout />;
+}

--- a/app/modules/billing/containers/exportActiveUsers.route.tsx
+++ b/app/modules/billing/containers/exportActiveUsers.route.tsx
@@ -1,0 +1,58 @@
+import { redirect } from "react-router";
+import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
+import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
+import requireAuth from "~/modules/authentication/helpers/requireAuth";
+import { userIsSuperAdmin } from "~/modules/authorization/helpers/superAdmin";
+import { TeamBillingService } from "../teamBilling";
+import { TeamBillingBalanceService } from "../teamBillingBalance";
+
+import type { Route } from "./+types/exportActiveUsers.route";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const user = await requireAuth({ request });
+
+  if (!userIsSuperAdmin(user)) {
+    return redirect("/");
+  }
+
+  const queryParams = getQueryParamsFromRequest(request, {
+    searchValue: "",
+    currentPage: 1,
+    sort: "-totalBilledCosts",
+    filters: { minSpend: "5" },
+  });
+
+  const query = buildQueryFromParams({
+    match: {},
+    queryParams,
+    searchableFields: [],
+    sortableFields: ["totalBilledCosts"],
+    filterableFields: [
+      {
+        minSpend: (value: string) => {
+          const amount = Number(value);
+          if (isNaN(amount) || amount <= 0) return null;
+          return { totalBilledCosts: { $gt: amount } };
+        },
+      },
+    ],
+  });
+
+  const count = await TeamBillingBalanceService.count({
+    totalBilledCosts: { $gt: 0 },
+    ...query.match,
+  });
+  const result = await TeamBillingService.paginateActiveTeams(
+    { ...query, page: 1 },
+    count || 1,
+  );
+  const date = new Date().toISOString().split("T")[0];
+
+  return new Response(TeamBillingService.activeTeamsToCSV(result.data), {
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": `attachment; filename="active-teams-${date}.csv"`,
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
+  });
+}

--- a/app/modules/billing/helpers/getActiveUserItemAttributes.tsx
+++ b/app/modules/billing/helpers/getActiveUserItemAttributes.tsx
@@ -1,0 +1,32 @@
+import type { CollectionItemAttributes } from "@/components/ui/collectionItemContent";
+import { Building2, DollarSign, Mail } from "lucide-react";
+import type { ActiveTeamRow } from "../services/getActiveTeams.server";
+
+export default function getActiveUserItemAttributes(
+  row: ActiveTeamRow,
+): CollectionItemAttributes {
+  const meta = [
+    {
+      text: `$${row.totalBilledCosts.toFixed(2)}`,
+      icon: <DollarSign className="h-3 w-3" />,
+    },
+    {
+      text: row.contactEmail,
+      icon: <Mail className="h-3 w-3" />,
+    },
+  ];
+
+  if (row.institution !== "--") {
+    meta.push({
+      text: row.institution,
+      icon: <Building2 className="h-3 w-3" />,
+    });
+  }
+
+  return {
+    id: row.teamId,
+    title: row.teamName,
+    description: `Contact: ${row.contactName}`,
+    meta,
+  };
+}

--- a/app/modules/billing/services/getActiveTeams.server.ts
+++ b/app/modules/billing/services/getActiveTeams.server.ts
@@ -1,0 +1,82 @@
+import { json2csv } from "json-2-csv";
+import type { Query } from "~/modules/app/helpers/buildQueryFromParams";
+import { TeamService } from "~/modules/teams/team";
+import { UserService } from "~/modules/users/user";
+import { TeamBillingBalanceService } from "../teamBillingBalance";
+
+export interface ActiveTeamRow {
+  teamId: string;
+  teamName: string;
+  contactName: string;
+  contactEmail: string;
+  institution: string;
+  totalBilledCosts: number;
+}
+
+async function resolveRows(
+  balances: { team: string; totalBilledCosts: number }[],
+): Promise<ActiveTeamRow[]> {
+  const teamIds = balances.map((b) => b.team);
+  const teams = await TeamService.find({ match: { _id: { $in: teamIds } } });
+  const teamMap = new Map(teams.map((t) => [t._id, t]));
+
+  const ownerIds = [
+    ...new Set(
+      teams
+        .map((t) => t.billingUser || t.createdBy)
+        .filter((id): id is string => !!id),
+    ),
+  ];
+  const owners = await UserService.find({
+    match: { _id: { $in: ownerIds } },
+  });
+  const ownerMap = new Map(owners.map((u) => [u._id, u]));
+
+  return balances.map((balance) => {
+    const team = teamMap.get(balance.team);
+    const ownerId = team?.billingUser || team?.createdBy;
+    const owner = ownerId ? ownerMap.get(ownerId) : null;
+
+    return {
+      teamId: balance.team,
+      teamName: team?.name || "Unknown",
+      contactName: owner?.name || owner?.username || "--",
+      contactEmail: owner?.email || "--",
+      institution: owner?.institution || "--",
+      totalBilledCosts: balance.totalBilledCosts,
+    };
+  });
+}
+
+export async function paginateActiveTeams(
+  query: Query,
+  pageSize?: number,
+): Promise<{
+  data: ActiveTeamRow[];
+  count: number;
+  totalPages: number;
+}> {
+  const result = await TeamBillingBalanceService.paginate({
+    match: { totalBilledCosts: { $gt: 0 }, ...query.match },
+    sort: query.sort,
+    page: query.page,
+    pageSize,
+  });
+
+  const rows = await resolveRows(result.data);
+
+  return { data: rows, count: result.count, totalPages: result.totalPages };
+}
+
+export function activeTeamsToCSV(rows: ActiveTeamRow[]): string {
+  const sanitize = (v: string) => (/^[=+\-@]/.test(v) ? `\t${v}` : v);
+  return json2csv(
+    rows.map((r) => ({
+      Team: sanitize(r.teamName),
+      Contact: sanitize(r.contactName),
+      Email: sanitize(r.contactEmail),
+      Institution: sanitize(r.institution),
+      "Total Spend": `$${r.totalBilledCosts.toFixed(2)}`,
+    })),
+  );
+}

--- a/app/modules/billing/teamBilling.ts
+++ b/app/modules/billing/teamBilling.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import type { Query } from "~/modules/app/helpers/buildQueryFromParams";
 import type { BalanceSummary } from "./billing.types";
 import { BillingLedgerEntryService } from "./billingLedgerEntry";
 import { BillingPlanService } from "./billingPlan";
@@ -9,6 +10,11 @@ import addCredits, {
 import applyBillingCredit from "./services/applyBillingCredit.server";
 import applyBillingDebit from "./services/applyBillingDebit.server";
 import estimateCost from "./services/estimateCost.server";
+import {
+  activeTeamsToCSV,
+  paginateActiveTeams,
+  type ActiveTeamRow,
+} from "./services/getActiveTeams.server";
 import getBillingReportingSummary, {
   type BillingReportingSummary,
 } from "./services/getBillingReportingSummary.server";
@@ -143,6 +149,14 @@ export class TeamBillingService {
   }
 
   static estimateCost = estimateCost;
+
+  static async paginateActiveTeams(query: Query, pageSize?: number) {
+    return paginateActiveTeams(query, pageSize);
+  }
+
+  static activeTeamsToCSV(rows: ActiveTeamRow[]) {
+    return activeTeamsToCSV(rows);
+  }
 
   static async applyStripeTopUp({
     teamId,

--- a/app/modules/billing/teamBillingBalance.ts
+++ b/app/modules/billing/teamBillingBalance.ts
@@ -1,5 +1,7 @@
 import mongoose, { type ClientSession } from "mongoose";
+import { getPaginationParams, getTotalPages } from "~/helpers/pagination";
 import teamBillingBalanceSchema from "~/lib/schemas/teamBillingBalance.schema";
+import type { PaginateProps } from "~/modules/common/types";
 import type { RunningTotals, TeamBillingBalance } from "./billing.types";
 import { balanceGauge } from "./helpers/billingMetrics";
 import reconcileTeamBillingBalance, {
@@ -36,6 +38,38 @@ export class TeamBillingBalanceService {
   static async findAllTeamIds(): Promise<string[]> {
     const ids = await TeamBillingBalanceModel.distinct("team");
     return ids.map((id: mongoose.Types.ObjectId) => id.toString());
+  }
+
+  static async count(match: Record<string, unknown> = {}): Promise<number> {
+    return TeamBillingBalanceModel.countDocuments(match);
+  }
+
+  static async paginate({
+    match,
+    sort,
+    page,
+    pageSize,
+  }: PaginateProps): Promise<{
+    data: TeamBillingBalance[];
+    count: number;
+    totalPages: number;
+  }> {
+    const pagination = getPaginationParams(page, pageSize);
+
+    let query = TeamBillingBalanceModel.find(match);
+    if (sort) query = query.sort(sort);
+    query = query.skip(pagination.skip).limit(pagination.limit);
+
+    const [docs, count] = await Promise.all([
+      query.exec(),
+      TeamBillingBalanceModel.countDocuments(match),
+    ]);
+
+    return {
+      data: docs.map((doc) => this.toTeamBillingBalance(doc)),
+      count,
+      totalPages: getTotalPages(count, pageSize),
+    };
   }
 
   static async deleteByTeam(teamId: string): Promise<void> {

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -205,6 +205,10 @@ export default [
     "modules/billing/containers/stripeWebhook.route.tsx",
   ),
   route(
+    "api/exportActiveUsers",
+    "modules/billing/containers/exportActiveUsers.route.tsx",
+  ),
+  route(
     "api/downloadMtmDataset",
     "modules/datasets/containers/downloadMtmDataset.route.tsx",
   ),
@@ -254,6 +258,14 @@ export default [
   ]),
   ...prefix("admin", [
     route("users", "modules/users/containers/adminUsers.route.tsx"),
+    ...prefix("billing", [
+      layout("modules/billing/containers/billingLayout.route.tsx", [
+        route(
+          "active-users",
+          "modules/billing/containers/activeUsers.route.tsx",
+        ),
+      ]),
+    ]),
     route(
       "maintenance",
       "modules/systemSettings/containers/maintenance.route.tsx",

--- a/app/uikit/components/ui/filtersItem.tsx
+++ b/app/uikit/components/ui/filtersItem.tsx
@@ -142,7 +142,11 @@ const FiltersItem = ({
             }}
           >
             <SelectTrigger className="w-full">
-              <SelectValue placeholder="--" aria-label={value} />
+              {value ? (
+                (filter.options.find((o) => o.value === value)?.text ?? "--")
+              ) : (
+                <SelectValue placeholder="--" />
+              )}
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>


### PR DESCRIPTION
## Summary
- Adds a super-admin billing section at `/admin/billing` with tab navigation
- First tab: **Active Teams** — lists teams with billing spend, showing team name with contact user (billingUser, fallback to createdBy) including email and institution
- Deliberately per-team (not per-user) since billing balance belongs to the team; the contact is the person to reach out to
- Server-side pagination and sort via Collection component
- Spend threshold filter ($5+ default, $10+, or All)
- CSV export via `/api/exportActiveUsers`, respects active filter, exports all matching rows
- Formula injection sanitization in CSV output
- Fix Collection Filters popover dismissing on nested Select click
- Fix FiltersItem not showing preselected value before dropdown opens
- Routes through `TeamBillingService` facade
- Adds `paginate()` and `count()` to `TeamBillingBalanceService`
- 9 tests covering pagination, filtering, contact resolution, and CSV output

Fixes #2151