### PR TITLE
Fix admin sub-route links missing /admin prefix

### DIFF
--- a/app/modules/app/components/appSidebar.tsx
+++ b/app/modules/app/components/appSidebar.tsx
@@ -41,9 +41,16 @@ import SideBarHelpDropdown from "~/modules/app/components/sidebarHelpDropdown";
 import getNavMode from "~/modules/app/helpers/getNavMode";
 import useActiveTeam from "~/modules/app/hooks/useActiveTeam";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
+import { adminBillingUrl } from "~/modules/billing/helpers/billingUrls";
 import FeatureFlag from "~/modules/featureFlags/components/flag";
+import { featureFlagsUrl } from "~/modules/featureFlags/helpers/featureFlagUrls";
+import { migrationsUrl } from "~/modules/migrations/helpers/migrationUrls";
 import { projectsUrl } from "~/modules/projects/helpers/projectUrls";
+import { queuesUrl } from "~/modules/queues/helpers/queueUrls";
+import { maintenanceUrl } from "~/modules/systemSettings/helpers/maintenanceUrls";
+import { adminTeamsUrl } from "~/modules/teams/helpers/teamUrls";
 import useCreateTeam from "~/modules/teams/hooks/useCreateTeam";
+import { adminUsersUrl } from "~/modules/users/helpers/userUrls";
 import type { User } from "~/modules/users/users.types";
 
 type NavEntry = {
@@ -149,19 +156,19 @@ export default function AppSidebar() {
       ]
     : [];
   const organizationEntries: NavEntry[] = [
-    { to: "/admin/teams", icon: Building2, label: "Teams" },
-    { to: "/admin/users", icon: UsersRound, label: "Users" },
-    { to: "/admin/billing", icon: CircleDollarSign, label: "Billing" },
+    { to: adminTeamsUrl(), icon: Building2, label: "Teams" },
+    { to: adminUsersUrl(), icon: UsersRound, label: "Users" },
+    { to: adminBillingUrl(), icon: CircleDollarSign, label: "Billing" },
   ];
   const infrastructureEntries: NavEntry[] = [
-    { to: "/admin/featureFlags", icon: FlagIcon, label: "Feature flags" },
+    { to: featureFlagsUrl(), icon: FlagIcon, label: "Feature flags" },
     {
-      to: "/admin/queues/tasks/active",
+      to: queuesUrl("tasks", "active"),
       icon: ChartNoAxesGantt,
       label: "Queues",
     },
-    { to: "/admin/migrations", icon: Database, label: "Migrations" },
-    { to: "/admin/maintenance", icon: Construction, label: "Maintenance" },
+    { to: migrationsUrl(), icon: Database, label: "Migrations" },
+    { to: maintenanceUrl(), icon: Construction, label: "Maintenance" },
   ];
 
   const exitAdmin = () => {
@@ -286,7 +293,7 @@ export default function AppSidebar() {
                   roleLabel={roleLabel}
                   onSwitchTeam={switchActiveTeam}
                   onCreateTeam={onCreateTeamClicked}
-                  onEnterAdmin={() => navigate("/admin/teams")}
+                  onEnterAdmin={() => navigate(adminTeamsUrl())}
                   onLogout={onLogoutClicked}
                 />
               </SidebarMenuItem>

--- a/app/modules/billing/components/billingLayout.tsx
+++ b/app/modules/billing/components/billingLayout.tsx
@@ -2,12 +2,13 @@ import { PageHeader, PageHeaderLeft } from "@/components/ui/pageHeader";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
+import { adminBillingUrl } from "../helpers/billingUrls";
 
 const TABS = [
-  { key: "spend-overview", path: "/admin/billing", label: "Spend Overview" },
+  { key: "spend-overview", path: adminBillingUrl(), label: "Spend Overview" },
   {
     key: "active-users",
-    path: "/admin/billing/active-users",
+    path: adminBillingUrl("active-users"),
     label: "Active Teams",
   },
 ];

--- a/app/modules/billing/helpers/billingUrls.ts
+++ b/app/modules/billing/helpers/billingUrls.ts
@@ -1,0 +1,7 @@
+export type AdminBillingTab = "active-users";
+
+export function adminBillingUrl(tab?: AdminBillingTab): string {
+  let url = "/admin/billing";
+  if (tab !== undefined) url += `/${tab}`;
+  return url;
+}

--- a/app/modules/featureFlags/components/featureFlags.tsx
+++ b/app/modules/featureFlags/components/featureFlags.tsx
@@ -16,6 +16,7 @@ import { Link, Outlet } from "react-router";
 import type { Breadcrumb } from "~/modules/app/app.types";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
 import type { FeatureFlag } from "../featureFlags.types";
+import { featureFlagsUrl } from "../helpers/featureFlagUrls";
 
 export default function FeatureFlags({
   featureFlags,
@@ -54,7 +55,7 @@ export default function FeatureFlags({
                       className="rounded-full"
                       asChild
                     >
-                      <Link to={`/featureFlags/${featureFlag._id}`}>
+                      <Link to={featureFlagsUrl(featureFlag._id)}>
                         <ChevronRight className="size-4" />
                       </Link>
                     </Button>

--- a/app/modules/featureFlags/containers/featureFlag.route.tsx
+++ b/app/modules/featureFlags/containers/featureFlag.route.tsx
@@ -12,6 +12,7 @@ import DeleteFeatureFlagDialog from "../components/deleteFeatureFlagDialog";
 import FeatureFlag from "../components/featureFlag";
 import { FeatureFlagService } from "../featureFlag";
 import type { FeatureFlag as FeatureFlagType } from "../featureFlags.types";
+import { featureFlagsUrl } from "../helpers/featureFlagUrls";
 import type { Route } from "./+types/featureFlag.route";
 import AddUsersToFeatureFlagDialogContainer from "./addUsersToFeatureFlagDialog.container";
 
@@ -23,7 +24,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const featureFlag = await FeatureFlagService.findById(params.id);
   if (!featureFlag) {
-    return redirect("/admin/featureFlags");
+    return redirect(featureFlagsUrl());
   }
 
   const users = await UserService.find({
@@ -89,7 +90,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     case "DELETE_FEATURE_FLAG": {
       const featureFlag = await FeatureFlagService.findById(params.id);
       if (!featureFlag) {
-        return redirect("/admin/featureFlags");
+        return redirect(featureFlagsUrl());
       }
 
       await FeatureFlagService.deleteById(params.id);
@@ -144,7 +145,7 @@ export default function FeatureFlagRoute({
         fetcher.data.intent === "DELETE_FEATURE_FLAG"
       ) {
         toast.success("Feature flag deleted");
-        window.location.href = "/admin/featureFlags";
+        window.location.href = featureFlagsUrl();
       } else if (fetcher.data.errors) {
         toast.error(fetcher.data.errors.general || "An error occurred");
       }

--- a/app/modules/featureFlags/containers/featureFlags.route.tsx
+++ b/app/modules/featureFlags/containers/featureFlags.route.tsx
@@ -9,6 +9,7 @@ import CreateFeatureFlagDialog from "../components/createFeatureFlagDialog";
 import FeatureFlags from "../components/featureFlags";
 import { FeatureFlagService } from "../featureFlag";
 import type { FeatureFlag } from "../featureFlags.types";
+import { featureFlagsUrl } from "../helpers/featureFlagUrls";
 import type { Route } from "./+types/featureFlags.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -66,14 +67,14 @@ export default function FeatureFlagsRoute({
 }: Route.ComponentProps) {
   const { featureFlags } = loaderData;
   const fetcher = useFetcher();
-  const match = useMatch("/admin/featureFlags");
+  const match = useMatch(featureFlagsUrl());
   const matches = useMatches();
 
   const featureFlag = get(matches, "2.data.featureFlag", {}) as FeatureFlag;
   const breadcrumbs = match
     ? [{ text: "Feature flags" }]
     : [
-        { text: "Feature flags", link: "/admin/featureFlags" },
+        { text: "Feature flags", link: featureFlagsUrl() },
         { text: featureFlag.name },
       ];
 

--- a/app/modules/featureFlags/helpers/featureFlagUrls.ts
+++ b/app/modules/featureFlags/helpers/featureFlagUrls.ts
@@ -1,0 +1,5 @@
+export function featureFlagsUrl(featureFlagId?: string): string {
+  let url = "/admin/featureFlags";
+  if (featureFlagId !== undefined) url += `/${featureFlagId}`;
+  return url;
+}

--- a/app/modules/migrations/helpers/migrationUrls.ts
+++ b/app/modules/migrations/helpers/migrationUrls.ts
@@ -1,0 +1,3 @@
+export function migrationsUrl(): string {
+  return "/admin/migrations";
+}

--- a/app/modules/queues/components/queueStateTabs.tsx
+++ b/app/modules/queues/components/queueStateTabs.tsx
@@ -1,5 +1,6 @@
 import { ToggleGroup } from "@/components/ui/toggle-group";
 import { useLocation, useNavigate } from "react-router";
+import { queuesUrl } from "../helpers/queueUrls";
 import { QueueTab } from "./queueTab";
 
 interface QueueState {
@@ -27,7 +28,7 @@ export default function QueueStateTabs({
 
   const handleValueChange = (value: string) => {
     if (value) {
-      navigate(`/queues/${queueType}/${value}`);
+      navigate(queuesUrl(queueType, value));
     }
   };
 

--- a/app/modules/queues/components/queueTypeTabs.tsx
+++ b/app/modules/queues/components/queueTypeTabs.tsx
@@ -1,5 +1,6 @@
 import { ToggleGroup } from "@/components/ui/toggle-group";
 import { useLocation, useNavigate } from "react-router";
+import { queuesUrl } from "../helpers/queueUrls";
 import { QueueTab } from "./queueTab";
 
 export interface Queue {
@@ -24,7 +25,7 @@ export default function QueueTypeTabs({ queues }: QueueTypeTabsProps) {
 
   const handleValueChange = (value: string) => {
     if (value) {
-      navigate(`/queues/${value}/active`);
+      navigate(queuesUrl(value, "active"));
     }
   };
 

--- a/app/modules/queues/helpers/queueUrls.ts
+++ b/app/modules/queues/helpers/queueUrls.ts
@@ -1,0 +1,6 @@
+export function queuesUrl(type?: string, state?: string): string {
+  let url = "/admin/queues";
+  if (type !== undefined) url += `/${type}`;
+  if (state !== undefined) url += `/${state}`;
+  return url;
+}

--- a/app/modules/systemSettings/helpers/maintenanceUrls.ts
+++ b/app/modules/systemSettings/helpers/maintenanceUrls.ts
@@ -1,0 +1,3 @@
+export function maintenanceUrl(): string {
+  return "/admin/maintenance";
+}

--- a/app/modules/teams/containers/team.route.tsx
+++ b/app/modules/teams/containers/team.route.tsx
@@ -6,6 +6,7 @@ import addDialog from "~/modules/dialogs/addDialog";
 import TeamAuthorization from "../authorization";
 import EditTeamDialog from "../components/editTeamDialog";
 import TeamComponent from "../components/team";
+import { adminTeamsUrl } from "../helpers/teamUrls";
 import { TeamService } from "../team";
 import type { Team } from "../teams.types";
 import type { Route } from "./+types/team.route";
@@ -19,7 +20,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const team = await TeamService.findById(params.teamId);
   if (!team) {
-    return redirect("/admin/teams");
+    return redirect(adminTeamsUrl());
   }
   return { team };
 }

--- a/app/modules/teams/containers/teamBilling.route.tsx
+++ b/app/modules/teams/containers/teamBilling.route.tsx
@@ -34,6 +34,7 @@ import { findModelByCode } from "~/modules/llm/modelRegistry";
 import { UserService } from "~/modules/users/user";
 import TeamAuthorization from "../authorization";
 import TeamBilling from "../components/teamBilling";
+import { adminTeamsUrl } from "../helpers/teamUrls";
 import { TeamService } from "../team";
 import type { Route } from "./+types/teamBilling.route";
 
@@ -45,7 +46,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
 
   const team = await TeamService.findById(params.teamId);
-  if (!team) return redirect("/admin/teams");
+  if (!team) return redirect(adminTeamsUrl());
 
   if (!BillingAuthorization.canViewBilling(user, team, isBillingEnabled())) {
     return redirect(`/teams/${params.teamId}/users`);

--- a/app/modules/teams/helpers/teamUrls.ts
+++ b/app/modules/teams/helpers/teamUrls.ts
@@ -1,0 +1,3 @@
+export function adminTeamsUrl(): string {
+  return "/admin/teams";
+}

--- a/app/modules/users/components/editUserDialog.tsx
+++ b/app/modules/users/components/editUserDialog.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label";
 import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import addDialog from "~/modules/dialogs/addDialog";
+import { adminUsersUrl } from "../helpers/userUrls";
 import type { User } from "../users.types";
 
 const EditUserDialog = ({
@@ -41,7 +42,7 @@ const EditUserDialog = ({
         intent: "UPDATE_USER",
         payload: { targetUserId: user._id, name, email },
       }),
-      { method: "POST", encType: "application/json", action: "/admin/users" },
+      { method: "POST", encType: "application/json", action: adminUsersUrl() },
     );
   };
 

--- a/app/modules/users/helpers/userUrls.ts
+++ b/app/modules/users/helpers/userUrls.ts
@@ -1,0 +1,3 @@
+export function adminUsersUrl(): string {
+  return "/admin/users";
+}


### PR DESCRIPTION
Three navigation targets pointed at paths outside the /admin prefix and 404'd: the feature flag detail link and both queue toggle tabs.

Added featureFlagUrls.ts and queueUrls.ts helpers (mirroring the existing projectUrls/promptUrls pattern) and routed all in-module references through them so the prefix lives in one place.

Fixes #2384