### PR TITLE
Docs: audit and publish 5 draft articles

### DIFF
--- a/documentation/adjudication.md
+++ b/documentation/adjudication.md
@@ -2,7 +2,7 @@
 title: "Adjudication"
 tags: ["adjudication", "evaluation", "runs"]
 category: "Analysis"
-isPublished: false
+isPublished: true
 ---
 
 # Adjudication
@@ -23,15 +23,18 @@ Adjudication is initiated from the **Evaluation** tab of a **Run Set**.
 
 1.  **Run an Evaluation:** First, create an evaluation in your run set to compare your runs and identify disagreements.
 2.  **Review Results:** Examine the pairwise agreement matrix to see where runs disagree.
-3.  **Start Adjudication:** Click **"Start Adjudication"** from the evaluation results page.
-4.  **Select Source Runs:** Choose the runs whose disagreements you want to resolve. Typically, you select the top-performing runs or the runs you are most interested in reconciling.
+3.  **Open the Adjudication Dialog:** Click **"Improve via adjudication"** from the evaluation results page.
+4.  **Select Source Runs:** The dialog pre-selects the top 3 non-human runs by Kappa score against your base run. You can check or uncheck runs to customize the selection. A minimum of 2 runs is required.
+5.  **Choose an Adjudicator Model:** Select the LLM model that will resolve disagreements. The default model is pre-loaded, but you can swap in any configured provider model.
+6.  **Start the Run:** Click **"Start adjudication"** to launch the run.
 
 ### How Adjudication Works
 
-1.  **Disagreement Detection:** Sandpiper identifies all utterances or sessions where the selected source runs produced different annotations.
-2.  **LLM Voting:** For each disagreement, the adjudication LLM reviews the source annotations and the original transcript data, then votes on which annotation is correct.
-3.  **Consensus Output:** The adjudication produces a new run with consensus annotations — one label per utterance or session, reflecting the resolved disagreement.
-4.  **Automatic Re-evaluation:** Once adjudication completes, the evaluation is re-run with the adjudication run included, so you can see how the consensus compares to the original runs.
+1.  **Disagreement Detection:** Sandpiper compares annotations across the selected source runs and identifies utterances or sessions where they disagree.
+2.  **Agreement Pass-through:** Where all source runs already agree, the consensus annotation is copied through directly — no LLM call is made for unanimous results.
+3.  **LLM Voting:** For each remaining disagreement, the adjudicator LLM reviews the source annotations alongside the original transcript content, then votes on which annotation is correct.
+4.  **Consensus Output:** A new run is created with one consensus annotation per utterance or session. The run is named after the adjudicator model (e.g. "Adjudication - Claude Sonnet 4.6") and flagged as an adjudication run.
+5.  **Automatic Re-evaluation:** Once the adjudication run finishes successfully, Sandpiper automatically re-runs the evaluation to include it alongside the originals.
 
 ### Interpreting Adjudication Results
 

--- a/documentation/billing.md
+++ b/documentation/billing.md
@@ -2,7 +2,7 @@
 title: "Billing and Credits"
 tags: ["billing", "credits", "teams"]
 category: "Collaboration"
-isPublished: false
+isPublished: true
 ---
 
 # Billing and Credits
@@ -32,22 +32,26 @@ Each team is assigned a **Billing Plan** that determines the markup rate applied
 
 ### Purchasing Credits
 
-1.  **Add Credits:** From the billing page, click **"Add Credits"**.
-2.  **Stripe Checkout:** You will be redirected to Stripe to complete the purchase.
-3.  **Credits Applied:** Once the payment is processed, credits are immediately added to your team's balance.
+1.  **Top Up:** From the billing page, click **"Top up"**.
+2.  **Stripe Checkout:** Confirm the amount, then click **"Continue to checkout"** to be redirected to Stripe.
+3.  **Credits Applied:** Once the payment is processed, credits are immediately added to your team's balance and a confirmation toast appears on return.
+
+> **Admin note:** A separate **"Add credits"** button is available to super admins for manually granting credits to a team without going through Stripe — for example, when issuing research credits or refunds.
 
 ### Understanding Costs
 
 Costs are tracked across several categories:
 
-| Cost Source                    | Description                                   |
-| ------------------------------ | --------------------------------------------- |
-| **Annotation (per session)**   | LLM calls for per-session annotation runs     |
-| **Annotation (per utterance)** | LLM calls for per-utterance annotation runs   |
-| **Verification**               | Self-verification of annotation quality       |
-| **Adjudication**               | LLM calls to resolve annotation disagreements |
-| **File Conversion**            | LLM calls during transcript parsing           |
-| **Codebook Prompt Generation** | LLM calls to generate prompts from codebooks  |
+| Cost Source                    | Description                                               |
+| ------------------------------ | --------------------------------------------------------- |
+| **Annotation (per session)**   | LLM calls for per-session annotation runs                 |
+| **Annotation (per utterance)** | LLM calls for per-utterance annotation runs               |
+| **Verification**               | Self-verification of annotation quality                   |
+| **Adjudication**               | LLM calls to resolve annotation disagreements             |
+| **File Conversion**            | LLM calls during transcript parsing                       |
+| **Attribute Mapping**          | LLM calls to detect column mappings during file upload    |
+| **Codebook Generation**        | LLM calls to generate prompts from codebooks              |
+| **Prompt Alignment**           | LLM calls to align prompt schemas with codebook structure |
 
 ### Cost Estimation
 
