### PR TITLE
Reject empty-email users from GitHub SSO signup

### DIFF
--- a/app/modules/authentication/__tests__/extractPrimaryEmail.test.ts
+++ b/app/modules/authentication/__tests__/extractPrimaryEmail.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import extractPrimaryEmail from "../helpers/extractPrimaryEmail";
+
+describe("extractPrimaryEmail", () => {
+  it("prefers the primary email", () => {
+    expect(
+      extractPrimaryEmail([
+        { primary: false, email: "secondary@example.com" },
+        { primary: true, email: "primary@example.com" },
+      ]),
+    ).toBe("primary@example.com");
+  });
+
+  it("falls back to the first entry when none is primary", () => {
+    expect(
+      extractPrimaryEmail([
+        { email: "first@example.com" },
+        { email: "second@example.com" },
+      ]),
+    ).toBe("first@example.com");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(extractPrimaryEmail([{ primary: true, email: "  a@b.com  " }])).toBe(
+      "a@b.com",
+    );
+  });
+
+  it("returns null for a GitHub error object (non-array)", () => {
+    expect(
+      extractPrimaryEmail({
+        message: "Bad credentials",
+        documentation_url: "https://docs.github.com",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty array", () => {
+    expect(extractPrimaryEmail([])).toBeNull();
+  });
+
+  it("returns null when entries are missing a string email", () => {
+    expect(
+      extractPrimaryEmail([{ primary: true }, { email: null }]),
+    ).toBeNull();
+  });
+
+  it("returns null when the only email is empty or whitespace", () => {
+    expect(extractPrimaryEmail([{ primary: true, email: "   " }])).toBeNull();
+    expect(extractPrimaryEmail([{ primary: true, email: "" }])).toBeNull();
+  });
+
+  it("returns null for null or undefined input", () => {
+    expect(extractPrimaryEmail(null)).toBeNull();
+    expect(extractPrimaryEmail(undefined)).toBeNull();
+  });
+});

--- a/app/modules/authentication/__tests__/handleTeamInviteSignup.test.ts
+++ b/app/modules/authentication/__tests__/handleTeamInviteSignup.test.ts
@@ -60,3 +60,50 @@ describe("handleTeamInviteSignup already_member", () => {
     expect(setCookie).toMatch(/=.+/);
   });
 });
+
+describe("handleTeamInviteSignup with no usable email", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  it("redirects to NO_EMAIL and does not create a user when GitHub returns an error object", async () => {
+    const team = await TeamService.create({ name: "Invite Team" });
+    const inviter = await UserService.create({
+      username: "inviter",
+      email: "inviter@example.com",
+      githubId: 99,
+      hasGithubSSO: true,
+      isRegistered: true,
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const invite = await TeamInviteService.create({
+      team: team._id,
+      name: "Test Invite",
+      maxUses: 5,
+      createdBy: inviter._id,
+    });
+
+    const request = new Request("http://localhost/auth/github", {
+      headers: { cookie: "" },
+    });
+
+    const response = await captureThrow(
+      handleTeamInviteSignup({
+        teamInviteId: invite._id,
+        githubUser: { id: 1234, login: "newcomer", name: "Newcomer" },
+        // GitHub /user/emails can return an error object instead of an array
+        emails: {
+          message: "Bad credentials",
+          documentation_url: "https://docs.github.com",
+        } as never,
+        request,
+      }),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/signup?error=NO_EMAIL");
+
+    const created = await UserService.findOne({ githubId: 1234 });
+    expect(created).toBeNull();
+  });
+});

--- a/app/modules/authentication/components/signup.tsx
+++ b/app/modules/authentication/components/signup.tsx
@@ -29,6 +29,11 @@ const ERROR_MESSAGES: Record<string, { title: string; description: string }> = {
     title: "You have not been registered",
     description: "Use the Sign up button below to create an account.",
   },
+  NO_EMAIL: {
+    title: "We couldn't read an email from your GitHub account",
+    description:
+      "Make sure your GitHub account has a verified email and the email scope is granted, then try again.",
+  },
 };
 
 export default function Signup({

--- a/app/modules/authentication/helpers/extractPrimaryEmail.ts
+++ b/app/modules/authentication/helpers/extractPrimaryEmail.ts
@@ -1,0 +1,17 @@
+type GithubEmail = { primary?: boolean; email: string };
+
+const hasEmail = (e: unknown): e is GithubEmail =>
+  typeof e === "object" &&
+  e !== null &&
+  typeof (e as GithubEmail).email === "string";
+
+export default function extractPrimaryEmail(emails: unknown): string | null {
+  if (!Array.isArray(emails)) return null;
+
+  const candidates = emails.filter(hasEmail);
+  const email = (
+    candidates.find((e) => e.primary) ?? candidates[0]
+  )?.email.trim();
+
+  return email || null;
+}

--- a/app/modules/authentication/helpers/githubStrategy.ts
+++ b/app/modules/authentication/helpers/githubStrategy.ts
@@ -8,6 +8,7 @@ import { UserService } from "~/modules/users/user";
 import type { UserTeam } from "~/modules/users/users.types";
 import sessionStorage from "../../../../sessionStorage";
 import setupNewUser from "../services/setupNewUser.server";
+import extractPrimaryEmail from "./extractPrimaryEmail";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const githubStrategy = new GitHubStrategy<any>(
@@ -95,11 +96,8 @@ const githubStrategy = new GitHubStrategy<any>(
         }
       } else {
         // Direct signup — no invite required
-        const primaryEmail = (
-          find(emails, (e: { primary: boolean; email: string }) => e.primary) ||
-          emails[0] ||
-          {}
-        ).email;
+        const primaryEmail = extractPrimaryEmail(emails);
+        if (!primaryEmail) throw redirect("/signup?error=NO_EMAIL");
         const newUser = await UserService.create({
           username: githubUser.login,
           name: githubUser.name || githubUser.login,
@@ -146,23 +144,13 @@ const githubStrategy = new GitHubStrategy<any>(
       await UserService.deleteById(invitedUser._id);
     }
 
-    let email = find(emails, (email) => {
-      if (email.primary) {
-        return email;
-      }
-    });
-
-    if (!email) {
-      if (emails.length > 0) {
-        email = emails[0];
-      } else {
-        email = {};
-      }
-    }
-
     update.username = githubUser.login;
     update.name = githubUser.name || githubUser.login;
-    update.email = email.email;
+
+    // Only update the email when GitHub returned a usable one, so a failed
+    // /user/emails response never overwrites an existing valid email with "".
+    const primaryEmail = extractPrimaryEmail(emails);
+    if (primaryEmail) update.email = primaryEmail;
 
     user = await UserService.updateById(user._id, update);
 

--- a/app/modules/authentication/helpers/handleTeamInviteSignup.server.ts
+++ b/app/modules/authentication/helpers/handleTeamInviteSignup.server.ts
@@ -1,7 +1,7 @@
-import find from "lodash/find";
 import { redirect } from "react-router";
 import consumeTeamInvite from "~/modules/teams/services/consumeTeamInvite.server";
 import sessionStorage from "../../../../sessionStorage";
+import extractPrimaryEmail from "./extractPrimaryEmail";
 
 export default async function handleTeamInviteSignup({
   teamInviteId,
@@ -11,14 +11,11 @@ export default async function handleTeamInviteSignup({
 }: {
   teamInviteId: string;
   githubUser: { id: number; login: string; name?: string };
-  emails: Array<{ primary?: boolean; email: string }>;
+  emails: unknown;
   request: Request;
 }) {
-  const primaryEmail =
-    (
-      find(emails, (e: { primary?: boolean; email: string }) => !!e.primary) ||
-      emails[0] || { email: "" }
-    ).email || "";
+  const primaryEmail = extractPrimaryEmail(emails);
+  if (!primaryEmail) throw redirect("/signup?error=NO_EMAIL");
 
   const result = await consumeTeamInvite({
     inviteId: teamInviteId,

--- a/app/modules/users/__tests__/adminUsers.route.test.ts
+++ b/app/modules/users/__tests__/adminUsers.route.test.ts
@@ -539,7 +539,7 @@ describe("adminUsers.route", () => {
         payload: {
           targetUserId: "nonexistent-id",
           name: "New Name",
-          email: "",
+          email: "new@example.com",
         },
       });
 
@@ -598,6 +598,47 @@ describe("adminUsers.route", () => {
 
       const response = (result as any).data;
       expect(response?.errors?.email).toBe("Email is already in use");
+    });
+
+    it("returns error when email is empty", async () => {
+      const superAdmin = await UserService.create({
+        username: "super-admin",
+        role: "SUPER_ADMIN",
+        githubId: 1,
+      });
+
+      const targetUser = await UserService.create({
+        username: "target-user",
+        role: "USER",
+        githubId: 2,
+        email: "target@example.com",
+      });
+
+      const cookieHeader = await loginUser(superAdmin._id);
+
+      const body = JSON.stringify({
+        intent: "UPDATE_USER",
+        payload: {
+          targetUserId: targetUser._id,
+          name: "Updated User",
+          email: "   ",
+        },
+      });
+
+      const result = await action({
+        request: new Request("http://localhost/userManagement", {
+          method: "POST",
+          headers: { cookie: cookieHeader },
+          body,
+        }),
+        params: {},
+      } as any);
+
+      const response = (result as any).data;
+      expect(response?.errors?.email).toBe("Email is required");
+
+      const unchanged = await UserService.findById(targetUser._id);
+      expect(unchanged?.email).toBe("target@example.com");
     });
 
     it("successfully updates user name and email", async () => {

--- a/app/modules/users/__tests__/user.test.ts
+++ b/app/modules/users/__tests__/user.test.ts
@@ -192,6 +192,44 @@ describe("UserService", () => {
       expect(result.username).toBe("newuser");
       expect(result.role).toBe("USER");
     });
+
+    it("rejects an empty email", async () => {
+      await expect(
+        UserService.create({
+          username: "emptyemail",
+          email: "",
+          role: "USER",
+          githubId: 100002,
+          hasGithubSSO: true,
+          isRegistered: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects a whitespace-only email", async () => {
+      await expect(
+        UserService.create({
+          username: "spaceemail",
+          email: "   ",
+          role: "USER",
+          githubId: 100003,
+          hasGithubSSO: true,
+          isRegistered: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("creates an invited user without an email", async () => {
+      const result = await UserService.create({
+        username: "invited",
+        role: "USER",
+        isRegistered: false,
+        inviteId: "invite-123",
+      });
+
+      expect(result._id).toBeDefined();
+      expect(result.email).toBeUndefined();
+    });
   });
 
   describe("updateById", () => {

--- a/app/modules/users/containers/adminUsers.route.tsx
+++ b/app/modules/users/containers/adminUsers.route.tsx
@@ -223,6 +223,13 @@ export async function action({ request }: Route.ActionArgs) {
       const trimmedName = typeof name === "string" ? name.trim() : "";
       const trimmedEmail = typeof email === "string" ? email.trim() : "";
 
+      if (!trimmedEmail) {
+        return data(
+          { errors: { email: "Email is required" } },
+          { status: 400 },
+        );
+      }
+
       let targetUser;
       try {
         targetUser = await UserService.findById(targetUserId);

--- a/app/modules/users/user.ts
+++ b/app/modules/users/user.ts
@@ -78,6 +78,12 @@ export class UserService {
   }
 
   static async create(data: Partial<User>): Promise<User> {
+    if (
+      "email" in data &&
+      (typeof data.email !== "string" || !data.email.trim())
+    ) {
+      throw new Error("Cannot create a user with an empty email");
+    }
     const doc = await UserModel.create(data);
     return this.toUser(doc);
   }
@@ -86,6 +92,12 @@ export class UserService {
     id: string,
     updates: Partial<User>,
   ): Promise<User | null> {
+    if (
+      "email" in updates &&
+      (typeof updates.email !== "string" || !updates.email.trim())
+    ) {
+      throw new Error("Cannot update a user with an empty email");
+    }
     const doc = await UserModel.findByIdAndUpdate(id, updates, {
       new: true,
     });


### PR DESCRIPTION
GitHub SSO signup silently defaulted the primary email to "" when GitHub's /user/emails endpoint returned anything other than an array of usable email objects (an error body, a 403/rate-limit, or entries missing .email). The empty string was then written to the user record, breaking any email-dependent feature and tripping the unique+sparse index on the next such signup.

- Add extractPrimaryEmail helper that returns null for non-array responses, entries without a string email, and empty/whitespace emails. Replaces three duplicated, buggy extraction chains.
- Abort both signup paths (team-invite and direct) with /signup?error=NO_EMAIL when no usable email is found, and surface a matching message on the signup page.
- On existing-user re-login, only refresh the email when a usable one is returned, so a transient /user/emails failure never overwrites a valid email with "".
- Guard UserService.create/updateById against empty-string email (omitted email still allowed for invited users) and validate the admin user-edit action.

Fixes #2242