### PR TITLE
Show splash to logged-out visitors instead of redirecting to /signup

### DIFF
--- a/app/modules/home/__tests__/home.route.test.ts
+++ b/app/modules/home/__tests__/home.route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { TeamService } from "~/modules/teams/team";
+import { UserService } from "~/modules/users/user";
+import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
+import loginUser from "../../../../test/helpers/loginUser";
+import { loader } from "../containers/home.route";
+
+describe("home.route", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  describe("loader", () => {
+    // Regression: logged-out visitors to "/" must reach the client
+    // AuthenticationContainer, which renders the Splash page. The loader used
+    // to call requireAuth and redirect them to /signup, so the splash never
+    // showed. It must return data without throwing instead.
+    it("returns splash data without redirecting when there is no session cookie", async () => {
+      const result = (await loader({
+        request: new Request("http://localhost/"),
+        params: {},
+        context: {},
+      } as any)) as any;
+
+      expect(result).toEqual({ activeTeamId: null });
+    });
+
+    it("returns the personal team as active team for a logged-in user", async () => {
+      const personal = await TeamService.create({
+        name: "personal",
+        isPersonal: true,
+      });
+      const other = await TeamService.create({ name: "other" });
+      const user = await UserService.create({
+        username: "u",
+        teams: [
+          { team: other._id, role: "ADMIN" },
+          { team: personal._id, role: "ADMIN" },
+        ],
+      });
+
+      const cookieHeader = await loginUser(user._id);
+      const result = (await loader({
+        request: new Request("http://localhost/", {
+          headers: { cookie: cookieHeader },
+        }),
+        params: {},
+        context: {},
+      } as any)) as any;
+
+      expect(result.activeTeamId).toBe(personal._id);
+    });
+
+    it("returns a null active team for a logged-in user with no teams", async () => {
+      const user = await UserService.create({ username: "u", teams: [] });
+
+      const cookieHeader = await loginUser(user._id);
+      const result = (await loader({
+        request: new Request("http://localhost/", {
+          headers: { cookie: cookieHeader },
+        }),
+        params: {},
+        context: {},
+      } as any)) as any;
+
+      expect(result.activeTeamId).toBeNull();
+    });
+  });
+});

--- a/app/modules/home/containers/home.route.tsx
+++ b/app/modules/home/containers/home.route.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useFetcher, useLoaderData, useRouteLoaderData } from "react-router";
 import useActiveTeam from "~/modules/app/hooks/useActiveTeam";
-import requireAuth from "~/modules/authentication/helpers/requireAuth";
+import getSessionUser from "~/modules/authentication/helpers/getSessionUser";
 import { readActiveTeamFromRequest } from "~/modules/teams/helpers/activeTeamCookie";
 import useCreateTeam from "~/modules/teams/hooks/useCreateTeam";
 import { TeamService } from "~/modules/teams/team";
@@ -9,7 +9,12 @@ import Home from "../components/home";
 import type { Route } from "./+types/home.route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const user = await requireAuth({ request });
+  // Don't requireAuth here: logged-out visitors to "/" must reach the client
+  // AuthenticationContainer, which renders the Splash page. Redirecting from
+  // the loader would send them to /signup instead.
+  const user = await getSessionUser({ request });
+  if (!user) return { activeTeamId: null };
+
   const userTeamIds = user.teams.map((t) => t.team);
   if (userTeamIds.length === 0) return { activeTeamId: null };
 


### PR DESCRIPTION
## Problem

Logged-out visitors to `/` are redirected straight to `/signup` and never see the marketing splash page.

## Cause

The home route loader called `requireAuth`, which throws a server-side redirect to `/signup` during SSR — before the client `AuthenticationContainer` can render `<Splash />`. The splash-vs-home decision is meant to live in that container:

```tsx
if (!authentication) {
  return isHomeRoute ? <Splash /> : <Navigate to="/signup" replace />;
}
```

The loader redirect short-circuited it. Regression introduced in `b91135f4` (loader changed from `return {}` to `requireAuth`).

## Fix

The loader now uses `getSessionUser` and returns `{ activeTeamId: null }` for logged-out requests, so the request reaches `AuthenticationContainer` and the splash renders. Authenticated behavior (active team resolution) is unchanged.

Adds a regression test asserting the loader returns splash data without throwing a redirect when there is no session cookie.

Fixes #2389