### PR TITLE
Add migration to expand legacy billing into individual ledger entries

### DIFF
--- a/app/migrations/20260518120000-expand-legacy-billing-into-ledger.ts
+++ b/app/migrations/20260518120000-expand-legacy-billing-into-ledger.ts
@@ -1,0 +1,381 @@
+import Decimal from "decimal.js";
+import type { Db, ObjectId } from "mongodb";
+import type {
+  MigrationFile,
+  MigrationResult,
+} from "~/modules/migrations/types";
+
+async function getTeamAdminUser(
+  db: Db,
+  teamId: ObjectId,
+  createdBy: ObjectId | undefined,
+): Promise<ObjectId | undefined> {
+  if (createdBy) return createdBy;
+
+  const user = await db
+    .collection("users")
+    .find({ teams: { $elemMatch: { team: teamId, role: "ADMIN" } } })
+    .sort({ _id: 1 })
+    .limit(1)
+    .next();
+
+  return user?._id;
+}
+
+async function getMarkupRate(db: Db, teamId: ObjectId): Promise<number | null> {
+  const assignment = await db
+    .collection("teambillingplans")
+    .find({ team: teamId, effectiveFrom: { $lte: new Date() } })
+    .sort({ effectiveFrom: -1 })
+    .limit(1)
+    .next();
+
+  if (!assignment?.plan) return null;
+
+  const plan = await db
+    .collection("billingplans")
+    .findOne({ _id: assignment.plan });
+
+  return typeof plan?.markupRate === "number" ? plan.markupRate : null;
+}
+
+async function getLedgerTotals(
+  db: Db,
+  teamId: ObjectId,
+): Promise<{ credits: number; rawCosts: number; billedCosts: number }> {
+  const result = await db
+    .collection("billingledgerentries")
+    .aggregate([
+      { $match: { team: teamId } },
+      {
+        $group: {
+          _id: null,
+          credits: {
+            $sum: {
+              $cond: [{ $eq: ["$direction", "credit"] }, "$amount", 0],
+            },
+          },
+          rawCosts: {
+            $sum: {
+              $cond: [{ $eq: ["$direction", "debit"] }, "$rawAmount", 0],
+            },
+          },
+          billedCosts: {
+            $sum: {
+              $cond: [{ $eq: ["$direction", "debit"] }, "$amount", 0],
+            },
+          },
+        },
+      },
+    ])
+    .toArray();
+
+  return {
+    credits: result[0]?.credits ?? 0,
+    rawCosts: result[0]?.rawCosts ?? 0,
+    billedCosts: result[0]?.billedCosts ?? 0,
+  };
+}
+
+async function recalculateBillingPeriods(
+  db: Db,
+  teamId: ObjectId,
+): Promise<void> {
+  // Only recalculate closed periods. The current open period (if any) will
+  // self-correct when BillingPeriodService.closePeriod() runs at month-end,
+  // as it re-aggregates from the ledger at that point.
+  const periods = await db
+    .collection("billingperiods")
+    .find({ team: teamId, status: "closed" })
+    .sort({ startAt: 1 })
+    .toArray();
+
+  if (periods.length === 0) return;
+
+  const firstPeriodStart = new Date(periods[0].startAt);
+  const prePeriodResult = await db
+    .collection("billingledgerentries")
+    .aggregate([
+      { $match: { team: teamId, createdAt: { $lt: firstPeriodStart } } },
+      {
+        $group: {
+          _id: null,
+          credits: {
+            $sum: {
+              $cond: [{ $eq: ["$direction", "credit"] }, "$amount", 0],
+            },
+          },
+          debits: {
+            $sum: {
+              $cond: [{ $eq: ["$direction", "debit"] }, "$amount", 0],
+            },
+          },
+        },
+      },
+    ])
+    .toArray();
+
+  let runningBalance = new Decimal(prePeriodResult[0]?.credits ?? 0)
+    .minus(prePeriodResult[0]?.debits ?? 0)
+    .toNumber();
+
+  const periodTotals = await Promise.all(
+    periods.map((period) =>
+      db
+        .collection("billingledgerentries")
+        .aggregate([
+          {
+            $match: {
+              team: teamId,
+              createdAt: {
+                $gte: new Date(period.startAt),
+                $lt: new Date(period.endAt),
+              },
+            },
+          },
+          {
+            $group: {
+              _id: null,
+              creditsAdded: {
+                $sum: {
+                  $cond: [{ $eq: ["$direction", "credit"] }, "$amount", 0],
+                },
+              },
+              rawCost: {
+                $sum: {
+                  $cond: [{ $eq: ["$direction", "debit"] }, "$rawAmount", 0],
+                },
+              },
+              billedAmount: {
+                $sum: {
+                  $cond: [{ $eq: ["$direction", "debit"] }, "$amount", 0],
+                },
+              },
+            },
+          },
+        ])
+        .toArray(),
+    ),
+  );
+
+  const bulkOps = [];
+  for (let i = 0; i < periods.length; i++) {
+    const totals = periodTotals[i][0];
+    const creditsAdded = totals?.creditsAdded ?? 0;
+    const rawCost = totals?.rawCost ?? 0;
+    const billedAmount = totals?.billedAmount ?? 0;
+    const openingBalance = runningBalance;
+    const closingBalance = new Decimal(openingBalance)
+      .plus(creditsAdded)
+      .minus(billedAmount)
+      .toNumber();
+
+    bulkOps.push({
+      updateOne: {
+        filter: { _id: periods[i]._id },
+        update: {
+          $set: {
+            openingBalance,
+            creditsAdded,
+            rawCost,
+            billedAmount,
+            closingBalance,
+          },
+        },
+      },
+    });
+
+    runningBalance = closingBalance;
+  }
+
+  await db.collection("billingperiods").bulkWrite(bulkOps);
+}
+
+export default {
+  id: "20260518120000-expand-legacy-billing-into-ledger",
+  name: "Expand Legacy Billing Into Ledger",
+  description:
+    "Replaces the per-team legacy carry-forward ledger entry with individual debit/credit entries from llmcosts and teamcredits, preserving original timestamps. Recalculates billing period summaries and TeamBillingBalance running totals.",
+
+  async up(db: Db): Promise<MigrationResult> {
+    console.log("Starting Expand Legacy Billing Into Ledger migration...");
+
+    const teams = await db
+      .collection("teams")
+      .find({}, { projection: { _id: 1, createdBy: 1 } })
+      .toArray();
+
+    console.log(`Found ${teams.length} team(s)`);
+
+    let insertedDebits = 0;
+    let insertedCredits = 0;
+    let deletedCarryForwards = 0;
+    let updatedBalances = 0;
+    let failed = 0;
+
+    for (const team of teams) {
+      const teamId = team._id as ObjectId;
+
+      try {
+        const markupRate = await getMarkupRate(db, teamId);
+        if (markupRate === null) {
+          console.log(`  Skipping team ${teamId} — no billing plan found`);
+          continue;
+        }
+
+        const [llmCosts, teamCredits, existingEntries, teamUserId] =
+          await Promise.all([
+            db
+              .collection("llmcosts")
+              .find({ team: teamId, isLegacy: true })
+              .toArray(),
+            db
+              .collection("teamcredits")
+              .find({ team: teamId, isLegacy: true })
+              .toArray(),
+            db
+              .collection("billingledgerentries")
+              .find(
+                { team: teamId, isLegacy: true },
+                { projection: { idempotencyKey: 1, _id: 0 } },
+              )
+              .toArray(),
+            getTeamAdminUser(db, teamId, team.createdBy),
+          ]);
+
+        const existingKeySet = new Set(
+          existingEntries.map((e) => e.idempotencyKey as string),
+        );
+
+        console.log(
+          `  Team ${teamId}: ${llmCosts.length} cost(s), ${teamCredits.length} credit(s), markupRate=${markupRate}`,
+        );
+
+        const newDebits = llmCosts
+          .filter(
+            (cost) =>
+              !existingKeySet.has(`legacy-llmcost:${cost._id.toString()}`),
+          )
+          .map((cost) => {
+            const rawAmount: number = cost.cost ?? 0;
+            const billedAmount = new Decimal(rawAmount)
+              .times(markupRate)
+              .toNumber();
+            return {
+              team: teamId,
+              ...(teamUserId != null ? { user: teamUserId } : {}),
+              direction: "debit",
+              amount: billedAmount,
+              currency: "USD",
+              rawAmount,
+              markupRateApplied: markupRate,
+              billedAmount,
+              ...(cost.model != null ? { model: cost.model } : {}),
+              ...(cost.inputTokens != null
+                ? { inputTokens: cost.inputTokens }
+                : {}),
+              ...(cost.outputTokens != null
+                ? { outputTokens: cost.outputTokens }
+                : {}),
+              ...(cost.providerCost != null
+                ? { providerCost: cost.providerCost }
+                : {}),
+              source: cost.source ?? "legacy-llmcost",
+              sourceId: cost.sourceId ?? cost._id.toString(),
+              idempotencyKey: `legacy-llmcost:${cost._id.toString()}`,
+              isLegacy: true,
+              legacyNotes: "expanded from llmcosts collection",
+              metadata: { llmCostId: cost._id.toString() },
+              createdAt: cost.createdAt ?? new Date(),
+            };
+          });
+
+        const newCredits = teamCredits
+          .filter(
+            (credit) =>
+              !existingKeySet.has(`legacy-credit:${credit._id.toString()}`),
+          )
+          .map((credit) => ({
+            team: teamId,
+            direction: "credit",
+            amount: credit.amount ?? 0,
+            currency: "USD",
+            source: "legacy-credit",
+            sourceId: credit._id.toString(),
+            idempotencyKey: `legacy-credit:${credit._id.toString()}`,
+            isLegacy: true,
+            legacyNotes: "expanded from teamcredits collection",
+            metadata: {
+              ...(credit.addedBy != null ? { addedBy: credit.addedBy } : {}),
+              ...(credit.note != null ? { note: credit.note } : {}),
+            },
+            createdAt: credit.createdAt ?? new Date(),
+          }));
+
+        if (newDebits.length > 0) {
+          await db
+            .collection("billingledgerentries")
+            .insertMany(newDebits, { ordered: false });
+          insertedDebits += newDebits.length;
+        }
+
+        if (newCredits.length > 0) {
+          await db
+            .collection("billingledgerentries")
+            .insertMany(newCredits, { ordered: false });
+          insertedCredits += newCredits.length;
+        }
+
+        const deleteResult = await db
+          .collection("billingledgerentries")
+          .deleteOne({
+            idempotencyKey: `legacy-balance:${teamId.toString()}`,
+          });
+        deletedCarryForwards += deleteResult.deletedCount;
+
+        const [totals] = await Promise.all([
+          getLedgerTotals(db, teamId),
+          recalculateBillingPeriods(db, teamId),
+        ]);
+
+        await db.collection("teambillingbalances").updateOne(
+          { team: teamId },
+          {
+            $set: {
+              availableBalance: totals.credits - totals.billedCosts,
+              totalCredits: totals.credits,
+              totalRawCosts: totals.rawCosts,
+              totalBilledCosts: totals.billedCosts,
+            },
+          },
+          { upsert: true },
+        );
+        updatedBalances++;
+
+        console.log(
+          `  ✓ Team ${teamId}: ${llmCosts.length} debit(s), ${teamCredits.length} credit(s), carry-forward removed`,
+        );
+      } catch (error) {
+        console.error(`  ✗ Failed for team ${teamId}:`, error);
+        failed++;
+      }
+    }
+
+    console.log(
+      `Done: ${insertedDebits} debit(s), ${insertedCredits} credit(s), ${deletedCarryForwards} carry-forward(s) removed, ${updatedBalances} balance(s) refreshed`,
+    );
+
+    return {
+      success: failed === 0,
+      message: `Inserted ${insertedDebits} debit(s) and ${insertedCredits} credit(s), removed ${deletedCarryForwards} carry-forward(s)`,
+      stats: {
+        migrated: insertedDebits + insertedCredits,
+        failed,
+        insertedDebits,
+        insertedCredits,
+        deletedCarryForwards,
+        updatedBalances,
+      },
+    };
+  },
+} satisfies MigrationFile;

