### PR TITLE
Adopt URL helpers for remaining admin routes

### DIFF
--- a/app/modules/app/components/appSidebar.tsx
+++ b/app/modules/app/components/appSidebar.tsx
@@ -41,9 +41,16 @@ import SideBarHelpDropdown from "~/modules/app/components/sidebarHelpDropdown";
 import getNavMode from "~/modules/app/helpers/getNavMode";
 import useActiveTeam from "~/modules/app/hooks/useActiveTeam";
 import { AuthenticationContext } from "~/modules/authentication/authentication.context";
+import { adminBillingUrl } from "~/modules/billing/helpers/billingUrls";
 import FeatureFlag from "~/modules/featureFlags/components/flag";
+import { featureFlagsUrl } from "~/modules/featureFlags/helpers/featureFlagUrls";
+import { migrationsUrl } from "~/modules/migrations/helpers/migrationUrls";
 import { projectsUrl } from "~/modules/projects/helpers/projectUrls";
+import { queuesUrl } from "~/modules/queues/helpers/queueUrls";
+import { maintenanceUrl } from "~/modules/systemSettings/helpers/maintenanceUrls";
+import { adminTeamsUrl } from "~/modules/teams/helpers/teamUrls";
 import useCreateTeam from "~/modules/teams/hooks/useCreateTeam";
