### PR TITLE
Add strategy board automations for NTO Product Strategy

### DIFF
--- a/.github/workflows/project-auto-add-by-label.yml
+++ b/.github/workflows/project-auto-add-by-label.yml
@@ -1,0 +1,24 @@
+name: "Strategy Board: Auto-add labeled issues"
+
+on:
+  issues:
+    types: [labeled]
+
+env:
+  PROJECT_NUMBER: 54
+  ORG: National-Tutoring-Observatory
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.label.name, 'outcome') ||
+      contains(github.event.label.name, 'epic') ||
+      contains(github.event.label.name, 'problem-statement') ||
+      contains(github.event.label.name, 'initiative')
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/${{ env.ORG }}/projects/${{ env.PROJECT_NUMBER }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          labeled: outcome, epic, problem-statement, initiative

--- a/.github/workflows/project-pr-merge-epic.yml
+++ b/.github/workflows/project-pr-merge-epic.yml
@@ -1,0 +1,79 @@
+name: "Strategy Board: PR merge → advance epic"
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  PROJECT_NUMBER: 54
+  ORG: National-Tutoring-Observatory
+
+jobs:
+  advance-epic-on-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Check linked issues and advance epics
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          PR_BODY="${{ github.event.pull_request.body }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+
+          # Extract issue references from PR body (e.g., #123, closes #123, fixes #123)
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oP '(?:closes|fixes|resolves|ref|relates to)?\s*#(\d+)' | grep -oP '\d+' || true)
+
+          if [ -z "$ISSUE_NUMBERS" ]; then
+            echo "No linked issues found in PR body, skipping"
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUE_NUMBERS; do
+            ISSUE_URL="https://github.com/$REPO/issues/$ISSUE_NUM"
+
+            # Check if this issue is an epic on the strategy board
+            RESULT=$(gh api graphql -f query='
+              query($url: URI!) {
+                resource(url: $url) {
+                  ... on Issue {
+                    labels(first: 10) {
+                      nodes { name }
+                    }
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { number }
+                      }
+                    }
+                  }
+                }
+              }' -f url="$ISSUE_URL" 2>/dev/null || echo '{}')
+
+            IS_EPIC=$(echo "$RESULT" | jq -r '.data.resource.labels.nodes[]?.name' 2>/dev/null | grep -c "epic" || true)
+            ITEM_ID=$(echo "$RESULT" | jq -r '.data.resource.projectItems.nodes[]? | select(.project.number == ${{ env.PROJECT_NUMBER }}) | .id' 2>/dev/null || true)
+
+            if [ "$IS_EPIC" -gt 0 ] && [ -n "$ITEM_ID" ]; then
+              PROJECT_ID=$(gh api graphql -f query='
+                query {
+                  organization(login: "${{ env.ORG }}") {
+                    projectV2(number: ${{ env.PROJECT_NUMBER }}) { id }
+                  }
+                }' --jq '.data.organization.projectV2.id')
+
+              # Set to In Progress (PRs merging means active work)
+              gh api graphql -f query='
+                mutation {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: "'"$PROJECT_ID"'"
+                    itemId: "'"$ITEM_ID"'"
+                    fieldId: "PVTSSF_lADOC5cpas4BYaa-zhTgeBA"
+                    value: { singleSelectOptionId: "6263e571" }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }'
+
+              echo "✅ Advanced epic #$ISSUE_NUM to In Progress after PR #$PR_NUMBER merged"
+            fi
+          done

--- a/.github/workflows/project-stale-discovery.yml
+++ b/.github/workflows/project-stale-discovery.yml
@@ -62,14 +62,17 @@ jobs:
             "\(.number) \(.url) \(.title)"
           ' | while read -r NUM URL TITLE; do
             if [ -n "$NUM" ]; then
-              gh issue comment "$URL" --body "⏰ **Stale Discovery Alert**
+              COMMENT_BODY=$(cat <<'EOFCOMMENT'
+          ⏰ **Stale Discovery Alert**
 
-This item has been in **Discovery** status for 14+ days without updates.
+          This item has been in **Discovery** status for 14+ days without updates.
 
-**Action needed:** Move it forward to **Scoping**, add context on blockers, or close if no longer relevant.
+          **Action needed:** Move it forward to **Scoping**, add context on blockers, or close if no longer relevant.
 
-_Automated by NTO Product Strategy board_"
-
+          _Automated by NTO Product Strategy board_
+          EOFCOMMENT
+              )
+              gh issue comment "$URL" --body "$COMMENT_BODY"
               echo "⏰ Flagged stale issue #$NUM: $TITLE"
             fi
           done

--- a/.github/workflows/project-stale-discovery.yml
+++ b/.github/workflows/project-stale-discovery.yml
@@ -2,7 +2,7 @@ name: "Strategy Board: Stale discovery alert"
 
 on:
   schedule:
-    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+    - cron: "0 9 * * 1" # Every Monday at 9am UTC
   workflow_dispatch:
 
 env:

--- a/.github/workflows/project-stale-discovery.yml
+++ b/.github/workflows/project-stale-discovery.yml
@@ -1,0 +1,77 @@
+name: "Strategy Board: Stale discovery alert"
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+  workflow_dispatch:
+
+env:
+  PROJECT_NUMBER: 54
+  ORG: National-Tutoring-Observatory
+
+jobs:
+  check-stale-items:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flag stale Discovery items
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          FOURTEEN_DAYS_AGO=$(date -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -v-14d +%Y-%m-%dT%H:%M:%SZ)
+
+          # Get all items on the board
+          ITEMS=$(gh api graphql -f query='
+            query {
+              organization(login: "${{ env.ORG }}") {
+                projectV2(number: ${{ env.PROJECT_NUMBER }}) {
+                  items(first: 100) {
+                    nodes {
+                      id
+                      updatedAt
+                      content {
+                        ... on Issue {
+                          number
+                          title
+                          url
+                          updatedAt
+                        }
+                      }
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field { ... on ProjectV2SingleSelectField { name } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }')
+
+          # Find items in Discovery status that haven't been updated in 14+ days
+          echo "$ITEMS" | jq -r '
+            .data.organization.projectV2.items.nodes[] |
+            select(
+              .fieldValues.nodes[]? |
+              select(.field?.name == "Status" and .name == "Discovery")
+            ) |
+            select(.content.updatedAt < "'"$FOURTEEN_DAYS_AGO"'") |
+            .content |
+            "\(.number) \(.url) \(.title)"
+          ' | while read -r NUM URL TITLE; do
+            if [ -n "$NUM" ]; then
+              gh issue comment "$URL" --body "⏰ **Stale Discovery Alert**
+
+This item has been in **Discovery** status for 14+ days without updates.
+
+**Action needed:** Move it forward to **Scoping**, add context on blockers, or close if no longer relevant.
+
+_Automated by NTO Product Strategy board_"
+
+              echo "⏰ Flagged stale issue #$NUM: $TITLE"
+            fi
+          done
+
+          echo "✅ Stale discovery check complete"

--- a/.github/workflows/project-status-automations.yml
+++ b/.github/workflows/project-status-automations.yml
@@ -1,0 +1,112 @@
+name: "Strategy Board: Status automations"
+
+on:
+  issues:
+    types: [closed, reopened]
+
+env:
+  PROJECT_NUMBER: 54
+  ORG: National-Tutoring-Observatory
+
+jobs:
+  issue-closed-set-shipped:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+    steps:
+      - name: Set status to Shipped
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          ISSUE_URL="${{ github.event.issue.html_url }}"
+
+          # Get project item ID for this issue
+          ITEM_ID=$(gh api graphql -f query='
+            query($url: URI!) {
+              resource(url: $url) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      project { number }
+                    }
+                  }
+                }
+              }
+            }' -f url="$ISSUE_URL" --jq '.data.resource.projectItems.nodes[] | select(.project.number == ${{ env.PROJECT_NUMBER }}) | .id')
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue not on strategy board, skipping"
+            exit 0
+          fi
+
+          # Get the Status field ID and Shipped option ID
+          PROJECT_ID=$(gh api graphql -f query='
+            query {
+              organization(login: "${{ env.ORG }}") {
+                projectV2(number: ${{ env.PROJECT_NUMBER }}) { id }
+              }
+            }' --jq '.data.organization.projectV2.id')
+
+          gh api graphql -f query='
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: "'"$PROJECT_ID"'"
+                itemId: "'"$ITEM_ID"'"
+                fieldId: "PVTSSF_lADOC5cpas4BYaa-zhTgeBA"
+                value: { singleSelectOptionId: "1644e36d" }
+              }) {
+                projectV2Item { id }
+              }
+            }'
+
+          echo "✅ Set status to Shipped for issue $ISSUE_URL"
+
+  issue-reopened-set-in-progress:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'reopened'
+    steps:
+      - name: Set status to In Progress
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          ISSUE_URL="${{ github.event.issue.html_url }}"
+
+          ITEM_ID=$(gh api graphql -f query='
+            query($url: URI!) {
+              resource(url: $url) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      project { number }
+                    }
+                  }
+                }
+              }
+            }' -f url="$ISSUE_URL" --jq '.data.resource.projectItems.nodes[] | select(.project.number == ${{ env.PROJECT_NUMBER }}) | .id')
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue not on strategy board, skipping"
+            exit 0
+          fi
+
+          PROJECT_ID=$(gh api graphql -f query='
+            query {
+              organization(login: "${{ env.ORG }}") {
+                projectV2(number: ${{ env.PROJECT_NUMBER }}) { id }
+              }
+            }' --jq '.data.organization.projectV2.id')
+
+          gh api graphql -f query='
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: "'"$PROJECT_ID"'"
+                itemId: "'"$ITEM_ID"'"
+                fieldId: "PVTSSF_lADOC5cpas4BYaa-zhTgeBA"
+                value: { singleSelectOptionId: "6263e571" }
+              }) {
+                projectV2Item { id }
+              }
+            }'
+
+          echo "✅ Set status to In Progress for reopened issue $ISSUE_URL"


### PR DESCRIPTION
## Summary
- Adds 4 GitHub Actions workflows that automate the [NTO Product Strategy board](https://github.com/orgs/National-Tutoring-Observatory/projects/54)
- **Auto-add by label**: Issues labeled `outcome`, `epic`, `problem-statement`, or `initiative` are auto-added to the strategy board
- **Status automations**: Closed issues → Shipped, reopened issues → In Progress
- **PR merge → epic advance**: When a PR referencing an epic merges, the epic moves to In Progress
- **Stale discovery alert**: Weekly Monday check flags items stuck in Discovery for 14+ days

## Setup required
A repo secret `PROJECT_TOKEN` is needed — a GitHub PAT (classic) with `project` and `repo` scopes. Add it in Settings → Secrets and variables → Actions.

## Test plan
- [ ] Add `PROJECT_TOKEN` secret to repo
- [ ] Label a test issue with `outcome` → verify it appears on strategy board
- [ ] Close a board issue → verify status changes to Shipped
- [ ] Reopen it → verify status changes to In Progress
- [ ] Merge a PR referencing an epic → verify epic advances
- [ ] Run stale discovery workflow manually via Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)