--- a/app/migrations/__tests__/expand-legacy-billing-into-ledger.test.ts
+++ b/app/migrations/__tests__/expand-legacy-billing-into-ledger.test.ts
@@ -1,0 +1,431 @@
+import mongoose, { Types } from "mongoose";
+import { beforeEach, describe, expect, it } from "vitest";
+import markLegacyMigration from "~/migrations/20260421171000-mark-legacy-billing-rows";
+import seedBaselinesMigration from "~/migrations/20260421172000-seed-legacy-billing-baselines";
+import expandMigration from "~/migrations/20260518120000-expand-legacy-billing-into-ledger";
+import clearDocumentDB from "../../../test/helpers/clearDocumentDB";
+import makeDate from "../../../test/helpers/makeDate";
+import { BillingLedgerEntryService } from "../../modules/billing/billingLedgerEntry";
+import { BillingPeriodService } from "../../modules/billing/billingPeriod";
+import { BillingPlanService } from "../../modules/billing/billingPlan";
+import { TeamBillingBalanceService } from "../../modules/billing/teamBillingBalance";
+import { TeamBillingPlanService } from "../../modules/billing/teamBillingPlan";
+import { TeamService } from "../../modules/teams/team";
+import { UserService } from "../../modules/users/user";
+
+async function getDb() {
+  if (!mongoose.connection.db) throw new Error("No DB connection");
+  return mongoose.connection.db;
+}
+
+async function createTeamWithPlan(markupRate = 1.5) {
+  const owner = await UserService.create({
+    username: `owner-${new Types.ObjectId()}`,
+    teams: [],
+  });
+  const team = await TeamService.create({
+    name: "Test Team",
+    createdBy: owner._id,
+  });
+  const plan = await BillingPlanService.create({
+    name: "Standard",
+    markupRate,
+    isDefault: false,
+  });
+  await TeamBillingPlanService.assignPlanAt(team._id, plan._id, new Date(0));
+  return { team, owner };
+}
+
+async function insertLegacyCost(
+  teamId: string,
+  cost: number,
+  createdAt: Date,
+  extra: Record<string, unknown> = {},
+) {
+  const db = await getDb();
+  const result = await db.collection("llmcosts").insertOne({
+    team: new Types.ObjectId(teamId),
+    model: "claude-opus",
+    source: "annotation:per-session",
+    sourceId: "session-123",
+    inputTokens: 100,
+    outputTokens: 50,
+    cost,
+    providerCost: cost * 0.8,
+    createdAt,
+    ...extra,
+  });
+  return result.insertedId;
+}
+
+async function insertLegacyCredit(
+  teamId: string,
+  amount: number,
+  createdAt: Date,
+) {
+  const db = await getDb();
+  const result = await db.collection("teamcredits").insertOne({
+    team: new Types.ObjectId(teamId),
+    amount,
+    addedBy: new Types.ObjectId(),
+    note: "Top-up",
+    createdAt,
+  });
+  return result.insertedId;
+}
+
+async function runLegacyMigrationsAndExpand() {
+  const db = await getDb();
+  await markLegacyMigration.up(db);
+  await seedBaselinesMigration.up(db);
+  return expandMigration.up(db);
+}
+
+describe("expand-legacy-billing-into-ledger migration", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  describe("basic expansion", () => {
+    it("creates individual debit entries for each llmcost record", async () => {
+      const { team, owner } = await createTeamWithPlan(1.5);
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+      await insertLegacyCost(team._id, 20, makeDate(2026, 2, 10));
+
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      const debits = entries.filter((e) => e.direction === "debit");
+
+      expect(debits).toHaveLength(2);
+      expect(debits.map((d) => d.rawAmount).sort()).toEqual([10, 20]);
+      expect(debits.every((d) => d.user === owner._id)).toBe(true);
+    });
+
+    it("creates individual credit entries for each teamcredit record", async () => {
+      const { team } = await createTeamWithPlan();
+
+      await insertLegacyCredit(team._id, 50, makeDate(2026, 1, 1));
+      await insertLegacyCredit(team._id, 30, makeDate(2026, 2, 1));
+
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      const credits = entries.filter((e) => e.direction === "credit");
+
+      expect(credits).toHaveLength(2);
+      expect(credits.map((c) => c.amount).sort()).toEqual([30, 50]);
+    });
+
+    it("applies the team markup rate to compute billedAmount", async () => {
+      const { team } = await createTeamWithPlan(2.0);
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      const debit = entries.find((e) => e.direction === "debit");
+
+      expect(debit?.rawAmount).toBe(10);
+      expect(debit?.amount).toBe(20);
+      expect(debit?.markupRateApplied).toBe(2.0);
+    });
+
+    it("preserves original createdAt on expanded entries", async () => {
+      const { team } = await createTeamWithPlan();
+
+      const costDate = makeDate(2026, 1, 15);
+      const creditDate = makeDate(2026, 2, 1);
+      await insertLegacyCost(team._id, 10, costDate);
+      await insertLegacyCredit(team._id, 50, creditDate);
+
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      const debit = entries.find((e) => e.direction === "debit");
+      const credit = entries.find((e) => e.direction === "credit");
+
+      expect(new Date(debit!.createdAt).getTime()).toBe(costDate.getTime());
+      expect(new Date(credit!.createdAt).getTime()).toBe(creditDate.getTime());
+    });
+
+    it("carries over model, source, inputTokens, outputTokens, providerCost from llmcosts", async () => {
+      const { team } = await createTeamWithPlan();
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15), {
+        model: "claude-sonnet",
+        source: "verification:per-session",
+        inputTokens: 200,
+        outputTokens: 80,
+        providerCost: 7.5,
+      });
+
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      const debit = entries.find((e) => e.direction === "debit");
+
+      expect(debit?.model).toBe("claude-sonnet");
+      expect(debit?.source).toBe("verification:per-session");
+      expect(debit?.inputTokens).toBe(200);
+      expect(debit?.outputTokens).toBe(80);
+      expect(debit?.providerCost).toBe(7.5);
+    });
+
+    it("marks expanded entries as legacy", async () => {
+      const { team } = await createTeamWithPlan();
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+      await insertLegacyCredit(team._id, 50, makeDate(2026, 1, 1));
+
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      expect(entries.every((e) => e.isLegacy)).toBe(true);
+    });
+
+    it("uses the oldest admin when createdBy is not set", async () => {
+      const db = await getDb();
+
+      const teamDoc = await db
+        .collection("teams")
+        .insertOne({ name: "No Owner Team" });
+      const teamId = teamDoc.insertedId.toString();
+
+      const admin = await UserService.create({
+        username: "oldest-admin",
+        teams: [{ team: teamId, role: "ADMIN" }],
+      });
+
+      const plan = await BillingPlanService.create({
+        name: "Standard",
+        markupRate: 1.5,
+        isDefault: false,
+      });
+      await TeamBillingPlanService.assignPlanAt(teamId, plan._id, new Date(0));
+
+      await insertLegacyCost(teamId, 10, makeDate(2026, 1, 15));
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(teamId);
+      const debit = entries.find((e) => e.direction === "debit");
+      expect(debit?.user).toBe(admin._id);
+    });
+  });
+
+  describe("carry-forward removal", () => {
+    it("removes the legacy-balance carry-forward entry", async () => {
+      const { team } = await createTeamWithPlan();
+
+      await insertLegacyCredit(team._id, 100, makeDate(2026, 1, 1));
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+
+      await runLegacyMigrationsAndExpand();
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      const carryForward = entries.find((e) => e.source === "legacy-migration");
+      expect(carryForward).toBeUndefined();
+    });
+  });
+
+  describe("balance integrity", () => {
+    it("net balance is unchanged after expansion", async () => {
+      const { team } = await createTeamWithPlan(1.5);
+
+      await insertLegacyCredit(team._id, 100, makeDate(2026, 1, 1));
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+      await insertLegacyCost(team._id, 20, makeDate(2026, 2, 10));
+
+      const db = await getDb();
+      await markLegacyMigration.up(db);
+      await seedBaselinesMigration.up(db);
+
+      const balanceBefore = await TeamBillingBalanceService.findByTeam(
+        team._id,
+      );
+
+      await expandMigration.up(db);
+
+      const balanceAfter = await TeamBillingBalanceService.findByTeam(team._id);
+
+      expect(balanceAfter?.availableBalance).toBe(55); // 100 - (10 + 20) * 1.5
+      expect(balanceAfter?.availableBalance).toBe(
+        balanceBefore?.availableBalance,
+      );
+    });
+
+    it("updates TeamBillingBalance running totals", async () => {
+      const { team } = await createTeamWithPlan(1.5);
+
+      await insertLegacyCredit(team._id, 100, makeDate(2026, 1, 1));
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+      await insertLegacyCost(team._id, 20, makeDate(2026, 2, 10));
+
+      await runLegacyMigrationsAndExpand();
+
+      const balance = await TeamBillingBalanceService.findByTeam(team._id);
+
+      expect(balance?.totalCredits).toBe(100);
+      expect(balance?.totalRawCosts).toBe(30);
+      expect(balance?.totalBilledCosts).toBe(45); // (10 + 20) * 1.5
+    });
+  });
+
+  describe("idempotency", () => {
+    it("does not create duplicate entries when run twice", async () => {
+      const { team } = await createTeamWithPlan();
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+      await insertLegacyCredit(team._id, 50, makeDate(2026, 1, 1));
+
+      await runLegacyMigrationsAndExpand();
+
+      const db = await getDb();
+      await expandMigration.up(db);
+
+      const entries = await BillingLedgerEntryService.findByTeam(team._id);
+      const debits = entries.filter((e) => e.direction === "debit");
+      const credits = entries.filter((e) => e.direction === "credit");
+
+      expect(debits).toHaveLength(1);
+      expect(credits).toHaveLength(1);
+    });
+  });
+
+  describe("billing period recalculation", () => {
+    it("backfills rawCost and billedAmount on a closed period", async () => {
+      const { team } = await createTeamWithPlan(1.5);
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+      await insertLegacyCredit(team._id, 100, makeDate(2026, 1, 1));
+
+      const period = await BillingPeriodService.openPeriod(
+        team._id,
+        makeDate(2026, 1),
+      );
+      await BillingPeriodService.closePeriod(period);
+
+      await runLegacyMigrationsAndExpand();
+
+      const periods = await BillingPeriodService.findClosedByTeam(team._id);
+      expect(periods).toHaveLength(1);
+      expect(periods[0].rawCost).toBe(10);
+      expect(periods[0].billedAmount).toBe(15);
+      expect(periods[0].creditsAdded).toBe(100);
+      expect(periods[0].closingBalance).toBe(85);
+    });
+
+    it("chains openingBalance correctly across multiple periods", async () => {
+      const { team } = await createTeamWithPlan(1.5);
+
+      // Jan: 100 credit, 10 cost → closing = 85
+      await insertLegacyCredit(team._id, 100, makeDate(2026, 1, 1));
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+
+      // Feb: 20 cost → closing = 85 - 30 = 55
+      await insertLegacyCost(team._id, 20, makeDate(2026, 2, 10));
+
+      const p1 = await BillingPeriodService.openPeriod(
+        team._id,
+        makeDate(2026, 1),
+      );
+      await BillingPeriodService.closePeriod(p1);
+
+      const p2 = await BillingPeriodService.openPeriod(
+        team._id,
+        makeDate(2026, 2),
+      );
+      await BillingPeriodService.closePeriod(p2);
+
+      await runLegacyMigrationsAndExpand();
+
+      const periods = await BillingPeriodService.findClosedByTeam(team._id);
+      const jan = periods.find((p) => new Date(p.startAt).getUTCMonth() === 0)!;
+      const feb = periods.find((p) => new Date(p.startAt).getUTCMonth() === 1)!;
+
+      expect(jan.closingBalance).toBe(85);
+      expect(feb.openingBalance).toBe(85);
+      expect(feb.rawCost).toBe(20);
+      expect(feb.billedAmount).toBe(30);
+      expect(feb.closingBalance).toBe(55);
+    });
+
+    it("does not touch periods for other teams", async () => {
+      const { team } = await createTeamWithPlan();
+      const { team: otherTeam } = await createTeamWithPlan();
+
+      await insertLegacyCredit(team._id, 100, makeDate(2026, 1, 1));
+
+      const otherPeriod = await BillingPeriodService.openPeriod(
+        otherTeam._id,
+        makeDate(2026, 1),
+      );
+      await BillingPeriodService.closePeriod(otherPeriod);
+
+      await runLegacyMigrationsAndExpand();
+
+      const otherPeriods = await BillingPeriodService.findClosedByTeam(
+        otherTeam._id,
+      );
+      expect(otherPeriods[0].rawCost).toBe(0);
+      expect(otherPeriods[0].billedAmount).toBe(0);
+    });
+  });
+
+  describe("team isolation", () => {
+    it("does not create ledger entries for other teams", async () => {
+      const { team } = await createTeamWithPlan();
+      const { team: otherTeam } = await createTeamWithPlan();
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+
+      await runLegacyMigrationsAndExpand();
+
+      const otherEntries = await BillingLedgerEntryService.findByTeam(
+        otherTeam._id,
+      );
+      expect(otherEntries).toHaveLength(0);
+    });
+  });
+
+  describe("teams with no billing plan", () => {
+    it("skips teams with no billing plan assigned", async () => {
+      const db = await getDb();
+
+      const teamDoc = await db
+        .collection("teams")
+        .insertOne({ name: "No Plan Team" });
+      const teamId = teamDoc.insertedId.toString();
+
+      await insertLegacyCost(teamId, 10, makeDate(2026, 1, 15));
+
+      const result = await expandMigration.up(db);
+
+      expect(result.success).toBe(true);
+      const entries = await BillingLedgerEntryService.findByTeam(teamId);
+      expect(entries).toHaveLength(0);
+    });
+  });
+
+  describe("migration result stats", () => {
+    it("reports correct counts", async () => {
+      const { team } = await createTeamWithPlan();
+
+      await insertLegacyCost(team._id, 10, makeDate(2026, 1, 15));
+      await insertLegacyCost(team._id, 20, makeDate(2026, 2, 10));
+      await insertLegacyCredit(team._id, 100, makeDate(2026, 1, 1));
+
+      const db = await getDb();
+      await markLegacyMigration.up(db);
+      await seedBaselinesMigration.up(db);
+      const result = await expandMigration.up(db);
+
+      expect(result.success).toBe(true);
+      expect(result.stats?.insertedDebits).toBe(2);
+      expect(result.stats?.insertedCredits).toBe(1);
+      expect(result.stats?.deletedCarryForwards).toBe(1);
+    });
+  });
+});

