### PR TITLE
Add hotfix release workflow and trigger releases by patch digit

### DIFF
--- a/.github/workflows/ecs_build_image.yml
+++ b/.github/workflows/ecs_build_image.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
 
+      ref:
+        description: "Git ref to build (branch, tag, or SHA). Defaults to the triggering ref."
+        required: false
+        type: string
+
       build-args:
         description: "Docker build arguments (newline-separated KEY=VALUE pairs)"
         required: false
@@ -69,6 +74,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # When ref is empty, checkout uses the triggering ref — unchanged
+          # behaviour for staging. hotfix.yml passes the release's target
+          # branch (target_commitish) so an emergency build ships the branch
+          # selected in the release UI, not the default branch.
+          ref: ${{ inputs.ref }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.0.0

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,156 @@
+name: Hotfix Release
+
+# Emergency release path. Builds from source and deploys fast.
+#
+# Developer workflow
+#   1. Push the fix to a branch (a release branch, a revert, or main)
+#   2. Publish a GitHub Release whose tag patch digit is > 0
+#        e.g. v0.14.1  (v0.14.0 is a normal production release)
+#   3. This workflow builds that branch and deploys it to production
+#
+#   - https://github.com/National-Tutoring-Observatory/sandpiper/releases/new
+#
+# Differences from release.yml (#197)
+#   - Builds containers from source instead of promoting the staging image.
+#     A hotfix may need code that never went through staging.
+#   - Builds from the release's target branch (github.event.release.target_commitish),
+#     NOT main. The base-branch reachability check is intentionally absent so
+#     an emergency fix can ship from any branch.
+#   - No preflight job. release.yml waits for the cluster to stabilise before
+#     promoting; if the cluster is wedged, that wait never ends. hotfix.yml is
+#     the tool that UN-wedges it, so it must not be gated on cluster health.
+#   - Version is extracted inline (no resolve_release.yml call) to stay
+#     self-contained and fast.
+#
+# Routing
+#   release: published fires for EVERY release, so the patch-digit split is
+#   enforced as a job-level `if:`, not in the `on:` block:
+#     - release.yml  claims tags ending in  .0   (vX.Y.0  -> normal release)
+#     - hotfix.yml   claims tags NOT ending in .0 (vX.Y.N  -> hotfix, N > 0)
+#   The job is skipped (neutral, not failed) on tags that aren't ours, so a
+#   normal vX.Y.0 release leaves this workflow grey rather than red.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+concurrency:
+  group: production-hotfix
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve Hotfix Version
+    # Claim only tags whose patch digit is > 0 (i.e. NOT ending in .0).
+    if: ${{ !endsWith(github.event.release.tag_name, '.0') }}
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      ref: ${{ steps.version.outputs.ref }}
+    steps:
+      - name: Extract version from release tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${{ github.event.release.tag_name }}"
+          REF="${{ github.event.release.target_commitish }}"
+
+          # Validate format. Digits only, no suffixes. Same shape release.yml
+          # accepts, but here we additionally require the patch digit be > 0.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Invalid hotfix tag format: $TAG"
+            echo "   Expected vX.Y.Z (digits only)"
+            exit 1
+          fi
+
+          PATCH="${TAG##*.}"
+          if [[ "$PATCH" -eq 0 ]]; then
+            echo "❌ $TAG has patch digit 0 — that's a normal release, not a hotfix."
+            echo "   release.yml handles vX.Y.0 tags."
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+          echo "🚑 Hotfix release $VERSION building from '$REF'"
+
+  build-web:
+    name: Build Web Image
+    needs: resolve
+    uses: ./.github/workflows/ecs_build_image.yml
+    with:
+      environment: production
+      aws-region: us-east-1
+      ref: ${{ needs.resolve.outputs.ref }}
+      tag: v${{ needs.resolve.outputs.version }}
+      output-name: web
+    secrets:
+      AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
+
+  build-worker:
+    name: Build Worker Image
+    needs: resolve
+    uses: ./.github/workflows/ecs_build_image.yml
+    with:
+      environment: production
+      aws-region: us-east-1
+      ref: ${{ needs.resolve.outputs.ref }}
+      dockerfile: workers/Dockerfile
+      image-suffix: -worker
+      tag: v${{ needs.resolve.outputs.version }}
+      output-name: worker
+    secrets:
+      AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
+
+  deploy-web:
+    name: Deploy Web Service
+    needs: build-web
+    uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_deploy_service.yml@main
+    with:
+      environment: production
+      aws-region: us-east-1
+      image: ${{ needs.build-web.outputs.image }}
+      service: web
+    secrets:
+      AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+
+  deploy-worker:
+    name: Deploy Worker Service
+    needs: build-worker
+    uses: National-Tutoring-Observatory/workflows/.github/workflows/ecs_deploy_service.yml@main
+    with:
+      environment: production
+      aws-region: us-east-1
+      image: ${{ needs.build-worker.outputs.image }}
+      service: worker
+    secrets:
+      AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+
+  hotfix-summary:
+    name: Hotfix Deployment Summary
+    needs:
+      - resolve
+      - build-web
+      - build-worker
+      - deploy-web
+      - deploy-worker
+    if: success() || failure()
+    uses: National-Tutoring-Observatory/workflows/.github/workflows/deployment_summary.yml@main
+    with:
+      environment: production
+      web-image: ${{ needs.build-web.outputs.image }}
+      worker-image: ${{ needs.build-worker.outputs.image }}
+      app-url: https://app.nationaltutoringobservatory.org/
+      originating-sha: ${{ needs.resolve.outputs.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,26 +7,32 @@ name: Production Release
 #   4. CI re-tags the staging image as vX.Y.Z (no rebuild — digest preserved)
 #   5. ECS service updated to vX.Y.Z
 
-# After PR is merged. Run the following to trigger.
-#   git checkout main
-#   git pull
-#   git tag v1.2.3
-#   git push origin v1.2.3
-
-# Or create a GitHub Release
+# After PR is merged. Publish a GitHub Release to trigger.
 #   - https://github.com/National-Tutoring-Observatory/sandpiper/releases/new
+#   Tag the release vX.Y.Z. The patch digit MUST be 0 for a normal release
+#   (e.g. v1.2.0). A non-zero patch digit (v1.2.3) is treated as a hotfix and
+#   is handled by hotfix.yml instead — this workflow will skip it.
 
 # Promotion model (#180)
 #   This workflow does *not* build from source. It validates that staging
 #   is running the tagged commit, has been stable for ≥2 hours, and then
 #   re-tags the staging image in ECR with the release version. Same
-#   bytes, same digest, new tag. Use the hotfix workflow for emergency
-#   releases that need to bypass these checks.
+#   bytes, same digest, new tag. Use the hotfix workflow (#197) for emergency
+#   releases that need to build from source and bypass these checks.
+
+# Routing (#197)
+#   release: published fires for EVERY published release, so the split between
+#   a normal release and a hotfix is enforced as a job-level `if:`, not in the
+#   `on:` block:
+#     - release.yml  claims tags ending in  .0   (vX.Y.0  -> normal release)
+#     - hotfix.yml   claims tags NOT ending in .0 (vX.Y.N  -> hotfix, N > 0)
+#   When a tag isn't ours the `resolve` job is skipped, and because every other
+#   job needs it, the whole run skips as neutral. A v1.2.3 publish leaves this
+#   workflow grey, not red.
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types: [published]
 
 permissions:
   id-token: write
@@ -39,6 +45,11 @@ concurrency:
 
 jobs:
   resolve:
+    # Claim only normal-release tags: patch digit 0 (i.e. ending in .0).
+    # endsWith is a string test, so v1.2.0 matches and v1.2.10 (ends ".10")
+    # and v1.2.3 do not. resolve_release.yml still does the real semver
+    # regex downstream — this `if:` is just the router.
+    if: ${{ endsWith(github.event.release.tag_name, '.0') }}
     uses: National-Tutoring-Observatory/workflows/.github/workflows/resolve_release.yml@main
     with:
       base-branch: main
@@ -50,10 +61,10 @@ jobs:
     with:
       environment: staging
       aws-region: us-east-1
-      # github.sha on a tag push is the commit the tag points at.
-      # The staging build tags images with the 7-char short SHA;
-      # inspect_staging.yml truncates this internally to match.
-      tag-commit-sha: ${{ github.sha }}
+      # The release's commit. resolve_release.yml validates the tag points at a
+      # commit reachable from main; staging tags images with the 7-char short
+      # SHA, and inspect_staging.yml truncates this internally to match.
+      tag-commit-sha: ${{ needs.resolve.outputs.sha }}
       bake-hours: 1
 
   preflight-production:


### PR DESCRIPTION
## What

Introduces a second production deployment path — hotfix.yml — for
emergency releases, and updates release.yml so the two workflows
partition published releases cleanly between them.

Both workflows now trigger on `release: published` and split on the
tag's patch digit:

- release.yml claims vX.Y.0 (normal release — promotes the staged image)
- hotfix.yml claims vX.Y.N, N>0 (hotfix — builds from source)

The split is enforced as a job-level `if:` on each workflow's first job
rather than in the `on:` block, since `release: published` can't filter
on version. The workflow that doesn't own a given tag skips as neutral,
so a release leaves exactly one green run and no red X.

## Why

The promotion model is the right default, it ships the exact
bytes that baked in staging, but it can't help when staging itself is
broken or when a fix needs to bypass the bake period. hotfix.yml trades
those guarantees for speed: it builds web and worker from the release's
target branch, drops the preflight check (so it can recover a wedged
cluster instead of stalling on one), and runs in its own concurrency
group so it isn't queued behind an in-flight release.

## Changes

- Add hotfix.yml: build-from-source emergency path, no preflight,
  inline version extraction, production-hotfix concurrency group.
- Update release.yml: switch to release: published, guard resolve with
  `endsWith(tag_name, '.0')`, and fix tag-commit-sha to use the resolved
  release commit (github.sha points at main under release: published,
  not the released commit).
  
---
Part of the work towards:
- https://github.com/National-Tutoring-Observatory/infrastructure/issues/196
- https://github.com/National-Tutoring-Observatory/infrastructure/issues/197
