### PR TITLE
feat: show selected session count in session selector header

### DIFF
--- a/app/modules/sessions/components/sessionSelector.tsx
+++ b/app/modules/sessions/components/sessionSelector.tsx
@@ -72,6 +72,10 @@ export default function SessionSelector({
     <div>
       <div className="mb-2 flex items-center justify-between">
         <span className="text-sm font-medium">Select All</span>
+        <span className="text-muted-foreground text-sm">
+          <strong className="text-foreground">{selectedSessions.length}</strong>
+          &nbsp;session(s) selected
+        </span>
         <SessionRandomizer
           sampleSize={sampleSize}
           maxSize={sessions.length}


### PR DESCRIPTION
Adds a "{n} session(s) selected" label centered between the Select All label and the randomizer in the session selector. Users couldn't tell how many sessions they'd checked while scrolling — the only feedback was the dollar-amount estimate at the bottom.

Fixes #2068