--- a/scripts/compare-migration-snapshots.mjs
+++ b/scripts/compare-migration-snapshots.mjs
@@ -1,0 +1,61 @@
+import { readFileSync } from "fs";
+
+const [beforeFile = "before.json", afterFile = "after.json"] =
+  process.argv.slice(2);
+
+const before = JSON.parse(readFileSync(beforeFile, "utf8"));
+const after = JSON.parse(readFileSync(afterFile, "utf8"));
+
+const allTeams = new Set([
+  ...Object.keys(before.teams),
+  ...Object.keys(after.teams),
+]);
+
+const EPSILON = 1e-6;
+let allOk = true;
+
+const rows = [];
+for (const teamId of [...allTeams].sort()) {
+  const b = before.teams[teamId];
+  const a = after.teams[teamId];
+
+  if (!b) {
+    rows.push({ teamId, status: "MISSING_BEFORE", diff: null, b: null, a });
+    allOk = false;
+    continue;
+  }
+  if (!a) {
+    rows.push({ teamId, status: "MISSING_AFTER", diff: null, b, a: null });
+    allOk = false;
+    continue;
+  }
+
+  const diff = Math.abs((a.availableBalance ?? 0) - (b.availableBalance ?? 0));
+  const ok = diff < EPSILON;
+  if (!ok) allOk = false;
+  rows.push({ teamId, status: ok ? "OK" : "MISMATCH", diff, b, a });
+}
+
+const mismatches = rows.filter((r) => r.status !== "OK");
+console.log(`\nTotal teams: ${allTeams.size}`);
+console.log(`Mismatches:  ${mismatches.length}`);
+console.log(
+  `\n${"Team".padEnd(26)} ${"Before balance".padStart(20)} ${"After balance".padStart(20)} ${"Diff".padStart(14)}  Status`,
+);
+console.log("-".repeat(90));
+
+for (const r of rows) {
+  const bBal = r.b?.availableBalance ?? "-";
+  const aBal = r.a?.availableBalance ?? "-";
+  const diff = r.diff != null ? r.diff.toExponential(2) : "-";
+  const flag = r.status !== "OK" ? " <<<" : "";
+  console.log(
+    `${r.teamId.padEnd(26)} ${String(bBal).padStart(20)} ${String(aBal).padStart(20)} ${diff.padStart(14)}  ${r.status}${flag}`,
+  );
+}
+
+if (allOk) {
+  console.log("\n✓ All available balances preserved.");
+} else {
+  console.log(`\n✗ ${mismatches.length} mismatch(es) found.`);
+}

