### PR TITLE
release.yml: image promotion model

### DIFF
--- a/.github/workflows/ecs_promote_image.yml
+++ b/.github/workflows/ecs_promote_image.yml
@@ -1,0 +1,147 @@
+name: Promote ECR Image
+
+# Re-tags an existing ECR image with a new tag, preserving the image
+# digest. This is the core of the build-once / promote-digest model:
+# the bytes that ran in staging are the bytes that ship to production,
+# just with a release version tag added.
+#
+# Implementation: aws ecr batch-get-image reads the manifest of the
+# source tag, then aws ecr put-image writes that *same manifest* under
+# the target tag. ECR de-duplicates by digest, so no bytes are uploaded.
+#
+# This is intentionally not a docker pull / tag / push — that would
+# rebuild the manifest and change the digest.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "GitHub environment to source vars/secrets from (the *production* environment)"
+        required: true
+        type: string
+      aws-region:
+        description: "AWS region for the ECR registry"
+        required: false
+        type: string
+        default: us-east-1
+      source-tag:
+        description: "Existing ECR image tag to promote (e.g. e6d8d50 or e6d8d50-worker)"
+        required: true
+        type: string
+      target-tag:
+        description: "New tag to apply to the same image manifest (e.g. v1.2.3 or v1.2.3-worker)"
+        required: true
+        type: string
+    outputs:
+      image:
+        description: "Full URI of the newly-tagged image (consumed by ecs_deploy_service.yml)"
+        value: ${{ jobs.promote.outputs.image }}
+      digest:
+        description: "Image digest of the promoted manifest (same as the source)"
+        value: ${{ jobs.promote.outputs.digest }}
+    secrets:
+      AWS_ROLE_ARN:
+        description: "OIDC role ARN for the production account/environment"
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  promote:
+    name: Promote ${{ inputs.source-tag }} → ${{ inputs.target-tag }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    outputs:
+      image: ${{ steps.promote.outputs.image }}
+      digest: ${{ steps.promote.outputs.digest }}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Re-tag image
+        id: promote
+        env:
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          SOURCE_TAG: ${{ inputs.source-tag }}
+          TARGET_TAG: ${{ inputs.target-tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Resolve the ECR registry account ID via STS (matches the pattern
+          # in ecs_build_image.yml). The production cicd role permits
+          # sts:GetCallerIdentity via the STSIdentity SID; it does not
+          # permit ecr:DescribeRegistry.
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          REGISTRY_HOST="${ACCOUNT_ID}.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com"
+
+          echo "Promoting ${ECR_REPOSITORY}:${SOURCE_TAG} → ${ECR_REPOSITORY}:${TARGET_TAG}"
+
+          # Read the manifest of the source image. batch-get-image returns the
+          # raw manifest JSON, which we re-submit under the target tag below.
+          MANIFEST=$(aws ecr batch-get-image \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids "imageTag=${SOURCE_TAG}" \
+            --query 'images[0].imageManifest' \
+            --output text)
+
+          if [ -z "$MANIFEST" ] || [ "$MANIFEST" = "None" ]; then
+            echo "::error::Source image ${ECR_REPOSITORY}:${SOURCE_TAG} not found in ECR."
+            exit 1
+          fi
+
+          # Defensive check: ensure target tag does not already exist on a
+          # *different* manifest. Re-running the workflow against the same
+          # source tag is fine (same manifest, idempotent), but re-using a
+          # version tag on a different commit would silently overwrite — and
+          # that's the kind of mistake the audit trail should catch loudly.
+          SOURCE_DIGEST=$(aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids "imageTag=${SOURCE_TAG}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)
+
+          EXISTING_DIGEST=$(aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids "imageTag=${TARGET_TAG}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_DIGEST" ] && [ "$EXISTING_DIGEST" != "$SOURCE_DIGEST" ]; then
+            echo "::error::Target tag '${TARGET_TAG}' already exists on a different image."
+            echo "::error::  existing digest: $EXISTING_DIGEST"
+            echo "::error::  source digest:   $SOURCE_DIGEST"
+            echo "::error::Refusing to overwrite. Bump the version number and retry."
+            exit 1
+          fi
+
+          # Apply the new tag. If the tag already exists on the same digest
+          # (re-run of the same release) this is a no-op as far as bytes go,
+          # but ECR will return an ImageAlreadyExistsException — handle that.
+          if ! aws ecr put-image \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-tag "$TARGET_TAG" \
+            --image-manifest "$MANIFEST" 2> put-image.err; then
+            if grep -q "ImageAlreadyExistsException" put-image.err; then
+              echo "Tag '${TARGET_TAG}' already points at digest ${SOURCE_DIGEST}; nothing to do."
+            else
+              cat put-image.err >&2
+              exit 1
+            fi
+          fi
+
+          IMAGE_URI="${REGISTRY_HOST}/${ECR_REPOSITORY}:${TARGET_TAG}"
+          echo "Promoted image: $IMAGE_URI"
+          echo "Digest:         $SOURCE_DIGEST"
+
+          {
+            echo "image=${IMAGE_URI}"
+            echo "digest=${SOURCE_DIGEST}"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/inspect_staging.yml
+++ b/.github/workflows/inspect_staging.yml
@@ -1,0 +1,283 @@
+name: Inspect Staging
+
+# Reads the current state of the staging web + worker ECS services and
+# decides whether the staging deployment is fit to promote to production.
+#
+# Validates, in order:
+#   1. Both services are stable (one deployment, COMPLETED, runningCount == desiredCount)
+#   2. Web and worker are running the same image SHA tag
+#   3. That SHA tag matches the tagged commit's short SHA
+#   4. The deployment has been running for at least <bake-hours> hours
+#
+# This workflow is only called from the release path. Hotfix releases
+# bypass it entirely by running through a separate workflow that builds
+# from source.
+#
+# Outputs:
+#   - sha:                  the validated 7-char SHA tag
+#   - web-image-uri:        sandpiper:<sha> with full registry path
+#   - worker-image-uri:     sandpiper:<sha>-worker with full registry path
+#   - bake-duration-minutes the time since the older of the two services last stabilised
+#
+# Auth note: AWS_ROLE_ARN is read directly from the *staging* environment's
+# variables (via `environment: ${{ inputs.environment }}` on the job), so
+# the caller does not need to pass it in. This keeps prod's environment
+# free of any staging-side credentials.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "GitHub environment to source vars from (the *staging* environment)"
+        required: true
+        type: string
+      aws-region:
+        description: "AWS region for the staging cluster"
+        required: false
+        type: string
+        default: us-east-1
+      tag-commit-sha:
+        description: "Short (7-char) SHA of the tagged release commit"
+        required: true
+        type: string
+      bake-hours:
+        description: "Hours the staging deployment must have been stable before promotion"
+        required: false
+        type: number
+        default: 1
+      max-wait-seconds:
+        description: "How long to wait for staging to stabilise before failing"
+        required: false
+        type: number
+        default: 600
+      poll-interval-seconds:
+        description: "How often to poll while waiting for staging to stabilise"
+        required: false
+        type: number
+        default: 15
+    outputs:
+      sha:
+        description: "Validated SHA tag (the bytes that ran in staging)"
+        value: ${{ jobs.inspect.outputs.sha }}
+      web-image-uri:
+        description: "Full ECR URI of the staging web image to be promoted"
+        value: ${{ jobs.inspect.outputs.web-image-uri }}
+      worker-image-uri:
+        description: "Full ECR URI of the staging worker image to be promoted"
+        value: ${{ jobs.inspect.outputs.worker-image-uri }}
+      bake-duration-minutes:
+        description: "How long the staging deployment had been stable at inspect time"
+        value: ${{ jobs.inspect.outputs.bake-duration-minutes }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  inspect:
+    name: Inspect Staging
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    outputs:
+      sha: ${{ steps.validate.outputs.sha }}
+      web-image-uri: ${{ steps.validate.outputs.web-image-uri }}
+      worker-image-uri: ${{ steps.validate.outputs.worker-image-uri }}
+      bake-duration-minutes: ${{ steps.validate.outputs.bake-duration-minutes }}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Wait for staging to stabilise
+        id: wait
+        env:
+          # Web and worker currently share a cluster (ECS_CLUSTER), but they
+          # are exposed as distinct services. Keep the var names aligned with
+          # the repo's existing convention: ECS_SERVICE is the web service,
+          # ECS_WORKER_SERVICE is the worker service.
+          ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+          ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+          ECS_WORKER_SERVICE: ${{ vars.ECS_WORKER_SERVICE }}
+          MAX_WAIT_SECONDS: ${{ inputs.max-wait-seconds }}
+          SLEEP_SECONDS: ${{ inputs.poll-interval-seconds }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Waiting for staging cluster '$ECS_CLUSTER' to reach a stable state."
+          echo "  web service:    $ECS_SERVICE"
+          echo "  worker service: $ECS_WORKER_SERVICE"
+          echo "  max wait:       ${MAX_WAIT_SECONDS}s"
+          echo "  poll interval:  ${SLEEP_SECONDS}s"
+          echo
+
+          ELAPSED=0
+          while true; do
+            DESCRIBE=$(aws ecs describe-services \
+              --cluster "$ECS_CLUSTER" \
+              --services "$ECS_SERVICE" "$ECS_WORKER_SERVICE")
+
+            # For each of the two services, all of the following must hold:
+            #   - exactly one deployment in the deployments[] array
+            #   - that deployment has rolloutState == COMPLETED
+            #   - runningCount == desiredCount
+            UNSTABLE=$(echo "$DESCRIBE" | jq -r '
+              [.services[] | select(
+                (.deployments | length) != 1
+                or (.deployments[0].rolloutState != "COMPLETED")
+                or (.runningCount != .desiredCount)
+              ) | .serviceName] | join(",")
+            ')
+
+            if [ -z "$UNSTABLE" ]; then
+              echo "Staging is stable. Both services have a single COMPLETED deployment."
+              break
+            fi
+
+            if [ "$ELAPSED" -ge "$MAX_WAIT_SECONDS" ]; then
+              echo "::error::Staging did not stabilise within ${MAX_WAIT_SECONDS}s."
+              echo "::error::Unstable services: $UNSTABLE"
+              echo "::error::Check the ECS console for the '$ECS_CLUSTER' cluster and retry once staging is healthy."
+              exit 1
+            fi
+
+            echo "[${ELAPSED}s] Still waiting on: $UNSTABLE"
+            sleep "$SLEEP_SECONDS"
+            ELAPSED=$((ELAPSED + SLEEP_SECONDS))
+          done
+
+      - name: Validate SHA match and bake time
+        id: validate
+        env:
+          ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+          ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+          ECS_WORKER_SERVICE: ${{ vars.ECS_WORKER_SERVICE }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          TAG_COMMIT_SHA: ${{ inputs.tag-commit-sha }}
+          BAKE_HOURS: ${{ inputs.bake-hours }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Resolve the ECR registry account ID via STS (matches the pattern
+          # in ecs_build_image.yml). Both staging and production cicd roles
+          # permit sts:GetCallerIdentity via the STSIdentity SID; neither
+          # permits ecr:DescribeRegistry.
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          REGISTRY_HOST="${ACCOUNT_ID}.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com"
+
+          # Pull the primary deployment for each service. We've already gated on
+          # exactly one deployment per service in the previous step.
+          DESCRIBE=$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" "$ECS_WORKER_SERVICE")
+
+          WEB_TD=$(echo "$DESCRIBE" | jq -r --arg svc "$ECS_SERVICE" \
+            '.services[] | select(.serviceName == $svc) | .deployments[0].taskDefinition')
+          WORKER_TD=$(echo "$DESCRIBE" | jq -r --arg svc "$ECS_WORKER_SERVICE" \
+            '.services[] | select(.serviceName == $svc) | .deployments[0].taskDefinition')
+
+          WEB_UPDATED=$(echo "$DESCRIBE" | jq -r --arg svc "$ECS_SERVICE" \
+            '.services[] | select(.serviceName == $svc) | .deployments[0].updatedAt')
+          WORKER_UPDATED=$(echo "$DESCRIBE" | jq -r --arg svc "$ECS_WORKER_SERVICE" \
+            '.services[] | select(.serviceName == $svc) | .deployments[0].updatedAt')
+
+          # Each task definition has one container; pull its image URI.
+          # If the repo ever grows multiple containers per task def, this needs revisiting.
+          WEB_IMAGE=$(aws ecs describe-task-definition --task-definition "$WEB_TD" \
+            | jq -r '.taskDefinition.containerDefinitions[0].image')
+          WORKER_IMAGE=$(aws ecs describe-task-definition --task-definition "$WORKER_TD" \
+            | jq -r '.taskDefinition.containerDefinitions[0].image')
+
+          # Image URIs look like: <registry>/<repo>:<tag>
+          # Strip everything up to and including the colon to get the tag.
+          WEB_TAG="${WEB_IMAGE##*:}"
+          WORKER_TAG="${WORKER_IMAGE##*:}"
+
+          echo "Staging web    image: $WEB_IMAGE"
+          echo "Staging worker image: $WORKER_IMAGE"
+
+          # Worker tags follow the convention <sha>-worker. Strip the suffix so
+          # we can compare web and worker SHAs apples-to-apples.
+          if [[ "$WORKER_TAG" != *-worker ]]; then
+            echo "::error::Worker tag '$WORKER_TAG' does not end in '-worker'. Cannot derive SHA."
+            exit 1
+          fi
+          WORKER_SHA="${WORKER_TAG%-worker}"
+          WEB_SHA="$WEB_TAG"
+
+          if [ "$WEB_SHA" != "$WORKER_SHA" ]; then
+            echo "::error::Staging web and worker are running different SHAs."
+            echo "::error::  web:    $WEB_SHA"
+            echo "::error::  worker: $WORKER_SHA"
+            echo "::error::Promotion requires a matched pair. Redeploy staging from a single commit and retry."
+            exit 1
+          fi
+
+          STAGING_SHA="$WEB_SHA"
+
+          # Truncate the tag commit SHA to match the 7-char short SHA that
+          # ecs_build_image.yml uses for staging tags.
+          TAG_SHORT_SHA="${TAG_COMMIT_SHA:0:7}"
+
+          # Strict tag-vs-staging SHA check. The tagged commit must equal what
+          # staging is currently running. If they diverge, the release was
+          # tagged on a commit that staging has not validated.
+          if [ "$STAGING_SHA" != "$TAG_SHORT_SHA" ]; then
+            echo "::error::Staging is running SHA '$STAGING_SHA' but the release tag points at commit '$TAG_SHORT_SHA' (from $TAG_COMMIT_SHA)."
+            echo "::error::Promotion requires the tagged commit to match what staging has validated."
+            echo "::error::Either:"
+            echo "::error::  - re-tag from the commit currently in staging, or"
+            echo "::error::  - merge the tagged commit to main, wait for staging to redeploy, and retry."
+            exit 1
+          fi
+
+          # Bake time is computed from the *older* (more recent) of the two
+          # updatedAt timestamps, so both services have been stable for at
+          # least the reported duration.
+          NOW_EPOCH=$(date -u +%s)
+          WEB_EPOCH=$(date -u -d "$WEB_UPDATED" +%s)
+          WORKER_EPOCH=$(date -u -d "$WORKER_UPDATED" +%s)
+
+          if [ "$WEB_EPOCH" -gt "$WORKER_EPOCH" ]; then
+            STABILISED_EPOCH="$WEB_EPOCH"
+          else
+            STABILISED_EPOCH="$WORKER_EPOCH"
+          fi
+
+          BAKE_SECONDS=$((NOW_EPOCH - STABILISED_EPOCH))
+          BAKE_MINUTES=$((BAKE_SECONDS / 60))
+          # Required bake in seconds, computed via awk to allow fractional hours.
+          REQUIRED_SECONDS=$(awk -v h="$BAKE_HOURS" 'BEGIN { printf "%d", h * 3600 }')
+
+          echo
+          echo "Staging SHA matches tag commit: $STAGING_SHA"
+          echo "Staging has been stable for ${BAKE_MINUTES} minutes (required: ${BAKE_HOURS}h)."
+
+          if [ "$BAKE_SECONDS" -lt "$REQUIRED_SECONDS" ]; then
+            REMAINING_MINUTES=$(( (REQUIRED_SECONDS - BAKE_SECONDS) / 60 + 1 ))
+            echo "::error::Staging has been stable for ${BAKE_MINUTES} minutes; ${BAKE_HOURS}h required."
+            echo "::error::Retry this release in approximately ${REMAINING_MINUTES} minutes,"
+            echo "::error::or if this is an urgent fix, use the hotfix release path instead."
+            exit 1
+          fi
+
+          # Emit outputs for downstream jobs.
+          WEB_IMAGE_URI="${REGISTRY_HOST}/${ECR_REPOSITORY}:${STAGING_SHA}"
+          WORKER_IMAGE_URI="${REGISTRY_HOST}/${ECR_REPOSITORY}:${STAGING_SHA}-worker"
+
+          {
+            echo "sha=${STAGING_SHA}"
+            echo "web-image-uri=${WEB_IMAGE_URI}"
+            echo "worker-image-uri=${WORKER_IMAGE_URI}"
+            echo "bake-duration-minutes=${BAKE_MINUTES}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo
+          echo "Inspection passed. Ready to promote:"
+          echo "  web:    $WEB_IMAGE_URI"
+          echo "  worker: $WORKER_IMAGE_URI"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Production Release
 # Developer workflow
 #   1. Merge PR
 #   2. Tag main branch with vX.Y.Z
-#   3. CI builds vX.Y.Z
-#   4. Update ECS service vX.Y.Z
+#   3. CI validates staging is running the tagged commit, baked for ≥2h
+#   4. CI re-tags the staging image as vX.Y.Z (no rebuild — digest preserved)
+#   5. ECS service updated to vX.Y.Z
 
 # After PR is merged. Run the following to trigger.
 #   git checkout main
@@ -14,6 +15,13 @@ name: Production Release
 
 # Or create a GitHub Release
 #   - https://github.com/National-Tutoring-Observatory/sandpiper/releases/new
+
+# Promotion model (#180)
+#   This workflow does *not* build from source. It validates that staging
+#   is running the tagged commit, has been stable for ≥2 hours, and then
+#   re-tags the staging image in ECR with the release version. Same
+#   bytes, same digest, new tag. Use the hotfix workflow for emergency
+#   releases that need to bypass these checks.
 
 on:
   push:
@@ -34,6 +42,20 @@ jobs:
     uses: National-Tutoring-Observatory/workflows/.github/workflows/resolve_release.yml@main
     with:
       base-branch: main
+
+  inspect-staging:
+    name: Inspect Staging
+    needs: resolve
+    uses: ./.github/workflows/inspect_staging.yml
+    with:
+      environment: staging
+      aws-region: us-east-1
+      # github.sha on a tag push is the commit the tag points at.
+      # The staging build tags images with the 7-char short SHA;
+      # inspect_staging.yml truncates this internally to match.
+      tag-commit-sha: ${{ github.sha }}
+      bake-hours: 1
+
   preflight-production:
     name: Production Preflight
     needs: resolve
@@ -43,71 +65,76 @@ jobs:
       aws-region: us-east-1
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
-  build-web:
-    name: Build Web Image
+
+  promote-web:
+    name: Promote Web Image
     needs:
       - resolve
+      - inspect-staging
       - preflight-production
-    uses: ./.github/workflows/ecs_build_image.yml
+    uses: ./.github/workflows/ecs_promote_image.yml
     with:
       environment: production
       aws-region: us-east-1
-      dockerfile: Dockerfile
-      image-suffix: ""
-      output-name: web_image
-      tag: ${{ needs.resolve.outputs.version }}
+      source-tag: ${{ needs.inspect-staging.outputs.sha }}
+      target-tag: ${{ needs.resolve.outputs.version }}
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
-      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
-  build-worker:
-    name: Build Worker Image
+
+  promote-worker:
+    name: Promote Worker Image
     needs:
       - resolve
+      - inspect-staging
       - preflight-production
-    uses: ./.github/workflows/ecs_build_image.yml
+    uses: ./.github/workflows/ecs_promote_image.yml
     with:
       environment: production
       aws-region: us-east-1
-      dockerfile: workers/Dockerfile
-      image-suffix: "-worker"
-      output-name: worker_image
-      tag: ${{ needs.resolve.outputs.version }}
+      source-tag: ${{ needs.inspect-staging.outputs.sha }}-worker
+      target-tag: ${{ needs.resolve.outputs.version }}-worker
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
-      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
+
   deploy-web:
     name: Deploy Web Service
-    needs: build-web
+    needs: promote-web
     uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_deploy_service.yml@main
     with:
       environment: production
       aws-region: us-east-1
-      image: ${{ needs.build-web.outputs.image }}
+      image: ${{ needs.promote-web.outputs.image }}
       service: web
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+
   deploy-worker:
     name: Deploy Worker Service
-    needs: build-worker
+    needs: promote-worker
     uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_deploy_service.yml@main
     with:
       environment: production
       aws-region: us-east-1
-      image: ${{ needs.build-worker.outputs.image }}
+      image: ${{ needs.promote-worker.outputs.image }}
       service: worker
     secrets:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+
   production-summary:
     name: Production Deployment Summary
     needs:
-      - build-web
-      - build-worker
+      - resolve
+      - inspect-staging
+      - promote-web
+      - promote-worker
       - deploy-web
       - deploy-worker
     if: success() || failure()
     uses: National-Tutoring-Observatory/workflows/.github/workflows/deployment_summary.yml@main
     with:
       environment: production
-      web-image: ${{ needs.build-web.outputs.image }}
-      worker-image: ${{ needs.build-worker.outputs.image }}
+      web-image: ${{ needs.promote-web.outputs.image }}
+      worker-image: ${{ needs.promote-worker.outputs.image }}
       app-url: https://app.nationaltutoringobservatory.org/
+      originating-sha: ${{ needs.inspect-staging.outputs.sha }}
+      bake-duration-minutes: ${{ needs.inspect-staging.outputs.bake-duration-minutes }}


### PR DESCRIPTION
Replaces build-from-source with digest-preserving promotion: validate that staging is running the tagged commit and has been stable for ≥1h, then re-tag the staging image in ECR as the release version. Deploy jobs consume the re-tagged image.

Adds inspect_staging.yml and ecs_promote_image.yml as local reusable workflows.

### References

- https://github.com/National-Tutoring-Observatory/workflows/pull/15


Part of the work towards:
- https://github.com/National-Tutoring-Observatory/infrastructure/issues/180