### PR TITLE
Default verification on with a cost/benefit note

### DIFF
--- a/app/modules/runSets/components/runSetCreatorVerificationToggle.tsx
+++ b/app/modules/runSets/components/runSetCreatorVerificationToggle.tsx
@@ -22,8 +22,9 @@ export default function RunSetCreatorVerification({
         <Label htmlFor="shouldRunVerification">Enable verification step</Label>
       </div>
       <p className="text-muted-foreground text-sm">
-        When enabled, annotations will be verified by a second LLM pass to check
-        for accuracy.
+        When enabled, annotations are verified by a second LLM pass to check for
+        accuracy. This significantly improves results but roughly doubles the
+        cost on average.
       </p>
     </div>
   );

--- a/app/modules/runSets/containers/runSetCreateRuns.container.tsx
+++ b/app/modules/runSets/containers/runSetCreateRuns.container.tsx
@@ -37,7 +37,7 @@ export default function RunSetCreateRunsContainer({
 }: RunSetCreateRunsContainerProps) {
   const [selectedPrompts, setSelectedPrompts] = useState<PromptReference[]>([]);
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
-  const [shouldRunVerification, setShouldRunVerification] = useState(false);
+  const [shouldRunVerification, setShouldRunVerification] = useState(true);
   const [removedKeys, setRemovedKeys] = useState<Set<string>>(new Set());
 
   const usedKeys = buildUsedPromptModelSet(usedPromptModels);

--- a/app/modules/runSets/containers/runSetCreator.container.tsx
+++ b/app/modules/runSets/containers/runSetCreator.container.tsx
@@ -53,7 +53,7 @@ export default function RunSetCreatorContainer({
     prefillData?.selectedSessions || [],
   );
   const [shouldRunVerification, setShouldRunVerification] = useState(
-    prefillData?.shouldRunVerification ?? false,
+    prefillData?.shouldRunVerification ?? true,
   );
   const [removedKeys, setRemovedKeys] = useState<Set<string>>(new Set());
 

--- a/app/modules/runs/components/runCreator.tsx
+++ b/app/modules/runs/components/runCreator.tsx
@@ -163,8 +163,9 @@ export default function RunCreator({
         <CardHeader>
           <CardTitle>Verification</CardTitle>
           <CardDescription>
-            When enabled, annotations will be verified by a second LLM pass to
-            check for accuracy.
+            When enabled, annotations are verified by a second LLM pass to check
+            for accuracy. This significantly improves results but roughly
+            doubles the cost on average.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/app/modules/runs/containers/runCreator.container.tsx
+++ b/app/modules/runs/containers/runCreator.container.tsx
@@ -48,7 +48,7 @@ export default function ProjectRunCreatorContainer({
     initialRun?.sessions?.map((s) => ({ _id: s.sessionId })) || [],
   );
   const [shouldRunVerification, setShouldRunVerification] = useState(
-    initialRun?.shouldRunVerification ?? false,
+    initialRun?.shouldRunVerification ?? true,
   );
   const onSelectedAnnotationTypeChanged = (selectedAnnotationType: string) => {
     if (!isAnnotationType(selectedAnnotationType)) return;


### PR DESCRIPTION
The "Enable verification step" toggle now defaults to on for new runs and run sets. Verification adds a second LLM pass that significantly improves annotation accuracy, so most users should run it.

- Flip the default to true in the run, run set, and add-runs creators. Prefill/copy still wins, so duplicating a run set whose runs had verification off keeps it off.
- Update the toggle copy in both creators to note that verification significantly improves results but roughly doubles the cost on average.

Fixes #2392