@@ -57,7 +61,15 @@ Before starting a run, Sandpiper provides a cost estimate based on:
 - The **input token count** of each session
 - The pricing tiers of the selected **LLM Model**
 
-If your team has insufficient credits, you will see a warning. You can acknowledge the warning and proceed, or purchase additional credits first.
+If your team has insufficient credits, you will see a warning that estimated cost exceeds your remaining balance. You can acknowledge the warning ("I understand and want to proceed") and start the run anyway, or top up credits first. Runs may fail mid-execution if credits are exhausted.
+
+### Spend Analytics and History
+
+The billing page also surfaces:
+
+- **Spend Analytics** — usage broken down by model and over time, with day/week/month granularity
+- **Credit History** — searchable record of all credit transactions, including who added credits and the Stripe session ID for reconciliation
+- **Billing Period History** — closed billing periods showing raw cost, billed amount with markup applied, and closing balance
 
 ## Related Concepts
 

--- a/documentation/codebooks.md
+++ b/documentation/codebooks.md
@@ -32,12 +32,12 @@ In the codebook editor:
 3.  **Write Definitions:** For each code, write a clear definition explaining what it means and when it applies.
 4.  **Add Examples:** Provide examples for each code. Each example is tagged with one of four types:
 
-| Example Type | Description                                |
-| ------------ | ------------------------------------------ |
-| **HIT**      | A clear, unambiguous example of the code   |
-| **NEAR_HIT** | A borderline example that still qualifies  |
-| **NEAR_MISS**| A borderline example that does not qualify |
-| **MISS**     | A clear example of what the code is not    |
+| Example Type  | Description                                |
+| ------------- | ------------------------------------------ |
+| **HIT**       | A clear, unambiguous example of the code   |
+| **NEAR_HIT**  | A borderline example that still qualifies  |
+| **NEAR_MISS** | A borderline example that does not qualify |
+| **MISS**      | A clear example of what the code is not    |
 
 5.  **Save the Version:** Click **"Save codebook version"** and confirm in the dialog to persist your changes.
 

--- a/documentation/codebooks.md
+++ b/documentation/codebooks.md
@@ -2,7 +2,7 @@
 title: "Codebooks"
 tags: ["codebooks", "prompts"]
 category: "Configuration"
-isPublished: false
+isPublished: true
 ---
 
 # Codebooks
@@ -19,9 +19,9 @@ A key feature of codebooks is the ability to **auto-generate Prompts** directly 
 
 ### Creating a Codebook
 
-1.  **Navigate to Codebooks:** From your **Team** workspace, click the "Codebooks" section.
-2.  **Create New Codebook:** Click "New Codebook" and enter a name and description.
-3.  **Open the Editor:** The codebook editor opens with an empty structure ready for your categories and codes.
+1.  **Navigate to Codebooks:** Open the **Codebooks** link in the main sidebar under "Content". Codebooks are scoped to your team — only members of the same team can view or edit them.
+2.  **Create a Codebook:** Click **"Create codebook"** and fill in the **Name** and **Intention** fields (the Intention describes what this codebook is for).
+3.  **Open the Editor:** The codebook editor opens with an initial version ready for your categories and codes.
 
 ### Defining Categories and Codes
 
@@ -30,28 +30,30 @@ In the codebook editor:
 1.  **Add a Category:** Create a broad grouping (e.g., "Instructional Moves," "Student Responses").
 2.  **Add Codes:** Within each category, define specific codes (e.g., "Praise," "Scaffolding," "Probing Question").
 3.  **Write Definitions:** For each code, write a clear definition explaining what it means and when it applies.
-4.  **Add Examples:** Provide examples for each code using the example types:
+4.  **Add Examples:** Provide examples for each code. Each example is tagged with one of four types:
 
-| Example Type  | Description                                |
-| ------------- | ------------------------------------------ |
-| **Hit**       | A clear, unambiguous example of the code   |
-| **Near Hit**  | A borderline example that still qualifies  |
-| **Near Miss** | A borderline example that does not qualify |
-| **Miss**      | A clear example of what the code is not    |
+| Example Type | Description                                |
+| ------------ | ------------------------------------------ |
+| **HIT**      | A clear, unambiguous example of the code   |
+| **NEAR_HIT** | A borderline example that still qualifies  |
+| **NEAR_MISS**| A borderline example that does not qualify |
+| **MISS**     | A clear example of what the code is not    |
 
-5.  **Save the Version:** Click "Save" to store your codebook version.
+5.  **Save the Version:** Click **"Save codebook version"** and confirm in the dialog to persist your changes.
 
 ### Versioning
 
-1.  **Create a New Version:** Click "New Version" to create a copy of the current version for editing. The original version is preserved.
-2.  **Mark as Production:** Designate a version as "Production" to make it the active default for prompt generation.
+1.  **Create a New Version:** Click the **+** button next to the version list to create a copy of the current version for editing. The original version is preserved, and the new version is auto-named with an incrementing identifier.
+2.  **Make Production Version:** When you're satisfied with a version, click **"Make production version"** in the editor to designate it as the active default for prompt generation. The current production version displays a "Production" badge.
 
 ### Generating a Prompt from a Codebook
 
 1.  **Open the Codebook:** Navigate to the codebook version you want to use.