--- a/scripts/validate-migration-snapshot.mjs
+++ b/scripts/validate-migration-snapshot.mjs
@@ -1,0 +1,65 @@
+import "dotenv/config";
+import mongoose from "mongoose";
+
+const {
+  DOCUMENT_DB_CONNECTION_STRING,
+  DOCUMENT_DB_USERNAME,
+  DOCUMENT_DB_PASSWORD,
+} = process.env;
+const connectionString = `mongodb://${encodeURIComponent(DOCUMENT_DB_USERNAME)}:${encodeURIComponent(DOCUMENT_DB_PASSWORD)}@${DOCUMENT_DB_CONNECTION_STRING}`;
+
+await mongoose.connect(connectionString, { connectTimeoutMS: 10000 });
+const db = mongoose.connection.db;
+
+const balances = await db.collection("teambillingbalances").find({}).toArray();
+
+const teams = {};
+for (const b of balances) {
+  teams[b.team.toString()] = {
+    availableBalance: b.availableBalance,
+    totalCredits: b.totalCredits,
+    totalBilledCosts: b.totalBilledCosts,
+    totalRawCosts: b.totalRawCosts,
+  };
+}
+
+const ledgerTotals = await db
+  .collection("billingledgerentries")
+  .aggregate([
+    {
+      $group: {
+        _id: { team: "$team", direction: "$direction" },
+        total: { $sum: "$amount" },
+        count: { $sum: 1 },
+      },
+    },
+    { $sort: { "_id.team": 1, "_id.direction": 1 } },
+  ])
+  .toArray();
+
+const ledger = {};
+for (const row of ledgerTotals) {
+  const key = row._id.team.toString();
+  if (!ledger[key]) ledger[key] = {};
+  ledger[key][row._id.direction] = { total: row.total, count: row.count };
+}
+for (const dirs of Object.values(ledger)) {
+  dirs.net = (dirs.credit?.total ?? 0) - (dirs.debit?.total ?? 0);
+}
+
+const legacy = {
+  llmcosts: await db.collection("llmcosts").countDocuments({ isLegacy: true }),
+  teamcredits: await db
+    .collection("teamcredits")
+    .countDocuments({ isLegacy: true }),
+  ledgerEntries: await db
+    .collection("billingledgerentries")
+    .countDocuments({ isLegacy: true }),
+  carryForwards: await db
+    .collection("billingledgerentries")
+    .countDocuments({ idempotencyKey: { $regex: /^legacy-balance:/ } }),
+};
+
+console.log(JSON.stringify({ teams, ledger, legacy }, null, 2));
+
+await mongoose.disconnect();


### PR DESCRIPTION
Fixes #2194

Replaces the per-team carry-forward ledger entry with individual debit/credit entries sourced from llmcosts and teamcredits, preserving original timestamps so billing periods reflect accurate historical spend. Recalculates closed billing periods and refreshes TeamBillingBalance totals. Net balances are unchanged. Includes validation scripts for pre/post comparison.