### PR TITLE
feat: explain blocked downloads on failed runs and run sets

### DIFF
--- a/app/modules/runSets/components/runSetDetail.tsx
+++ b/app/modules/runSets/components/runSetDetail.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -23,6 +24,7 @@ import {
   Pencil,
   Plus,
   Trash2,
+  TriangleAlert,
   Upload,
 } from "lucide-react";
 import { Outlet } from "react-router";
@@ -186,6 +188,19 @@ export default function RunSetDetail({
             </div>
           </div>
         )}
+      {annotationProgress.erroredRuns > 0 && (
+        <Alert className="mb-6">
+          <TriangleAlert className="h-4 w-4" />
+          <AlertTitle>
+            {annotationProgress.erroredRuns} of {annotationProgress.totalRuns}{" "}
+            run{annotationProgress.totalRuns === 1 ? "" : "s"} failed
+          </AlertTitle>
+          <AlertDescription>
+            Run set data cannot be exported until all runs have succeeded.
+            Re-run the failed runs to continue.
+          </AlertDescription>
+        </Alert>
+      )}
       <Tabs
         value={activeView}
         onValueChange={onActiveViewChange}

--- a/app/modules/runs/components/run.tsx
+++ b/app/modules/runs/components/run.tsx
@@ -213,7 +213,15 @@ export default function RunDetail({
             <TriangleAlert className="h-4 w-4" />
             <AlertTitle>All sessions failed</AlertTitle>
             <AlertDescription>
-              This run failed during annotation.
+              <p>This run failed during annotation.</p>
+              <p>
+                Annotated data cannot be exported until this run completes
+                successfully
+                {runSetId
+                  ? ", and run set data cannot be exported until all runs have succeeded"
+                  : ""}
+                .
+              </p>
             </AlertDescription>
           </Alert>
         )}
@@ -226,7 +234,17 @@ export default function RunDetail({
               {run.sessions.length === 1 ? "" : "s"} failed
             </AlertTitle>
             <AlertDescription>
-              This run completed but some sessions failed during annotation.
+              <p>
+                This run completed but some sessions failed during annotation.
+              </p>
+              <p>
+                Annotated data cannot be downloaded until all sessions complete
+                successfully
+                {runSetId
+                  ? ", and run set data cannot be downloaded until all runs have succeeded"
+                  : ""}
+                .
+              </p>
             </AlertDescription>
           </Alert>
         )}


### PR DESCRIPTION
Extend the FAILED and PARTIAL_FAILURE alerts on the run detail page to explain that annotated data cannot be downloaded until the run/sessions complete, and add a failed-runs alert on the run set detail page noting that run set data is blocked until every run succeeds.

Fixes #2159