-2.  **Click "Create Prompt from Codebook":** Sandpiper sends your codebook's categories, codes, definitions, and examples to an LLM, which drafts an annotation prompt.
-3.  **Review the Prompt:** The generated prompt opens in the **Prompt** editor. Review and refine the instructions before saving.
-4.  **Link is Preserved:** The prompt retains a reference to the source codebook and version for traceability.
+2.  **Click "Create prompt":** Opens the **"Create prompt from codebook"** dialog.
+3.  **Choose an Annotation Type:** Select whether the generated prompt should annotate `PER_UTTERANCE` (default) or `PER_SESSION`.
+4.  **Generate:** Sandpiper sends your codebook's categories, codes, definitions, and examples to an LLM, which drafts an annotation prompt.
+5.  **Review the Prompt:** The generated prompt opens in the **Prompt** editor. Review and refine the instructions before saving.
+6.  **Link is Preserved:** The new prompt version stores a reference to the source codebook and version for traceability.
 
 ## External Guides
 

--- a/documentation/humanAnnotations.md
+++ b/documentation/humanAnnotations.md
@@ -25,20 +25,20 @@ When you upload a CSV of human annotations, Sandpiper validates the data, matche
     - `role` — the speaker role (e.g. Tutor, Student)
     - `content` — the utterance text
     - One annotation column per **annotator**, per **field**, per **slot**, using the naming format `annotator[<name>][<slot>]<fieldKey>` (for example, `annotator[joe][0]TUTOR_MOVE`). Each part of the name means:
-        - **`<name>`** — the annotator's name (e.g. `joe`). Each distinct name becomes its own Human Run. This is the only identifier of *who did the coding* — it is **not** tied to a tutor or student.
-        - **`<slot>`** — a zero-based index (`0`, `1`, `2`, …) that lets a **single annotator record more than one value for the same field on the same utterance**. You choose how many slots each field gets when downloading the template; a field with 2 slots produces `annotator[joe][0]TUTOR_MOVE` and `annotator[joe][1]TUTOR_MOVE`. **A slot is *not* a tutor ID** — speakers are identified by the `role` column, and each utterance by `session_id` + `sequence_id`. Most coding uses only slot `0`; extra slots exist for multi-label fields where one utterance can carry more than one code.
-        - **`<fieldKey>`** — the `fieldKey` of a field defined in your **[Prompt Schema](schema)**. Every field in the schema generates its own annotation column(s) here, and the values you enter should be that field's schema codes (e.g. `PRAISE`, `NOT_PRAISE`). Change a field in the schema and the template's columns change with it.
+      - **`<name>`** — the annotator's name (e.g. `joe`). Each distinct name becomes its own Human Run. This is the only identifier of _who did the coding_ — it is **not** tied to a tutor or student.
+      - **`<slot>`** — a zero-based index (`0`, `1`, `2`, …) that lets a **single annotator record more than one value for the same field on the same utterance**. You choose how many slots each field gets when downloading the template; a field with 2 slots produces `annotator[joe][0]TUTOR_MOVE` and `annotator[joe][1]TUTOR_MOVE`. **A slot is _not_ a tutor ID** — speakers are identified by the `role` column, and each utterance by `session_id` + `sequence_id`. Most coding uses only slot `0`; extra slots exist for multi-label fields where one utterance can carry more than one code.
+      - **`<fieldKey>`** — the `fieldKey` of a field defined in your **[Prompt Schema](schema)**. Every field in the schema generates its own annotation column(s) here, and the values you enter should be that field's schema codes (e.g. `PRAISE`, `NOT_PRAISE`). Change a field in the schema and the template's columns change with it.
 
 #### Sample template
 
 A template for annotator `joe` coding one field, `TUTOR_MOVE`, with **2 slots** looks like this:
 
-| session_id | sequence_id | role | content | annotator[joe][0]TUTOR_MOVE | annotator[joe][1]TUTOR_MOVE |
-|------------|-------------|---------|------------------------------------------------------|-----------------------------|-----------------------------|
-| sess_001 | 0 | Tutor | Let's pick up where we left off on question 3. | MANAGING | |
-| sess_001 | 1 | Student | Okay… I don't really get part b. | | |
-| sess_001 | 2 | Tutor | What do you notice about the denominator here? | PROBING_UNDERSTAND | GIVING_HINT |
-| sess_001 | 3 | Student | Oh — they have to match first. | | |
+| session_id | sequence_id | role    | content                                        | annotator[joe][0]TUTOR_MOVE | annotator[joe][1]TUTOR_MOVE |
+| ---------- | ----------- | ------- | ---------------------------------------------- | --------------------------- | --------------------------- |
+| sess_001   | 0           | Tutor   | Let's pick up where we left off on question 3. | MANAGING                    |                             |
+| sess_001   | 1           | Student | Okay… I don't really get part b.               |                             |                             |
+| sess_001   | 2           | Tutor   | What do you notice about the denominator here? | PROBING_UNDERSTAND          | GIVING_HINT                 |
+| sess_001   | 3           | Student | Oh — they have to match first.                 |                             |                             |
 
 - `session_id`, `sequence_id`, `role`, and `content` are pre-filled by the template — leave them unchanged so each row still matches the run set.
 - Fill the `annotator[...]` columns with codes from that field's schema; leave a cell blank when no code applies.

--- a/documentation/humanAnnotations.md
+++ b/documentation/humanAnnotations.md
@@ -18,19 +18,38 @@ When you upload a CSV of human annotations, Sandpiper validates the data, matche
 ### Downloading the Annotation Template
 
 1.  **Open a Run Set:** Navigate to the **Run Set** where you want to add human labels.