+import { adminUsersUrl } from "~/modules/users/helpers/userUrls";
 import type { User } from "~/modules/users/users.types";
 
 type NavEntry = {
@@ -149,19 +156,19 @@ export default function AppSidebar() {
       ]
     : [];
   const organizationEntries: NavEntry[] = [
-    { to: "/admin/teams", icon: Building2, label: "Teams" },
-    { to: "/admin/users", icon: UsersRound, label: "Users" },
-    { to: "/admin/billing", icon: CircleDollarSign, label: "Billing" },
+    { to: adminTeamsUrl(), icon: Building2, label: "Teams" },
+    { to: adminUsersUrl(), icon: UsersRound, label: "Users" },
+    { to: adminBillingUrl(), icon: CircleDollarSign, label: "Billing" },
   ];
   const infrastructureEntries: NavEntry[] = [
-    { to: "/admin/featureFlags", icon: FlagIcon, label: "Feature flags" },
+    { to: featureFlagsUrl(), icon: FlagIcon, label: "Feature flags" },
     {
-      to: "/admin/queues/tasks/active",
+      to: queuesUrl("tasks", "active"),
       icon: ChartNoAxesGantt,
       label: "Queues",
     },
-    { to: "/admin/migrations", icon: Database, label: "Migrations" },
-    { to: "/admin/maintenance", icon: Construction, label: "Maintenance" },
+    { to: migrationsUrl(), icon: Database, label: "Migrations" },
+    { to: maintenanceUrl(), icon: Construction, label: "Maintenance" },
   ];
 
   const exitAdmin = () => {
@@ -286,7 +293,7 @@ export default function AppSidebar() {
                   roleLabel={roleLabel}
                   onSwitchTeam={switchActiveTeam}
                   onCreateTeam={onCreateTeamClicked}
-                  onEnterAdmin={() => navigate("/admin/teams")}
+                  onEnterAdmin={() => navigate(adminTeamsUrl())}
                   onLogout={onLogoutClicked}
                 />
               </SidebarMenuItem>

--- a/app/modules/billing/components/billingLayout.tsx
+++ b/app/modules/billing/components/billingLayout.tsx
@@ -2,12 +2,13 @@ import { PageHeader, PageHeaderLeft } from "@/components/ui/pageHeader";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import Breadcrumbs from "~/modules/app/components/breadcrumbs";
+import { adminBillingUrl } from "../helpers/billingUrls";
 
 const TABS = [
-  { key: "spend-overview", path: "/admin/billing", label: "Spend Overview" },
+  { key: "spend-overview", path: adminBillingUrl(), label: "Spend Overview" },
   {
     key: "active-users",
-    path: "/admin/billing/active-users",
+    path: adminBillingUrl("active-users"),
     label: "Active Teams",
   },
 ];

--- a/app/modules/billing/helpers/billingUrls.ts
+++ b/app/modules/billing/helpers/billingUrls.ts
@@ -1,0 +1,7 @@
+export type AdminBillingTab = "active-users";
+
+export function adminBillingUrl(tab?: AdminBillingTab): string {
+  let url = "/admin/billing";
+  if (tab !== undefined) url += `/${tab}`;
+  return url;
+}

--- a/app/modules/migrations/helpers/migrationUrls.ts
+++ b/app/modules/migrations/helpers/migrationUrls.ts
@@ -1,0 +1,3 @@
+export function migrationsUrl(): string {
+  return "/admin/migrations";
+}

--- a/app/modules/systemSettings/helpers/maintenanceUrls.ts
+++ b/app/modules/systemSettings/helpers/maintenanceUrls.ts
@@ -1,0 +1,3 @@
+export function maintenanceUrl(): string {
+  return "/admin/maintenance";
+}

--- a/app/modules/teams/containers/team.route.tsx
+++ b/app/modules/teams/containers/team.route.tsx
@@ -6,6 +6,7 @@ import addDialog from "~/modules/dialogs/addDialog";
 import TeamAuthorization from "../authorization";
 import EditTeamDialog from "../components/editTeamDialog";
 import TeamComponent from "../components/team";
+import { adminTeamsUrl } from "../helpers/teamUrls";
 import { TeamService } from "../team";
 import type { Team } from "../teams.types";
 import type { Route } from "./+types/team.route";
@@ -19,7 +20,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const team = await TeamService.findById(params.teamId);
   if (!team) {
-    return redirect("/admin/teams");
+    return redirect(adminTeamsUrl());
   }
   return { team };
 }

--- a/app/modules/teams/containers/teamBilling.route.tsx
+++ b/app/modules/teams/containers/teamBilling.route.tsx
@@ -34,6 +34,7 @@ import { findModelByCode } from "~/modules/llm/modelRegistry";
 import { UserService } from "~/modules/users/user";
 import TeamAuthorization from "../authorization";
 import TeamBilling from "../components/teamBilling";
+import { adminTeamsUrl } from "../helpers/teamUrls";
 import { TeamService } from "../team";
 import type { Route } from "./+types/teamBilling.route";
 
@@ -45,7 +46,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
 
   const team = await TeamService.findById(params.teamId);
-  if (!team) return redirect("/admin/teams");
+  if (!team) return redirect(adminTeamsUrl());
 
   if (!BillingAuthorization.canViewBilling(user, team, isBillingEnabled())) {
     return redirect(`/teams/${params.teamId}/users`);

--- a/app/modules/teams/helpers/teamUrls.ts
+++ b/app/modules/teams/helpers/teamUrls.ts
@@ -1,0 +1,3 @@
+export function adminTeamsUrl(): string {
+  return "/admin/teams";
+}

--- a/app/modules/users/components/editUserDialog.tsx
+++ b/app/modules/users/components/editUserDialog.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label";
 import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import addDialog from "~/modules/dialogs/addDialog";
+import { adminUsersUrl } from "../helpers/userUrls";
 import type { User } from "../users.types";
 
 const EditUserDialog = ({
@@ -41,7 +42,7 @@ const EditUserDialog = ({
         intent: "UPDATE_USER",
         payload: { targetUserId: user._id, name, email },
       }),
-      { method: "POST", encType: "application/json", action: "/admin/users" },
+      { method: "POST", encType: "application/json", action: adminUsersUrl() },
     );
   };
 

--- a/app/modules/users/helpers/userUrls.ts
+++ b/app/modules/users/helpers/userUrls.ts
@@ -1,0 +1,3 @@
+export function adminUsersUrl(): string {
+  return "/admin/users";
+}


### PR DESCRIPTION
Centralize the rest of the /admin/* paths through module helpers mirroring the featureFlagUrls/queueUrls pattern from #2384.

New helpers:
- teams/helpers/teamUrls.ts: adminTeamsUrl()
- users/helpers/userUrls.ts: adminUsersUrl()
- billing/helpers/billingUrls.ts: adminBillingUrl(tab?)
- migrations/helpers/migrationUrls.ts: migrationsUrl()
- systemSettings/helpers/maintenanceUrls.ts: maintenanceUrl()

Call-sites: appSidebar (entries + onEnterAdmin), team.route, teamBilling.route, editUserDialog, billingLayout. Sidebar also adopts the existing featureFlagsUrl and queuesUrl so the whole admin nav now flows through helpers.