-2.  **Download Template:** From the Run Set dropdown menu, click **"Download Annotation Template"**. You can configure how many annotator slots to include per field before generating the CSV.
+2.  **Download Template:** From the Run Set dropdown menu, click **"Download Annotation Template"**. You can configure how many annotator slots to include per field before generating the CSV (see the definition of a **slot** below).
 3.  **Review the Template:** The generated CSV includes these columns:
     - `session_id` — the session identifier
     - `sequence_id` — the position of the utterance within the session
     - `role` — the speaker role (e.g. Tutor, Student)
     - `content` — the utterance text
-    - One annotation column per annotator per field, using the naming format `annotator[<name>][<slot>]<fieldKey>` (for example, `annotator[joe][0]TUTOR_MOVE`)
+    - One annotation column per **annotator**, per **field**, per **slot**, using the naming format `annotator[<name>][<slot>]<fieldKey>` (for example, `annotator[joe][0]TUTOR_MOVE`). Each part of the name means:
+        - **`<name>`** — the annotator's name (e.g. `joe`). Each distinct name becomes its own Human Run. This is the only identifier of *who did the coding* — it is **not** tied to a tutor or student.
+        - **`<slot>`** — a zero-based index (`0`, `1`, `2`, …) that lets a **single annotator record more than one value for the same field on the same utterance**. You choose how many slots each field gets when downloading the template; a field with 2 slots produces `annotator[joe][0]TUTOR_MOVE` and `annotator[joe][1]TUTOR_MOVE`. **A slot is *not* a tutor ID** — speakers are identified by the `role` column, and each utterance by `session_id` + `sequence_id`. Most coding uses only slot `0`; extra slots exist for multi-label fields where one utterance can carry more than one code.
+        - **`<fieldKey>`** — the `fieldKey` of a field defined in your **[Prompt Schema](schema)**. Every field in the schema generates its own annotation column(s) here, and the values you enter should be that field's schema codes (e.g. `PRAISE`, `NOT_PRAISE`). Change a field in the schema and the template's columns change with it.
+
+#### Sample template
+
+A template for annotator `joe` coding one field, `TUTOR_MOVE`, with **2 slots** looks like this:
+
+| session_id | sequence_id | role | content | annotator[joe][0]TUTOR_MOVE | annotator[joe][1]TUTOR_MOVE |
+|------------|-------------|---------|------------------------------------------------------|-----------------------------|-----------------------------|
+| sess_001 | 0 | Tutor | Let's pick up where we left off on question 3. | MANAGING | |
+| sess_001 | 1 | Student | Okay… I don't really get part b. | | |
+| sess_001 | 2 | Tutor | What do you notice about the denominator here? | PROBING_UNDERSTAND | GIVING_HINT |
+| sess_001 | 3 | Student | Oh — they have to match first. | | |
+
+- `session_id`, `sequence_id`, `role`, and `content` are pre-filled by the template — leave them unchanged so each row still matches the run set.
+- Fill the `annotator[...]` columns with codes from that field's schema; leave a cell blank when no code applies.
+- Here `joe` gives one utterance two codes (`PROBING_UNDERSTAND` + `GIVING_HINT`) using slots `0` and `1`; every other row uses only slot `0`.
+- Adding a second annotator (`josephine`) would add a parallel set of columns: `annotator[josephine][0]TUTOR_MOVE`, etc. — and create a second Human Run.
 
 ### Annotating the CSV
 
 1.  **Fill in Labels:** Open the CSV in a spreadsheet editor and fill in the annotator columns with your human labels.
 2.  **Multiple Annotators:** Each unique annotator name in the column headers becomes its own human run. Sandpiper detects annotators automatically from the `annotator[<name>][<slot>]<field>` format.
-3.  **Match Schema Codes:** Values in annotation columns should match the codes defined in your **Prompt Schema** (e.g., `PRAISE`, `NOT_PRAISE`) for meaningful comparisons. Sandpiper accepts any string value, but mismatched codes won't align with LLM runs during evaluation.
+3.  **Match Schema Codes:** Each column's `<fieldKey>` corresponds to a field in your **[Prompt Schema](schema)**, and the values you enter should match that field's codes (e.g., `PRAISE`, `NOT_PRAISE`). Sandpiper accepts any string value, but codes that don't match the schema won't align with LLM runs during evaluation.
 
 ### Uploading the CSV
 
@@ -57,5 +76,5 @@ Once human runs are added to a run set:
 - **[Run Sets](run-sets)** — Where human annotations are uploaded and compared
 - **[Runs](runs)** — Human runs appear alongside LLM runs
 - **[Evaluation Equations](evaluation-equations)** — The metrics used to compare runs
-- **[Schema](schema)** — Defines the annotation fields for the template
+- **[Schema](schema)** — Defines the annotation fields (`fieldKey` and codes) used in the template
 - **[Adjudication](adjudication)** — Resolve disagreements after human/LLM comparison

--- a/documentation/humanAnnotations.md
+++ b/documentation/humanAnnotations.md
@@ -2,7 +2,7 @@
 title: "Human Annotations"
 tags: ["human-annotations", "runs", "evaluation"]
 category: "Analysis"
-isPublished: false
+isPublished: true
 ---
 
 # Human Annotations
@@ -18,26 +18,31 @@ When you upload a CSV of human annotations, Sandpiper validates the data, matche
 ### Downloading the Annotation Template
 
 1.  **Open a Run Set:** Navigate to the **Run Set** where you want to add human labels.
-2.  **Download Template:** Click **"Download Annotation Template"** to get a CSV file pre-populated with all session transcripts and annotation fields from the run set.
-3.  **Review the Template:** The template includes columns for session IDs, utterance IDs (for per-utterance annotation), and empty annotation columns for each field in the schema.
+2.  **Download Template:** From the Run Set dropdown menu, click **"Download Annotation Template"**. You can configure how many annotator slots to include per field before generating the CSV.
+3.  **Review the Template:** The generated CSV includes these columns:
+    - `session_id` — the session identifier
+    - `sequence_id` — the position of the utterance within the session
+    - `role` — the speaker role (e.g. Tutor, Student)
+    - `content` — the utterance text
+    - One annotation column per annotator per field, using the naming format `annotator[<name>][<slot>]<fieldKey>` (for example, `annotator[joe][0]TUTOR_MOVE`)
 
 ### Annotating the CSV
 
-1.  **Fill in Labels:** Open the CSV in a spreadsheet editor and fill in the annotation columns with your human labels.
-2.  **Multiple Annotators:** If you have multiple human annotators, include each annotator's labels in separate columns. Sandpiper will detect and create a separate human run for each annotator.
-3.  **Use Consistent Codes:** Ensure the values in annotation columns match the codes defined in your **Prompt Schema** (e.g., `PRAISE`, `NOT_PRAISE`).
+1.  **Fill in Labels:** Open the CSV in a spreadsheet editor and fill in the annotator columns with your human labels.
+2.  **Multiple Annotators:** Each unique annotator name in the column headers becomes its own human run. Sandpiper detects annotators automatically from the `annotator[<name>][<slot>]<field>` format.
+3.  **Match Schema Codes:** Values in annotation columns should match the codes defined in your **Prompt Schema** (e.g., `PRAISE`, `NOT_PRAISE`) for meaningful comparisons. Sandpiper accepts any string value, but mismatched codes won't align with LLM runs during evaluation.
 
 ### Uploading the CSV
 
-1.  **Navigate to Human Annotations:** From the **Run Set** detail page, click on the human annotations upload option.
-2.  **Upload the CSV:** Select your completed CSV file. Sandpiper will analyze the file and display a validation summary:
-    - **Matched sessions** — Sessions in the CSV that match the run set
-    - **Unmatched sessions** — Session IDs in the CSV that were not found
-    - **Missing sessions** — Sessions in the run set not covered by the CSV
-    - **Detected annotators** — The annotators found in the column headers
-    - **Annotation fields** — The fields that will be imported
-3.  **Confirm Upload:** Review the analysis results and click "Upload" to create the human runs.
-4.  **Processing:** Sandpiper processes the annotations in the background and adds the human runs to the run set.
+1.  **Open the Upload Dialog:** From the **Run Set** dropdown menu, click **"Upload Human Annotations"**.
+2.  **Select the CSV:** Choose your completed CSV file. Sandpiper analyzes it and displays a validation summary:
+    - **Annotators** — the annotators detected from column headers, and how many runs will be created
+    - **Annotation Fields** — the fields that will be imported
+    - **Matched sessions** — sessions in the CSV that match a session in the run set
+    - **Unmatched sessions** — session IDs in the CSV that don't match any run set session
+    - **Missing sessions** — sessions in the run set that aren't covered by the CSV
+3.  **Confirm Upload:** Review the analysis results and confirm the upload to create the human runs.
+4.  **Processing:** Sandpiper processes the annotations in the background and adds the human runs to the run set. Each human annotation is stored with `identifiedBy: "HUMAN"` to distinguish it from LLM-generated annotations.
 
 ### Using Human Runs in Evaluations
 

--- a/documentation/transcripts.md
+++ b/documentation/transcripts.md
@@ -22,10 +22,10 @@ Sandpiper accepts uploads in two formats: **CSV** and **JSONL**. Both are conver
 
 Files are detected by extension:
 
-| Extension | Format | Notes                                                      |
-| --------- | ------ | ---------------------------------------------------------- |
-| `.csv`    | CSV    | One utterance per row, with a header row                   |
-| `.jsonl` | JSONL  | One JSON object per line, each representing an utterance   |
+| Extension | Format | Notes                                                    |
+| --------- | ------ | -------------------------------------------------------- |
+| `.csv`    | CSV    | One utterance per row, with a header row                 |
+| `.jsonl`  | JSONL  | One JSON object per line, each representing an utterance |
 
 Direct `.json` uploads are not currently supported — use CSV or JSONL.
 
@@ -33,12 +33,12 @@ Direct `.json` uploads are not currently supported — use CSV or JSONL.
 
 Every utterance row or record must include these fields:
 
-| Field         | Type   | Description                                                       |
-| ------------- | ------ | ----------------------------------------------------------------- |
-| `session_id`  | string | Identifier grouping utterances into a session                     |
-| `role`        | string | Speaker role (e.g. `Tutor`, `Student`, `Teacher`)                 |
-| `content`     | string | The actual text spoken in this turn                               |
-| `sequence_id` | string | Sequential position of the utterance within its session           |
+| Field         | Type   | Description                                             |
+| ------------- | ------ | ------------------------------------------------------- |
+| `session_id`  | string | Identifier grouping utterances into a session           |
+| `role`        | string | Speaker role (e.g. `Tutor`, `Student`, `Teacher`)       |
+| `content`     | string | The actual text spoken in this turn                     |
+| `sequence_id` | string | Sequential position of the utterance within its session |
 
 A single file can contain multiple sessions — utterances are grouped by their `session_id` during processing.
 
@@ -46,12 +46,12 @@ A single file can contain multiple sessions — utterances are grouped by their 
 
 Sandpiper accepts common alternate column names and maps them automatically:
 
-| Canonical Field | Accepted Aliases               |
-| --------------- | ------------------------------ |
-| `session_id`    | `sessionId`, `sessionID`       |
-| `role`          | `speaker`                      |
-| `content`       | `text`                         |
-| `sequence_id`   | _(no aliases)_                 |
+| Canonical Field | Accepted Aliases         |
+| --------------- | ------------------------ |
+| `session_id`    | `sessionId`, `sessionID` |
+| `role`          | `speaker`                |
+| `content`       | `text`                   |
+| `sequence_id`   | _(no aliases)_           |
 
 ### CSV Example
 
@@ -165,7 +165,9 @@ Annotations are attached at the session level and describe the entire conversati
 
 ```json
 {
-  "transcript": [/* utterances */],
+  "transcript": [
+    /* utterances */
+  ],
   "annotations": [
     {
       "_id": "0",

--- a/documentation/transcripts.md
+++ b/documentation/transcripts.md
@@ -2,25 +2,91 @@
 title: "Transcripts"
 tags: ["transcripts", "run", "run-sets"]
 category: "Data Management"
-isPublished: false
+isPublished: true
 ---
 
-# Transcript Format Specification
+# Transcripts
 
-This document describes the JSON format for tutoring session transcripts used in Sandpiper.
+This guide describes the file formats Sandpiper accepts when you upload tutoring session data, and the internal JSON structure those files are converted into for annotation and analysis.
 
 ## Overview
 
-Transcripts represent conversations between tutors and students. They consist of:
+Transcripts represent conversations between tutors and students. Each transcript consists of:
 
-- **Utterances**: Individual turns in the conversation
-- **Annotations**: Labels or codes applied to utterances or sessions
+- **Utterances** — individual turns in the conversation
+- **Annotations** — labels or codes applied to utterances or to the session as a whole
 
-## JSON Schema
+Sandpiper accepts uploads in two formats: **CSV** and **JSONL**. Both are converted into a canonical JSON structure during ingestion, then used as **Sessions** for annotation runs.
 
-See [`app/lib/schemas/json/transcript.schema.json`](../../app/lib/schemas/json/transcript.schema.json) for the formal JSON Schema definition used for validation in the codebase.
+## Supported Upload Formats
 
-## Format Structure
+Files are detected by extension:
+
+| Extension | Format | Notes                                                      |
+| --------- | ------ | ---------------------------------------------------------- |
+| `.csv`    | CSV    | One utterance per row, with a header row                   |
+| `.jsonl` | JSONL  | One JSON object per line, each representing an utterance   |
+
+Direct `.json` uploads are not currently supported — use CSV or JSONL.
+
+### Required Fields
+
+Every utterance row or record must include these fields:
+
+| Field         | Type   | Description                                                       |
+| ------------- | ------ | ----------------------------------------------------------------- |
+| `session_id`  | string | Identifier grouping utterances into a session                     |
+| `role`        | string | Speaker role (e.g. `Tutor`, `Student`, `Teacher`)                 |
+| `content`     | string | The actual text spoken in this turn                               |
+| `sequence_id` | string | Sequential position of the utterance within its session           |
+
+A single file can contain multiple sessions — utterances are grouped by their `session_id` during processing.
+
+### Optional Field Aliases
+
+Sandpiper accepts common alternate column names and maps them automatically:
+
+| Canonical Field | Accepted Aliases               |
+| --------------- | ------------------------------ |
+| `session_id`    | `sessionId`, `sessionID`       |
+| `role`          | `speaker`                      |
+| `content`       | `text`                         |
+| `sequence_id`   | _(no aliases)_                 |
+
+### CSV Example
+
+```csv
+session_id,role,content,sequence_id
+session_001,Tutor,Hello! Today we're going to work on fractions.,1
+session_001,Student,Hi! I'm ready to learn.,2
+session_001,Tutor,Great! Let's start with a simple example.,3
+session_002,Tutor,Welcome back! Let's review decimals today.,1
+session_002,Student,Hello! I've been practicing.,2
+```
+
+### JSONL Example
+
+```jsonl
+{"session_id":"session_003","role":"Tutor","content":"Welcome to our algebra lesson!","sequence_id":1}
+{"session_id":"session_003","role":"Student","content":"Hi! I'm excited to learn algebra.","sequence_id":2}
+{"session_id":"session_004","role":"Tutor","content":"Today we're covering geometry basics.","sequence_id":1}
+```
+
+## How Upload Works
+
+1. **File Upload:** Drop a `.csv` or `.jsonl` file into a Project. Sandpiper detects the file type and parses it.
+2. **Attribute Mapping:** Sandpiper inspects the first record to map your columns or fields to its canonical schema. If column names match an accepted alias (e.g. `speaker` for `role`), the mapping is applied automatically. The lead role for the conversation is inferred by an LLM from the unique roles in the file.
+3. **Session Splitting:** Utterances are grouped by `session_id` and split into one session per group.
+4. **Conversion:** Each session is converted into the internal transcript JSON structure (described below), with `_id` assigned, utterances ordered by `sequence_id`, and an empty `annotations` array attached to each utterance.
+5. **Ready for Runs:** Once converted, sessions can be added to Run Sets and annotated by LLMs or human raters.
+
+## Internal Transcript Structure
+
+After conversion, each session is represented as a JSON document. This structure is what annotation runs read from and write to.
+
+The formal schema lives at [`app/lib/schemas/json/transcript.schema.json`](../../app/lib/schemas/json/transcript.schema.json).
+
+### Format
 
 ```json
 {
@@ -41,9 +107,7 @@ See [`app/lib/schemas/json/transcript.schema.json`](../../app/lib/schemas/json/t
 }
 ```
 
-## Field Descriptions
-
-### Root Level
+### Root Fields
 
 | Field         | Type   | Required | Description                                                       |
 | ------------- | ------ | -------- | ----------------------------------------------------------------- |
@@ -64,55 +128,15 @@ See [`app/lib/schemas/json/transcript.schema.json`](../../app/lib/schemas/json/t
 | `sequence_id` | String | No       | Sequential position in conversation                                                                      |
 | `annotations` | Array  | No       | Utterance-level annotations (used with PER_UTTERANCE annotation type)                                    |
 
-### Annotation Object (Utterance-level)
-
-Used when `annotationType` is `PER_UTTERANCE`:
-
-```json
-{
-  "_id": "string",
-  "customField1": "value",
-  "customField2": "value"
-}
-```
-
-| Field           | Type   | Required | Description                                                 |
-| --------------- | ------ | -------- | ----------------------------------------------------------- |
-| `_id`           | String | **Yes**  | Reference to the utterance `_id` this annotation belongs to |
-| _custom fields_ | Any    | No       | Annotation schema fields defined by the prompt              |
-
-The annotation schema is defined in the prompt configuration. Common examples include:
-
-- `given_praise`: Boolean or string indicating if praise was given
-- `identifiedBy`: String identifying who/what created the annotation
-- `code`: String code or category
-- `explanation`: String explanation of the annotation
-
-### Annotation Object (Session-level)
-
-Used when `annotationType` is `PER_SESSION`:
-
-```json
-{
-  "_id": "string",
-  "customField1": "value",
-  "customField2": "value"
-}
-```
-
-Session-level annotations appear in the root `annotations` array and apply to the entire session rather than individual utterances.
-
 ## Annotation Types
 
-Sandpiper supports two annotation granularities:
+Sandpiper supports two annotation granularities. The annotation type is determined by the **Prompt** used in the run, not by the transcript file itself.
 
 ### PER_UTTERANCE
 
 Annotations are attached to individual utterances. Each utterance can have multiple annotations.
 
-**Use case**: Coding individual turns (e.g., identifying praise, questions, feedback)
-
-**Example**:
+**Use case:** Coding individual turns (e.g., identifying praise, questions, feedback).
 
 ```json
 {
@@ -137,13 +161,11 @@ Annotations are attached to individual utterances. Each utterance can have multi
 
 Annotations are attached at the session level and describe the entire conversation.
 
-**Use case**: Overall session coding (e.g., session quality, learning outcomes, engagement level)
-
-**Example**:
+**Use case:** Overall session coding (e.g., session quality, learning outcomes, engagement level).
 
 ```json
 {
-  "transcript": [...],
+  "transcript": [/* utterances */],
   "annotations": [
     {
       "_id": "0",
@@ -155,144 +177,47 @@ Annotations are attached at the session level and describe the entire conversati
 }
 ```
 
-## Examples
+## Validation and Error Handling
 
-### Minimal Valid Transcript
+The current upload flow validates transcripts at parse time:
 
-```json
-{
-  "transcript": [
-    {
-      "_id": "0",
-      "role": "Tutor",
-      "content": "Hello! Today we're going to work on fractions."
-    },
-    {
-      "_id": "1",
-      "role": "Student",
-      "content": "Hi! I'm ready to learn."
-    }
-  ]
-}
-```
+- **CSV:** Rows missing the `session_id` column are rejected with the error `CSV file is missing required "session_id" column`.
+- **JSONL:** Lines that fail to parse as JSON are rejected with a parsing error indicating the bad line. Records without a `session_id` field are rejected.
+- **Attribute Mapping:** If none of the required fields (`role`, `content`, `sequence_id`) or their aliases are present in the file, the mapping step will fail.
 
-### Complete Example with Timestamps
+A formal JSON Schema (`transcript.schema.json`) defines the internal transcript structure and is available for validating exported or programmatically-generated session JSON, though it is not currently invoked automatically during the standard upload flow.
 
-```json
-{
-  "transcript": [
-    {
-      "_id": "0",
-      "role": "Tutor",
-      "content": "Hello! Today we're going to work on fractions.",
-      "session_id": "session_001",
-      "sequence_id": "1",
-      "start_time": "00:00:00",
-      "end_time": "00:00:05",
-      "annotations": []
-    },
-    {
-      "_id": "1",
-      "role": "Student",
-      "content": "Hi! I'm ready to learn.",
-      "session_id": "session_001",
-      "sequence_id": "2",
-      "start_time": "00:00:05",
-      "end_time": "00:00:08",
-      "annotations": []
-    }
-  ],
-  "leadRole": "Tutor",
-  "annotations": []
-}
-```
+## Recommended Limits
 
-### Example with Utterance Annotations
+Sandpiper does not enforce hard size or count limits, but the following are recommended for predictable performance:
 
-```json
-{
-  "transcript": [
-    {
-      "_id": "2",
-      "role": "Tutor",
-      "content": "Great! Let's start with a simple example.",
-      "session_id": "session_001",
-      "sequence_id": "3",
-      "annotations": [
-        {
-          "_id": "2",
-          "identifiedBy": "AI",
-          "given_praise": "Great!"
-        }
-      ]
-    }
-  ],
-  "leadRole": "Tutor",
-  "annotations": []
-}
-```
+- **File size:** Up to 10MB per file
+- **Utterances per session:** Up to 1,000
 
-## Validation
-
-Transcripts are validated against the JSON Schema at the following points:
-
-1. **File Upload**: When uploading session files to the system
-2. **File Conversion**: When converting files to sessions
-3. **Before Annotation**: Before running annotation jobs
-
-Invalid transcripts will be rejected with a clear error message indicating:
-
-- Which field failed validation
-- What was expected vs. what was found
-- The location in the file (utterance index, field path)
+Files significantly larger than these guidelines may increase processing time, token costs, and the risk of LLM context limits during annotation runs.
 
 ## File Naming
 
-Session files should be named descriptively:
+Use descriptive file names that identify the dataset or session range. The file name (without extension) is used as the session name when only one session is present in the file.
 
-- Format: `{identifier}.json`
-- Example: `session_001.json`, `math_tutoring_20240115.json`
+Examples: `session_001.csv`, `math_tutoring_20240115.jsonl`
 
 ## Character Encoding
 
-All transcript files must be UTF-8 encoded to support international characters.
-
-## Size Limits
-
-- Maximum file size: 10MB per transcript
-- Recommended maximum utterances: 1000 per session
-- Very large sessions may impact processing performance
-
-## Common Validation Errors
-
-### Missing Required Fields
-
-```
-Error: Utterance at index 5 is missing required field '_id'
-```
-
-**Fix**: Ensure every utterance has `_id`, `role`, and `content` fields.
-
-### Invalid JSON
-
-```
-Error: Unable to parse JSON: Unexpected token at line 45
-```
-
-**Fix**: Validate JSON syntax using a JSON validator before upload.
-
-### Incorrect Data Types
-
-```
-Error: Field 'annotations' must be an array, got string
-```
-
-**Fix**: Ensure `annotations` is always an array `[]`, even if empty.
+All upload files should be UTF-8 encoded to support international characters and special punctuation.
 
 ## Best Practices
 
-1. **Unique IDs**: Use sequential numeric strings for utterance IDs ("0", "1", "2", etc.)
-2. **Consistent Roles**: Use consistent role names throughout a project
-3. **Empty Arrays**: Initialize `annotations` as `[]` rather than omitting the field
-4. **Timestamps**: Use consistent timestamp formats within a session
-5. **Content**: Preserve original punctuation and capitalization in utterance content
+1. **Consistent Session IDs:** Use a stable identifier scheme across sessions so re-uploads and updates can be matched.
+2. **Sequential `sequence_id`:** Number utterances starting at `1` and incrementing by `1` within each session.
+3. **Consistent Role Names:** Use the same role labels throughout a project (e.g., always `Tutor` and `Student`, not mixed with `Teacher`/`Pupil`).
+4. **Preserve Original Text:** Keep original punctuation and capitalization in the `content` field — this matters for annotations that look at linguistic features like questioning or praise.
+5. **One Format Per File:** Don't mix CSV and JSONL; pick one and stick with it for the file.
+
+## Related Concepts
+
+- **[Sessions](sessions)** — The unit each transcript becomes after conversion
+- **[Files](files)** — Upload, processing, and file management
+- **[Run Sets](run-sets)** — Group sessions for annotation
+- **[Annotation Type](annotationType)** — PER_UTTERANCE vs PER_SESSION runs
+- **[Schema](schema)** — Annotation field structure used by prompts


### PR DESCRIPTION
## Summary

- Audited the 6 documentation articles that had `isPublished: false` against the current Sandpiper implementation.
- Updated content in 5 articles to reflect what the app actually does and flipped them to `isPublished: true`.
- Left `de-identification.md` unpublished because the feature has no implementation yet (only a research-paper citation).

## Articles updated and published

| Article | Notable corrections |
| --- | --- |
| `adjudication.md` | Button is "Improve via adjudication", not "Start Adjudication". Documented top-3-by-Kappa pre-selection, adjudicator model choice, and unanimous-agreement pass-through. |
| `billing.md` | Stripe purchase button is "Top up" (not "Add Credits" — that's an admin-only manual entry). Added missing cost categories (Attribute Mapping, Prompt Alignment). Noted Spend Analytics, Credit History, and Billing Period History. |
| `codebooks.md` | Accessed from global sidebar under "Content", not Team workspace. Button labels: "Create codebook", "Make production version", "Create prompt". Example types are uppercase enums (`HIT`, `NEAR_HIT`, `NEAR_MISS`, `MISS`). Added annotation-type step in Create-prompt-from-codebook flow. |
| `humanAnnotations.md` | Documented actual CSV column structure including the `annotator[<name>][<slot>]<field>` naming format. Softened the "must match schema codes" claim (code accepts any string). Noted `identifiedBy: "HUMAN"` marker on uploaded annotations. |
| `transcripts.md` | Rewritten as an upload guide. Previous version only documented the internal JSON format; uploads actually only accept CSV and JSONL. Documents required fields, accepted aliases (e.g. `speaker` to `role`), and the conversion pipeline. Keeps the JSON structure documented as the post-conversion internal representation. |

## Articles still unpublished

- `de-identification.md` — no implementation exists in the codebase. Holding until the feature ships.

## Test plan

- [ ] Verify the published articles render correctly in the docs site
- [ ] Spot-check button labels and dialog flows against the live app to confirm corrections
- [ ] Confirm `de-identification.md` remains hidden from the public docs index

Generated with [Claude Code](https://claude.com/claude-code)
